### PR TITLE
chore: add mergify auto-merge for renovate PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,3 +6,24 @@ pull_request_rules:
       label:
         toggle:
           - conflict
+
+  - name: Automatic merge on approval
+    conditions:
+      - "#commits-behind=0"
+      - or:
+          - "#approved-reviews-by>=1"
+          - label=ci:auto-merge
+      - not:
+          and:
+            - "head*=renovate/lockfile-maintenance-*"
+            - "created-at>24h ago"
+      - base=master
+      - check-success=check
+      - check-success=test-pass
+      - check-success=license
+      - check-success=lint
+      - check-success=dprint
+      - check-success=binary
+    actions:
+      merge:
+        method: squash

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,5 +7,10 @@
   ],
   "schedule": [
     "* 4 29 2 7"
-  ]
+  ],
+  "labels": [
+    "ci:auto-merge",
+    "dependencies"
+  ],
+  "prConcurrentLimit": 3
 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,13 @@ jobs:
       - run: go build -o tmp/try.exe
       - run: ./tmp/try.exe --help
 
+  test-pass:
+    needs:
+      - test
+    runs-on: ubuntu-slim
+    steps:
+      - run: echo success
+
   license:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Summary:
- add Mergify automatic merge rule (approval or ci:auto-merge label)
- add stable test-pass gate job for matrix tests
- require stable checks: check, test-pass, license, lint, dprint, binary
- add Renovate labels ci:auto-merge and dependencies
- set Renovate prConcurrentLimit to 3