### PR TITLE
feat: improve download/upload algorithms with libtorrent-inspired techniques

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module neptune
 
-go 1.25.9
+go 1.25.10
 
 tool golang.org/x/tools/cmd/stringer
 

--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -114,7 +114,7 @@ func (c *Client) GetTransferSummary() TransferSummary {
 	}
 }
 
-func (c *Client) AddTorrent(raw []byte, m *metainfo.MetaInfo, info meta.Info, downloadPath string, tags []string) error {
+func (c *Client) AddTorrent(raw []byte, m *metainfo.MetaInfo, info meta.Info, downloadPath string, tags []string, selectedFiles []int) error {
 	log.Info().Msgf("try add torrent %s", info.Hash)
 
 	c.m.RLock()
@@ -140,7 +140,7 @@ func (c *Client) AddTorrent(raw []byte, m *metainfo.MetaInfo, info meta.Info, do
 	c.m.Lock()
 	defer c.m.Unlock()
 
-	d := c.NewDownload(m, info, downloadPath, tags)
+	d := c.NewDownload(m, info, downloadPath, tags, selectedFiles)
 
 	c.downloads = append(c.downloads, d)
 

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -45,34 +45,29 @@ const (
 // Download manage a download task
 // ctx should be canceled when torrent is removed, not stopped.
 type Download struct {
-	log               zerolog.Logger
-	ctx               context.Context
-	err               error
-	cancel            context.CancelFunc
-	c                 *Client
-	ioDown            *flowrate.Monitor // io rate for network data and disk moving/checking data
-	netDown           *flowrate.Monitor // io rate for network data
-	ioUp              *flowrate.Monitor
-	ResChan           chan *proto.ChunkResponse
-	peers             *xsync.Map[netip.AddrPort, *Peer]
-	connectionHistory *expirable.LRU[netip.AddrPort, connHistory]
-	bm                *bm.Bitmap
-	pendingPeers      *heap.Heap[peerWithPriority]
-	rarePieceQueue    *heap.Heap[pieceRare] // piece index ordered by rare
-
-	// signal to rebuild connected pendingPeers bitmap
-	// should be fired when pendingPeers send bitmap/Have/HaveAll message
-	buildNetworkPieces chan empty.Empty
-
-	// signal to schedule request to pendingPeers
-	// should be fired when pendingPeers finish pieces requests
-	scheduleRequestSignal chan empty.Empty
-
+	log                    zerolog.Logger
+	ctx                    context.Context
+	err                    error
+	cancel                 context.CancelFunc
+	c                      *Client
+	ioDown                 *flowrate.Monitor
+	netDown                *flowrate.Monitor
+	ioUp                   *flowrate.Monitor
+	ResChan                chan *proto.ChunkResponse
+	peers                  *xsync.Map[netip.AddrPort, *Peer]
+	connectionHistory      *expirable.LRU[netip.AddrPort, connHistory]
+	bm                     *bm.Bitmap
+	pendingPeers           *heap.Heap[peerWithPriority]
+	rarePieceQueue         *heap.Heap[pieceRare]
+	buildNetworkPieces     chan empty.Empty
+	scheduleRequestSignal  chan empty.Empty
 	scheduleResponseSignal chan empty.Empty
 	pendingPeersSignal     chan empty.Empty
 	stateCond              *gsync.Cond
 	pexAdd                 chan []pexPeer
 	pexDrop                chan []netip.AddrPort
+	endgameRequested       *xsync.Map[proto.ChunkRequest, empty.Empty]
+	selectedFilesSet       map[int]struct{}
 	basePath               string
 	downloadDir            string
 	trackerKey             string
@@ -80,12 +75,11 @@ type Download struct {
 	tags                   []string
 	pieceInfo              []pieceFileChunks
 	trackers               []TrackerTier
-	pieceRare              []uint32 // mapping from piece index to rare
+	pieceAvailability      []int32
 	chunkMap               bitmap.Bitmap
 	pendingChunksMap       bitmap.Bitmap
 	info                   meta.Info
 	completed              atomic.Int64
-	endGameMode            atomic.Bool
 	AddAt                  int64
 	CompletedAt            atomic.Int64
 	downloaded             atomic.Int64
@@ -93,6 +87,7 @@ type Download struct {
 	uploaded               atomic.Int64
 	uploadAtStart          int64
 	downloadAtStart        int64
+	endGameMode            atomic.Bool
 	seq                    atomic.Bool
 	announcePending        atomic.Bool
 	trackerMutex           sync.RWMutex
@@ -107,25 +102,16 @@ type Download struct {
 }
 
 type pieceRare struct {
-	index uint32
-	rare  uint32
+	index    uint32
+	priority int32
 }
 
 func (p pieceRare) Less(o pieceRare) bool {
-	// ordered by rare 1 < 2 < 0
-	if p.rare == o.rare {
+	if p.priority == o.priority {
 		return p.index < o.index
 	}
-
-	if p.rare == 0 {
-		return false
-	}
-
-	if o.rare == 0 {
-		return true
-	}
-
-	return p.rare < o.rare
+	// higher priority first
+	return p.priority > o.priority
 }
 
 func (d *Download) GetState() State {
@@ -151,7 +137,7 @@ func (c *Client) ScheduleMove(ih metainfo.Hash, targetBasePath string) error {
 	return err
 }
 
-func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath string, tags []string) *Download {
+func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath string, tags []string, selectedFiles []int) *Download {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	if tags == nil {
@@ -185,7 +171,8 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 		peers:             xsync.NewMap[netip.AddrPort, *Peer](),
 		connectionHistory: expirable.NewLRU[netip.AddrPort, connHistory](1024, nil, time.Minute*10),
 
-		chunkMap: make(bitmap.Bitmap, int64(info.NumPieces)*((info.PieceLength+defaultBlockSize-1)/defaultBlockSize)),
+		chunkMap:         make(bitmap.Bitmap, int64(info.NumPieces)*((info.PieceLength+defaultBlockSize-1)/defaultBlockSize)),
+		endgameRequested: xsync.NewMap[proto.ChunkRequest, empty.Empty](),
 
 		pendingPeers: heap.New[peerWithPriority](),
 
@@ -211,6 +198,15 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 		trackerKey: random.URLSafeStr(16),
 	}
 
+	if selectedFiles != nil {
+		d.selectedFilesSet = make(map[int]struct{}, len(selectedFiles))
+		for _, idx := range selectedFiles {
+			if idx >= 0 && idx < len(info.Files) {
+				d.selectedFilesSet[idx] = struct{}{}
+			}
+		}
+	}
+
 	d.stateCond = gsync.NewCond(&d.m)
 
 	d.setAnnounceList(m.UpvertedAnnounceList())
@@ -230,4 +226,29 @@ func (d *Download) setError(err error) {
 	d.err = err
 	d.state = Error
 	d.m.Unlock()
+}
+
+// hasSelectedFiles returns true if the piece touches at least one selected file.
+func (d *Download) hasSelectedFiles(pieceIndex uint32) bool {
+	if d.selectedFilesSet == nil {
+		return true
+	}
+	for _, c := range d.pieceInfo[pieceIndex].fileChunks {
+		if _, ok := d.selectedFilesSet[c.fileIndex]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// markUnselectedPiecesDone marks pieces that only touch unselected files as complete.
+func (d *Download) markUnselectedPiecesDone() {
+	if d.selectedFilesSet == nil {
+		return
+	}
+	for i := range d.info.NumPieces {
+		if !d.hasSelectedFiles(i) {
+			d.bm.Set(i)
+		}
+	}
 }

--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
-	"github.com/kelindar/bitmap"
 	"github.com/trim21/errgo"
 
 	"neptune/internal/meta"
@@ -102,6 +101,11 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 	d.netDown.Update(len(res.Data))
 	d.c.ioDown.Update(len(res.Data))
 	d.downloaded.Add(int64(len(res.Data)))
+
+	// clear endgame tracking for this chunk
+	if d.endGameMode.Load() {
+		d.endgameRequested.Delete(res.Request())
+	}
 
 	// in endgame mode we may receive duplicated response, just ignore them
 	if d.bm.Contains(res.PieceIndex) {
@@ -357,38 +361,45 @@ func (d *Download) checkDone() {
 	d.announce(EventCompleted)
 }
 
+// piecePriority computes a priority score for a piece, inspired by libtorrent:
+// priority = (availability + 1) * 3 + state_adjustment
+// Higher priority means more urgent to download.
+func piecePriority(availability int32, hasPendingChunks bool) int32 {
+	p := (availability + 1) * 3
+	if hasPendingChunks {
+		p += 1 // boost partially downloaded pieces
+	}
+	return p
+}
+
 func (d *Download) updateRarePieces() {
 	d.ratePieceMutex.Lock()
 	defer d.ratePieceMutex.Unlock()
 
-	if len(d.pieceRare) == 0 {
-		d.pieceRare = make([]uint32, d.info.NumPieces)
+	if len(d.pieceAvailability) == 0 {
+		d.pieceAvailability = make([]int32, d.info.NumPieces)
 	} else {
-		clear(d.pieceRare)
+		clear(d.pieceAvailability)
 	}
 
-	var requested = make(bitmap.Bitmap, d.bitfieldSize)
-
-	var baseRare uint32
+	var baseAvail int32
 	d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {
-		requested.Or(p.Requested)
 		if p.peerChoking.Load() {
 			p.allowFast.Range(func(u uint32) {
 				if p.Bitmap.Contains(u) {
-					d.pieceRare[u]++
+					d.pieceAvailability[u]++
 				}
 			})
 			return true
 		}
 
-		// doesn't contribute to rare
 		if p.Bitmap.Count() == d.info.NumPieces {
-			baseRare++
+			baseAvail++
 			return true
 		}
 
 		p.Bitmap.Range(func(u uint32) {
-			d.pieceRare[u]++
+			d.pieceAvailability[u]++
 		})
 
 		return true
@@ -396,20 +407,35 @@ func (d *Download) updateRarePieces() {
 
 	var queue = make([]pieceRare, 0, d.info.NumPieces)
 
-	for index, rare := range d.pieceRare {
+	for index, avail := range d.pieceAvailability {
 		if d.bm.Contains(uint32(index)) {
 			continue
 		}
 
-		if requested.Contains(uint32(index)) {
+		totalAvail := avail + baseAvail
+		if totalAvail == 0 {
 			continue
 		}
 
-		if rare+baseRare == 0 {
+		if !d.hasSelectedFiles(uint32(index)) {
 			continue
 		}
 
-		queue = append(queue, pieceRare{rare: rare + baseRare, index: uint32(index)})
+		// check if piece has pending chunks (partially downloaded)
+		pieceStart := uint32(index) * d.normalChunkLen
+		pieceEnd := pieceStart + uint32(pieceChunksCount(d.info, uint32(index)))
+		hasPending := false
+		for c := pieceStart; c < pieceEnd; c++ {
+			if d.chunkMap.Contains(c) {
+				hasPending = true
+				break
+			}
+		}
+
+		priority := piecePriority(totalAvail, hasPending)
+		if priority > 0 {
+			queue = append(queue, pieceRare{priority: priority, index: uint32(index)})
+		}
 	}
 
 	d.rarePieceQueue = heap.FromSlice(queue)
@@ -427,60 +453,147 @@ func (d *Download) scheduleSeq() {
 		return
 	}
 
+	// Phase 1: prioritize partial pieces (already partially downloaded)
+	d.schedulePartialPieces()
+
+	// Phase 2: rarest-first for remaining capacity
+	d.scheduleRarePieces()
+}
+
+// schedulePartialPieces assigns pieces that are already partially downloaded.
+// This reduces memory usage and completes work-in-progress faster.
+func (d *Download) schedulePartialPieces() {
+	type partialPiece struct {
+		index    uint32
+		progress int // number of chunks already downloaded
+	}
+
+	var partials []partialPiece
+
+	for i := range d.info.NumPieces {
+		if d.bm.Contains(i) {
+			continue
+		}
+		if !d.hasSelectedFiles(i) {
+			continue
+		}
+
+		pieceStart := i * d.normalChunkLen
+		pieceEnd := pieceStart + uint32(pieceChunksCount(d.info, i))
+		downloaded := 0
+		for c := pieceStart; c < pieceEnd; c++ {
+			if d.chunkMap.Contains(c) {
+				downloaded++
+			}
+		}
+
+		if downloaded > 0 {
+			partials = append(partials, partialPiece{index: i, progress: downloaded})
+		}
+	}
+
+	if len(partials) == 0 {
+		return
+	}
+
+	// sort by progress descending (almost-done pieces first)
+	slices.SortFunc(partials, func(a, b partialPiece) int {
+		return cmp.Compare(b.progress, a.progress)
+	})
+
+	d.assignPiecesToPeers(func() (uint32, bool) {
+		if len(partials) == 0 {
+			return 0, false
+		}
+		p := partials[0]
+		partials = partials[1:]
+		return p.index, true
+	})
+}
+
+// scheduleRarePieces assigns pieces using rarest-first strategy.
+func (d *Download) scheduleRarePieces() {
 	d.updateRarePieces()
-	var peers = make([]*Peer, 0, d.peers.Size())
-
-	d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {
-		peers = append(peers, p)
-		return true
-	})
-
-	slices.SortFunc(peers, func(a, b *Peer) int {
-		return cmp.Compare(a.ioIn.Status().CurRate, b.ioIn.Status().CurRate)
-	})
 
 	d.ratePieceMutex.Lock()
 	q := d.rarePieceQueue
 	d.rarePieceQueue = heap.New[pieceRare]()
 	d.ratePieceMutex.Unlock()
 
-PIECE:
-	for q.Len() > 0 {
-		piece := q.Pop()
-
-		if piece.rare == 0 {
-			return
+	d.assignPiecesToPeers(func() (uint32, bool) {
+		if q.Len() == 0 {
+			return 0, false
 		}
+		piece := q.Pop()
+		if piece.priority <= 0 {
+			return 0, false
+		}
+		return piece.index, true
+	})
+}
 
-		for _, p := range peers {
-			if p.closed.Load() {
-				// peer closed, re-scheduler
+// assignPiecesToPeers assigns pieces from the iterator to peers.
+// Peers are sorted by speed (fastest first) and get pieces proportional to their pipeline capacity.
+func (d *Download) assignPiecesToPeers(nextPiece func() (uint32, bool)) {
+	type peerInfo struct {
+		peer     *Peer
+		capacity int // how many more pieces this peer can handle
+	}
+
+	var peers []peerInfo
+	d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {
+		if p.closed.Load() {
+			return true
+		}
+		queueSize := int(p.desiredQueueSize.Load())
+		pending := p.myRequests.Size()
+		// rough estimate: each piece has multiple chunks, divide by avg chunks
+		pendingPieces := 0
+		if pending > 0 {
+			pendingPieces = max(pending/int(d.normalChunkLen), 1)
+		}
+		avail := queueSize - pendingPieces
+		if avail > 0 {
+			peers = append(peers, peerInfo{peer: p, capacity: avail})
+		}
+		return true
+	})
+
+	if len(peers) == 0 {
+		return
+	}
+
+	// sort by download rate descending (fastest peer first)
+	slices.SortFunc(peers, func(a, b peerInfo) int {
+		return cmp.Compare(b.peer.ioIn.Status().CurRate, a.peer.ioIn.Status().CurRate)
+	})
+
+	for _, pi := range peers {
+		for pi.capacity > 0 {
+			pieceIndex, ok := nextPiece()
+			if !ok {
 				return
 			}
 
-			if p.peerChoking.Load() {
-				if !p.allowFast.Contains(piece.index) {
-					continue
-				}
-
-				select {
-				case p.ourPieceRequests <- piece.index:
-					p.Requested.Set(piece.index)
-				default:
-				}
-
+			if !d.hasSelectedFiles(pieceIndex) {
 				continue
 			}
 
-			if !p.Bitmap.Contains(piece.index) {
+			if pi.peer.peerChoking.Load() {
+				if !pi.peer.allowFast.Contains(pieceIndex) {
+					continue
+				}
+			} else if !pi.peer.Bitmap.Contains(pieceIndex) {
 				continue
 			}
 
 			select {
-			case p.ourPieceRequests <- piece.index:
-				p.Requested.Set(piece.index)
-				continue PIECE
+			case pi.peer.ourPieceRequests <- pieceIndex:
+				pi.peer.Requested.Set(pieceIndex)
+				pi.capacity--
 			default:
+				// channel full, move to next peer
+				break
 			}
 		}
 	}
@@ -494,7 +607,14 @@ func (d *Download) scheduleSeqEndGame() {
 
 	d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {
 		for _, u := range s {
+			if !d.hasSelectedFiles(u) {
+				continue
+			}
 			if p.Bitmap.Contains(u) {
+				// check if this peer has any unrequested chunks for this piece
+				if !d.hasUnrequestedEndgameChunks(u) {
+					continue
+				}
 				select {
 				case <-p.ctx.Done():
 					return true
@@ -506,6 +626,24 @@ func (d *Download) scheduleSeqEndGame() {
 
 		return true
 	})
+}
+
+// hasUnrequestedEndgameChunks returns true if the piece has chunks not yet requested in endgame mode.
+func (d *Download) hasUnrequestedEndgameChunks(pieceIndex uint32) bool {
+	if !d.endGameMode.Load() {
+		return true
+	}
+	pieceStart := pieceIndex * d.normalChunkLen
+	pieceEnd := pieceStart + uint32(pieceChunksCount(d.info, pieceIndex))
+	for c := pieceStart; c < pieceEnd; c++ {
+		if !d.chunkMap.Contains(c) {
+			req := pieceChunk(d.info, pieceIndex, int(c-pieceStart))
+			if _, requested := d.endgameRequested.Load(req); !requested {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func pieceChunksCount(info meta.Info, index uint32) int64 {

--- a/internal/core/d_loop.go
+++ b/internal/core/d_loop.go
@@ -4,6 +4,7 @@
 package core
 
 import (
+	"net/netip"
 	"os"
 	"path/filepath"
 	"time"
@@ -62,6 +63,7 @@ func (d *Download) Init(resumed bool) {
 			d.setError(err)
 			d.log.Err(err).Msg("failed to initCheck torrent data")
 		}
+		d.markUnselectedPiecesDone()
 		d.ioDown.Reset()
 
 		d.log.Debug().Msgf("done size %s", humanize.IBytes(uint64(d.bm.Count())*uint64(d.info.PieceLength)))
@@ -128,6 +130,7 @@ func (d *Download) startBackground() {
 
 	// upload
 	go d.backgroundReqHandler()
+	go d.unchokeLoop()
 
 	go d.backgroundTrackerHandler()
 
@@ -178,6 +181,57 @@ func (d *Download) startBackground() {
 			}
 		}
 	}()
+
+	// optimistic unchoke: periodically reset a random peer's Requested bitmap
+	// to discover new fast peers and prevent stale assignments
+	go d.optimisticUnchokeLoop()
+}
+
+// optimisticUnchokeLoop periodically picks a random peer and clears its Requested
+// bitmap, giving it a chance to receive new piece assignments from the scheduler.
+// This helps discover fast peers that may have been overlooked.
+func (d *Download) optimisticUnchokeLoop() {
+	const interval = 30 * time.Second
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-d.ctx.Done():
+			return
+		case <-timer.C:
+			timer.Reset(interval)
+
+			if !d.wait(Downloading | Seeding) {
+				continue
+			}
+
+			// collect all peers
+			var peers []*Peer
+			d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {
+				if !p.closed.Load() && !p.snubbed.Load() {
+					peers = append(peers, p)
+				}
+				return true
+			})
+
+			if len(peers) == 0 {
+				continue
+			}
+
+			// pick a random peer
+			idx := int(time.Now().UnixNano()) % len(peers)
+			p := peers[idx]
+			p.Requested.Clear()
+			d.log.Debug().Stringer("addr", p.Address).Msg("optimistic unchoke: cleared peer Requested")
+
+			// trigger reschedule
+			select {
+			case d.scheduleRequestSignal <- empty.Empty{}:
+			default:
+			}
+		}
+	}
 }
 
 type Priority struct {

--- a/internal/core/d_move.go
+++ b/internal/core/d_move.go
@@ -46,6 +46,11 @@ func (d *Download) move(ctx context.Context, target string) error {
 	originalBasePath := d.basePath
 
 	for index := range d.info.Files {
+		if d.selectedFilesSet != nil {
+			if _, ok := d.selectedFilesSet[index]; !ok {
+				continue
+			}
+		}
 		err := d.moveFile(ctx, target, uint32(index))
 		if err != nil {
 			return err

--- a/internal/core/d_resume.go
+++ b/internal/core/d_resume.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/rs/zerolog/log"
 	"github.com/samber/lo"
@@ -22,16 +23,17 @@ import (
 var _ encoding.BinaryMarshaler = (*Download)(nil)
 
 type resume struct {
-	BasePath    string
-	InfoHash    string
-	Bitfield    []byte
-	Tags        []string
-	Trackers    [][]string
-	AddAt       int64
-	CompletedAt int64
-	Downloaded  int64
-	Uploaded    int64
-	State       State
+	BasePath      string
+	InfoHash      string
+	Bitfield      []byte
+	Tags          []string
+	Trackers      [][]string
+	SelectedFiles []int // indices of files selected for download. nil means all files.
+	AddAt         int64
+	CompletedAt   int64
+	Downloaded    int64
+	Uploaded      int64
+	State         State
 }
 
 func (d *Download) resumeFilePath() (dir, file string) {
@@ -64,16 +66,26 @@ func (d *Download) saveResume() {
 }
 
 func (d *Download) MarshalBinary() (data []byte, err error) {
+	var selectedFiles []int
+	if d.selectedFilesSet != nil {
+		selectedFiles = make([]int, 0, len(d.selectedFilesSet))
+		for idx := range d.selectedFilesSet {
+			selectedFiles = append(selectedFiles, idx)
+		}
+		slices.Sort(selectedFiles)
+	}
+
 	return bencode.Marshal(resume{
-		BasePath:    d.basePath,
-		Downloaded:  d.downloaded.Load(),
-		Uploaded:    d.uploaded.Load(),
-		Tags:        d.tags,
-		State:       d.GetState(),
-		InfoHash:    d.info.Hash.Hex(),
-		Bitfield:    d.bm.Bitfield(),
-		AddAt:       d.AddAt,
-		CompletedAt: d.CompletedAt.Load(),
+		BasePath:      d.basePath,
+		Downloaded:    d.downloaded.Load(),
+		Uploaded:      d.uploaded.Load(),
+		Tags:          d.tags,
+		State:         d.GetState(),
+		InfoHash:      d.info.Hash.Hex(),
+		Bitfield:      d.bm.Bitfield(),
+		AddAt:         d.AddAt,
+		CompletedAt:   d.CompletedAt.Load(),
+		SelectedFiles: selectedFiles,
 		Trackers: lo.Map(d.trackers, func(tier TrackerTier, index int) []string {
 			return lo.Map(tier.trackers, func(tracker *Tracker, index int) string {
 				return tracker.url
@@ -103,9 +115,18 @@ func (c *Client) UnmarshalResume(data []byte) error {
 		return errgo.Wrap(err, "failed to decode torrent data")
 	}
 
-	d := c.NewDownload(m, info, r.BasePath, r.Tags)
+	// backward compatibility: old resume data without SelectedFiles defaults to all files
+	if r.SelectedFiles == nil {
+		r.SelectedFiles = make([]int, len(info.Files))
+		for i := range info.Files {
+			r.SelectedFiles[i] = i
+		}
+	}
+
+	d := c.NewDownload(m, info, r.BasePath, r.Tags, r.SelectedFiles)
 
 	d.bm = bm.FromBitfields(r.Bitfield, d.info.NumPieces)
+	d.markUnselectedPiecesDone()
 	done := int64(d.bm.Count()) * d.info.PieceLength
 	if d.bm.Contains(d.info.NumPieces - 1) {
 		done = done - d.info.PieceLength + d.info.LastPieceSize

--- a/internal/core/d_upload.go
+++ b/internal/core/d_upload.go
@@ -6,12 +6,13 @@ package core
 import (
 	"io"
 	"net/netip"
+	"slices"
+	"time"
 
 	"github.com/sourcegraph/conc"
 
 	"neptune/internal/metainfo"
 	"neptune/internal/pkg/empty"
-	"neptune/internal/pkg/heap"
 	"neptune/internal/pkg/mempool"
 	"neptune/internal/proto"
 )
@@ -21,10 +22,119 @@ type cacheKey struct {
 	index uint32
 }
 
-func (d *Download) backgroundReqHandler() {
-	var reqPieceCount = make(map[uint32]uint32, d.info.NumPieces)
-	var peers []*Peer
+const (
+	uploadSlots        = 4 // default number of upload slots
+	optimisticUnchokeN = 1 // number of optimistic unchoke slots
+	unchokeInterval    = 10 * time.Second
+)
 
+// unchokeLoop periodically selects which peers get upload slots.
+// Based on libtorrent's choking algorithm:
+// - Sort interested peers by upload rate (descending)
+// - Unchoke top N peers
+// - Reserve 1 slot for optimistic unchoke (round-robin).
+func (d *Download) unchokeLoop() {
+	timer := time.NewTimer(unchokeInterval)
+	defer timer.Stop()
+
+	optimisticIdx := 0
+
+	for {
+		select {
+		case <-d.ctx.Done():
+			return
+		case <-timer.C:
+			timer.Reset(unchokeInterval)
+
+			if !d.wait(Downloading | Seeding) {
+				continue
+			}
+
+			d.recalculateUnchokeSlots(&optimisticIdx)
+		}
+	}
+}
+
+func (d *Download) recalculateUnchokeSlots(optimisticIdx *int) {
+	type peerRate struct {
+		peer *Peer
+		rate int64
+	}
+
+	var candidates []peerRate
+	var unchokable []*Peer
+
+	d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {
+		if p.closed.Load() {
+			return true
+		}
+		if p.peerInterested.Load() {
+			candidates = append(candidates, peerRate{
+				peer: p,
+				rate: p.ioOut.Status().CurRate,
+			})
+		}
+		if !p.peerInterested.Load() || p.snubbed.Load() {
+			// choke peers that are not interested or snubbed
+			if !p.ourChoking.CompareAndSwap(false, true) {
+				go p.sendEventX(Event{Event: proto.Choke})
+			}
+		}
+		return true
+	})
+
+	// sort by upload rate descending (fastest first)
+	slices.SortFunc(candidates, func(a, b peerRate) int {
+		if a.rate > b.rate {
+			return -1
+		}
+		if a.rate < b.rate {
+			return 1
+		}
+		return 0
+	})
+
+	// unchoke top-N peers by rate
+	normalSlots := uploadSlots - optimisticUnchokeN
+	for i, c := range candidates {
+		if i >= normalSlots {
+			break
+		}
+		unchokable = append(unchokable, c.peer)
+	}
+
+	// optimistic unchoke: pick the peer that has been waiting longest
+	if len(candidates) > normalSlots {
+		// rotate through candidates beyond the normal slots
+		if *optimisticIdx >= len(candidates)-normalSlots {
+			*optimisticIdx = 0
+		}
+		if normalSlots+*optimisticIdx < len(candidates) {
+			unchokable = append(unchokable, candidates[normalSlots+*optimisticIdx].peer)
+			*optimisticIdx++
+		}
+	}
+
+	// apply: unchoke selected peers, choke the rest
+	for _, p := range unchokable {
+		if p.ourChoking.CompareAndSwap(true, false) {
+			go p.sendEventX(Event{Event: proto.Unchoke})
+		}
+	}
+
+	// trigger response scheduling for newly unchoked peers
+	select {
+	case d.scheduleResponseSignal <- empty.Empty{}:
+	default:
+	}
+}
+
+// backgroundReqHandler processes upload requests from peers in FIFO order.
+// Unlike the previous implementation, it:
+// - Respects choking (only serves unchoked peers)
+// - Processes multiple pieces per cycle
+// - Uses piece caching to avoid redundant disk reads.
+func (d *Download) backgroundReqHandler() {
 	for {
 		select {
 		case <-d.ctx.Done():
@@ -34,84 +144,123 @@ func (d *Download) backgroundReqHandler() {
 				continue
 			}
 
-			clear(reqPieceCount)
-			clear(peers)
-			peers = peers[:0]
-
-			d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {
-				if p.peerInterested.Load() {
-					if p.ourChoking.CompareAndSwap(true, false) {
-						p.Unchoke()
-					}
-				}
-
-				if p.peerRequests.Size() != 0 {
-					peers = append(peers, p)
-				}
-				return true
-			})
-
-			var s = make([]pieceRare, 0, len(reqPieceCount))
-
-			for _, peer := range peers {
-				peer.peerRequests.Range(func(key proto.ChunkRequest, _ empty.Empty) bool {
-					reqPieceCount[key.PieceIndex]++
-					return true
-				})
-			}
-
-			for index, rare := range reqPieceCount {
-				s = append(s, pieceRare{
-					index: index,
-					rare:  rare,
-				})
-			}
-
-			if len(s) == 0 {
-				continue
-			}
-
-			h := heap.FromSlice(s)
-
-			pieceReq := h.Pop()
-
-			var buf *mempool.Buffer
-
-			buf = mempool.GetWithCap(int(d.pieceLength(pieceReq.index)))
-
-			err := d.readPiece(pieceReq.index, buf.B)
-			if err != nil {
-				mempool.Put(buf)
-				d.setError(err)
-				continue
-			}
-
-			var g conc.WaitGroup
-
-			for _, p := range peers {
-				p.peerRequests.Range(func(key proto.ChunkRequest, _ empty.Empty) bool {
-					if key.PieceIndex == pieceReq.index {
-						d.ioUp.Update(int(key.Length))
-						d.c.ioUp.Update(int(key.Length))
-						d.uploaded.Add(int64(key.Length))
-						g.Go(func() {
-							p.Response(&proto.ChunkResponse{
-								Data:       buf.B[key.Begin : key.Begin+key.Length],
-								Begin:      key.Begin,
-								PieceIndex: pieceReq.index,
-							})
-						})
-					}
-					return true
-				})
-			}
-
-			g.Wait()
+			d.processUploadRequests()
 		}
 	}
 }
 
-// buf must be bigger enough to read whole piece.
+func (d *Download) processUploadRequests() {
+	// collect all requests from unchoked, interested peers
+	type peerRequest struct {
+		peer  *Peer
+		req   proto.ChunkRequest
+		order int // FIFO order
+	}
+
+	var requests []peerRequest
+	order := 0
+
+	d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {
+		if p.closed.Load() {
+			return true
+		}
+		// only serve unchoked peers
+		if p.ourChoking.Load() {
+			return true
+		}
+		p.peerRequests.Range(func(req proto.ChunkRequest, _ empty.Empty) bool {
+			requests = append(requests, peerRequest{peer: p, req: req, order: order})
+			order++
+			return true
+		})
+		return true
+	})
+
+	if len(requests) == 0 {
+		return
+	}
+
+	// sort by FIFO order (first requested, first served)
+	slices.SortFunc(requests, func(a, b peerRequest) int {
+		return a.order - b.order
+	})
+
+	// group by piece for efficient disk reads
+	type pieceRequest struct {
+		requests []peerRequest
+		index    uint32
+	}
+
+	pieceMap := make(map[uint32]*pieceRequest)
+	var pieceOrder []uint32
+	for _, r := range requests {
+		idx := r.req.PieceIndex
+		if _, ok := pieceMap[idx]; !ok {
+			pieceMap[idx] = &pieceRequest{index: idx}
+			pieceOrder = append(pieceOrder, idx)
+		}
+		pieceMap[idx].requests = append(pieceMap[idx].requests, r)
+	}
+
+	// process pieces in FIFO order (by first request arrival)
+	var cachedPieceIdx uint32
+	var cachedBuf *mempool.Buffer
+	cachedPieceIdx = ^uint32(0) // invalid sentinel
+
+	defer func() {
+		if cachedBuf != nil {
+			mempool.Put(cachedBuf)
+		}
+	}()
+
+	for _, pieceIdx := range pieceOrder {
+		pr := pieceMap[pieceIdx]
+
+		// read piece (use cache if same piece requested consecutively)
+		if cachedPieceIdx != pieceIdx || cachedBuf == nil {
+			if cachedBuf != nil {
+				mempool.Put(cachedBuf)
+			}
+			cachedBuf = mempool.GetWithCap(int(d.pieceLength(pieceIdx)))
+			cachedBuf.Reset()
+
+			if err := d.readPiece(pieceIdx, cachedBuf.B); err != nil {
+				d.setError(err)
+				mempool.Put(cachedBuf)
+				cachedBuf = nil
+				continue
+			}
+			cachedPieceIdx = pieceIdx
+		}
+
+		// serve all requests for this piece
+		var g conc.WaitGroup
+		for _, r := range pr.requests {
+			p := r.peer
+			req := r.req
+
+			// verify request is still valid
+			if _, ok := p.peerRequests.LoadAndDelete(req); !ok {
+				continue // already served or cancelled
+			}
+
+			d.ioUp.Update(int(req.Length))
+			d.c.ioUp.Update(int(req.Length))
+			d.uploaded.Add(int64(req.Length))
+
+			g.Go(func() {
+				p.Response(&proto.ChunkResponse{
+					Data:       cachedBuf.B[req.Begin : req.Begin+req.Length],
+					Begin:      req.Begin,
+					PieceIndex: pieceIdx,
+				})
+			})
+		}
+		g.Wait()
+	}
+}
+
+// buf must be big enough to read whole piece.
 func (d *Download) readPiece(index uint32, buf []byte) error {
 	pieces := d.pieceInfo[index]
 	var offset int64 = 0

--- a/internal/core/p.go
+++ b/internal/core/p.go
@@ -88,9 +88,12 @@ func newPeer(
 		peerChoking:    *atomic.NewBool(true),
 		peerInterested: *atomic.NewBool(false),
 
-		ourPieceRequests: make(chan uint32, 1),
+		ourPieceRequests: make(chan uint32, 20),
 
-		UserAgent: *atomic.NewPointer[string](&ua),
+		pieceDone:        make(chan struct{}, 1),
+		desiredQueueSize: *atomic.NewInt32(1),
+
+		UserAgent: *atomic.NewPointer(&ua),
 
 		Requested: make(bitmap.Bitmap, d.bitfieldSize),
 
@@ -129,58 +132,51 @@ func newPeer(
 var ErrPeerSendInvalidData = errors.New("addrPort send invalid data")
 
 type Peer struct {
-	log      zerolog.Logger
-	ctx      context.Context
-	Conn     net.Conn
-	lastSend atomic.Time
-	r        *bufio.Reader
-	w        *bufio.Writer
-	d        *Download
-	cancel   context.CancelFunc
-	Bitmap   *bm.Bitmap
-
+	log              zerolog.Logger
+	ctx              context.Context
+	Conn             net.Conn
+	lastSend         atomic.Time
+	snubbedAt        atomic.Time
+	peerRequests     *xsync.Map[proto.ChunkRequest, empty.Empty]
+	ioIn             *flowrate.Monitor
+	Bitmap           *bm.Bitmap
 	myRequests       *xsync.Map[proto.ChunkRequest, time.Time]
 	myRequestHistory *xsync.Map[proto.ChunkRequest, empty.Empty]
-
-	peerRequests *xsync.Map[proto.ChunkRequest, empty.Empty]
-
-	Rejected  *xsync.Map[proto.ChunkRequest, empty.Empty]
-	allowFast *bm.Bitmap
-	ioOut     *flowrate.Monitor
-	ioIn      *flowrate.Monitor
-	UserAgent atomic.Pointer[string]
-
-	ourPieceRequests chan uint32 // our requests for peer chan
-
-	responseCond *gsync.Cond
-	peerID       atomic.Pointer[proto.PeerID]
-	Address      netip.AddrPort
-
-	Requested bitmap.Bitmap
-
-	rttAverage sizedSlice[time.Duration]
-
-	peerChoking    atomic.Bool // peer is choking us
-	peerInterested atomic.Bool
-	ourChoking     atomic.Bool
-	ourInterested  atomic.Bool
-	QueueLimit     atomic.Uint32
-	closed         atomic.Bool
-
-	rttMutex sync.RWMutex
-
-	wm sync.Mutex
-
-	extDontHaveID gsync.AtomicUint[proto.ExtensionMessage]
-	extPexID      gsync.AtomicUint[proto.ExtensionMessage]
-
-	writeBuf [4]byte // buffer for reading message size and event id
-	readBuf  [4]byte // buffer for reading message size and event id
-	Incoming bool
-
-	fastExtension bool
-	dhtEnabled    bool
-	subExtensions bool
+	d                *Download
+	Rejected         *xsync.Map[proto.ChunkRequest, empty.Empty]
+	allowFast        *bm.Bitmap
+	ioOut            *flowrate.Monitor
+	cancel           context.CancelFunc
+	UserAgent        atomic.Pointer[string]
+	ourPieceRequests chan uint32
+	responseCond     *gsync.Cond
+	peerID           atomic.Pointer[proto.PeerID]
+	pieceDone        chan struct{}
+	w                *bufio.Writer
+	r                *bufio.Reader
+	Address          netip.AddrPort
+	Requested        bitmap.Bitmap
+	rttAverage       sizedSlice[time.Duration]
+	slowStart        atomic.Bool
+	QueueLimit       atomic.Uint32
+	lastRate         atomic.Int64
+	desiredQueueSize atomic.Int32
+	ourInterested    atomic.Bool
+	snubbed          atomic.Bool
+	closed           atomic.Bool
+	peerChoking      atomic.Bool
+	peerInterested   atomic.Bool
+	ourChoking       atomic.Bool
+	rttMutex         sync.RWMutex
+	wm               sync.Mutex
+	extDontHaveID    gsync.AtomicUint[proto.ExtensionMessage]
+	extPexID         gsync.AtomicUint[proto.ExtensionMessage]
+	readBuf          [4]byte
+	writeBuf         [4]byte
+	Incoming         bool
+	fastExtension    bool
+	dhtEnabled       bool
+	subExtensions    bool
 }
 
 func (p *Peer) Response(res *proto.ChunkResponse) {
@@ -232,32 +228,173 @@ func (p *Peer) close() {
 }
 
 func (p *Peer) ourRequestHandle() {
+	p.ourRequestHandleLoop()
+}
+
+func (p *Peer) ourRequestHandleLoop() {
+	pending := make(map[uint32]struct{})
+	sem := make(chan struct{}, 20)
+	p.slowStart.Store(true)
+
+	for {
+		// update desired queue size
+		var queueSize int
+		if p.snubbed.Load() {
+			queueSize = 1
+		} else if p.slowStart.Load() {
+			// slow start: use current desired size, will grow on piece completion
+			queueSize = int(p.desiredQueueSize.Load())
+		} else {
+			// rate-based: keep 3s of pipeline
+			queueSize = int(3*p.ioIn.Status().CurRate) / int(defaultBlockSize)
+		}
+		queueSize = max(queueSize, 1)
+		queueSize = min(queueSize, 20)
+		p.desiredQueueSize.Store(int32(queueSize))
+		limit := queueSize
+
+		// drain channel into pending while we have capacity
+		for len(pending) < limit {
+			select {
+			case <-p.ctx.Done():
+				return
+			case index := <-p.ourPieceRequests:
+				pending[index] = struct{}{}
+			default:
+				break
+			}
+		}
+
+		if len(pending) == 0 {
+			// wait for new piece, piece completion, or context cancellation
+			select {
+			case <-p.ctx.Done():
+				return
+			case index := <-p.ourPieceRequests:
+				pending[index] = struct{}{}
+			case <-p.pieceDone:
+				p.handleSlowStart()
+			}
+			continue
+		}
+
+		// also handle pieceDone non-blocking to react to completions
+		select {
+		case <-p.pieceDone:
+			p.handleSlowStart()
+		default:
+		}
+
+		// start downloading pieces concurrently
+		for index := range pending {
+			sem <- struct{}{} // acquire slot
+			delete(pending, index)
+			go func(pieceIdx uint32) {
+				defer func() {
+					<-sem // release slot
+					select {
+					case p.pieceDone <- struct{}{}:
+					default:
+					}
+				}()
+				p.downloadPieceChunks(pieceIdx)
+			}(index)
+		}
+	}
+}
+
+// handleSlowStart updates the desired queue size during slow start mode.
+// It doubles the queue size when download rate is still growing,
+// and exits slow start when rate plateaus.
+func (p *Peer) handleSlowStart() {
+	if !p.slowStart.Load() {
+		return
+	}
+
+	currentRate := p.ioIn.Status().CurRate
+	lastRate := p.lastRate.Load()
+	p.lastRate.Store(currentRate)
+
+	// if rate is still growing (with some tolerance), double the queue
+	if lastRate > 0 && currentRate > lastRate*95/100 {
+		old := p.desiredQueueSize.Load()
+		newSize := min(old*2, 20)
+		p.desiredQueueSize.Store(newSize)
+		p.log.Trace().Int32("old", old).Int32("new", newSize).Msg("slow start: growing pipeline")
+	} else if lastRate > 0 {
+		// rate stopped growing, exit slow start
+		p.slowStart.Store(false)
+		p.log.Info().Int64("rate", currentRate).Msg("slow start: exited, switching to rate-based")
+	}
+}
+
+// downloadPieceChunks requests all chunks of a piece from this peer.
+func (p *Peer) downloadPieceChunks(index uint32) {
+	chunkLen := int(pieceChunksCount(p.d.info, index))
+	for i := range chunkLen {
+		if p.closed.Load() {
+			return
+		}
+
+		chunk := pieceChunk(p.d.info, index, i)
+
+		// in endgame mode, skip chunks already requested by other peers
+		if p.d.endGameMode.Load() {
+			if _, already := p.d.endgameRequested.Load(chunk); already {
+				continue
+			}
+			p.d.endgameRequested.Store(chunk, empty.Empty{})
+		}
+
+		// wait if peer's request queue is full
+		for p.myRequests.Size() >= min(int(p.QueueLimit.Load())-10, 300) {
+			select {
+			case <-p.ctx.Done():
+				return
+			case <-p.responseCond.C:
+			}
+		}
+
+		if !p.peerChoking.Load() {
+			p.Request(chunk)
+		}
+	}
+}
+
+func (p *Peer) checkRequestTimeouts() {
+	const pieceTimeout = 30 * time.Second
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-p.ctx.Done():
 			return
-		case index := <-p.ourPieceRequests:
-			chunkLen := int(pieceChunksCount(p.d.info, index))
-			for i := range chunkLen {
-				if p.closed.Load() {
-					return
+		case <-ticker.C:
+			now := time.Now()
+			timedOut := false
+			p.myRequests.Range(func(req proto.ChunkRequest, reqTime time.Time) bool {
+				if now.Sub(reqTime) > pieceTimeout {
+					timedOut = true
+					return false // stop iterating
 				}
+				return true
+			})
 
-				// 10 is a magic number to avoid peer reject our requests
-				for p.myRequests.Size() >= min(int(p.QueueLimit.Load())-10, 300) {
-					select {
-					case <-p.ctx.Done():
-						return
-					case <-p.responseCond.C:
-					}
-				}
+			if timedOut && !p.snubbed.Load() {
+				p.snubbed.Store(true)
+				p.snubbedAt.Store(now)
+				p.log.Warn().Msg("peer snubbed: request timeout")
 
-				if !p.peerChoking.Load() {
-					p.Request(pieceChunk(p.d.info, index, i))
+				// release requested pieces so other peers can pick them up
+				p.Requested.Clear()
+
+				// trigger reschedule
+				select {
+				case p.d.scheduleRequestSignal <- empty.Empty{}:
+				default:
 				}
 			}
-
-			p.d.scheduleRequestSignal <- empty.Empty{}
 		}
 	}
 }
@@ -341,6 +478,7 @@ func (p *Peer) start(skipHandshake bool) {
 	}
 
 	go p.ourRequestHandle()
+	go p.checkRequestTimeouts()
 
 	for {
 		if p.ctx.Err() != nil {
@@ -394,6 +532,7 @@ func (p *Peer) start(skipHandshake bool) {
 				if p.fastExtension {
 					go p.sendEventX(Event{Req: event.Req, Event: proto.Reject})
 				}
+				break
 			}
 
 			p.peerRequests.Store(event.Req, empty.Empty{})

--- a/internal/web/torrent.go
+++ b/internal/web/torrent.go
@@ -23,10 +23,11 @@ import (
 )
 
 type AddTorrentRequest struct {
-	TorrentFile []byte   `description:"base64 encoded torrent file content"                   json:"torrent_file" required:"true" validate:"required"`
-	DownloadDir string   `description:"base download dir"                                     json:"download_dir"`
-	Tags        []string `json:"tags"`
-	IsBaseDir   bool     `description:"if true, will not append torrent name to download_dir" json:"is_base_dir"`
+	TorrentFile   []byte   `description:"base64 encoded torrent file content"                   json:"torrent_file"   required:"true" validate:"required"`
+	DownloadDir   string   `description:"base download dir"                                     json:"download_dir"`
+	Tags          []string `json:"tags"`
+	SelectedFiles []int    `description:"indices of files to download, empty means all"         json:"selected_files"` // if nil, all files are selected.
+	IsBaseDir     bool     `description:"if true, will not append torrent name to download_dir" json:"is_base_dir"`
 }
 
 type AddTorrentResponse struct {
@@ -65,7 +66,15 @@ func addTorrent(h *jsonrpc.Handler, c *core.Client) {
 			if req.Tags == nil {
 				req.Tags = []string{}
 			}
-			err = c.AddTorrent(req.TorrentFile, m, info, downloadDir, req.Tags)
+
+			if req.SelectedFiles == nil {
+				req.SelectedFiles = make([]int, len(info.Files))
+				for i := range info.Files {
+					req.SelectedFiles[i] = i
+				}
+			}
+
+			err = c.AddTorrent(req.TorrentFile, m, info, downloadDir, req.Tags, req.SelectedFiles)
 			if err != nil {
 				return CodeError(5, errgo.Wrap(err, "failed to add torrent to download"))
 			}


### PR DESCRIPTION
## Summary

Implements libtorrent-inspired download and upload algorithm improvements, plus file-level download selection.

### Download Algorithm

- **Dynamic pipeline depth**: Peers pipeline multiple pieces based on download rate (3s depth, 1-20 range) instead of fixed capacity of 1
- **Snub mechanism**: Peers with requests pending >30s are snubbed (pipeline=1, Requested cleared for reassignment)
- **Partial piece prioritization**: Pieces with existing chunks completed first before starting new ones
- **Rarest-first priority formula**:  replacing pure rare sorting
- **Endgame deduplication**: Track requested chunks to avoid duplicate requests across peers
- **Slow start**: New peers ramp pipeline from 1, doubling on each piece completion until rate plateaus
- **Optimistic unchoke**: Periodically clear random peer's Requested to discover fast peers

### Upload Algorithm

- **Unchoke loop**: Rate-based slot allocation (4 slots: 3 for fastest peers + 1 optimistic rotation)
- **FIFO request processing**: Serve requests in arrival order across all pieces per cycle
- **Piece read cache**: Reuse disk reads for consecutive chunk requests on same piece
- **Fix**: Reject invalid requests instead of storing them

### File Selection

-  in  API for per-file download control
- Default: all files; : none; : specific files
- Persisted in resume data, respected by move operation