### PR TITLE
perf: upload pool

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,7 +18,10 @@ type Application struct {
 	NumWant         uint16 `toml:"num-want"`
 	// hard global connection limit
 	GlobalConnectionLimit uint16 `toml:"global-connections-limit"`
-	Fallocate             bool   `toml:"fallocate"`
+	// hard global upload slot limit (across all torrents)
+	// 0 means auto (derived from GlobalConnectionLimit).
+	GlobalUploadSlots uint16 `toml:"global-upload-slots"`
+	Fallocate         bool   `toml:"fallocate"`
 }
 
 type Config struct {
@@ -51,6 +54,14 @@ func LoadFromFile(path string) (Config, error) {
 		}
 
 		cfg.App.DownloadDir = filepath.Join(hd, "downloads")
+	}
+
+	if cfg.App.GlobalUploadSlots == 0 {
+		// Default to a small multiple of connection limit to allow pipelining,
+		// while still providing a hard cap across all torrents.
+		// Min 64 to avoid being too restrictive on small setups.
+		slots := max(cfg.App.GlobalConnectionLimit*4, 64)
+		cfg.App.GlobalUploadSlots = slots
 	}
 
 	return cfg, nil

--- a/internal/core/c.go
+++ b/internal/core/c.go
@@ -99,6 +99,7 @@ func New(cfg config.Config, sessionPath string, debug bool) *Client {
 		debug:   debug,
 	}
 
+	c.startUploadPool()
 	c.initMetrics()
 
 	return c
@@ -125,6 +126,7 @@ type Client struct {
 	downloadMap map[metainfo.Hash]*Download
 	connChan    chan incomingConn
 	sem         *semaphore.Weighted
+	uploadQ     chan uploadTask
 	fh          map[string]*os.File
 
 	ioDown *flowrate.Monitor

--- a/internal/core/c_upload_pool.go
+++ b/internal/core/c_upload_pool.go
@@ -1,0 +1,98 @@
+// Copyright 2024 trim21 <trim21.me@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package core
+
+import (
+	"context"
+	"slices"
+
+	"neptune/internal/proto"
+)
+
+type uploadTask struct {
+	d    *Download
+	peer *Peer
+	data []byte
+	req  proto.ChunkRequest
+}
+
+func (c *Client) startUploadPool() {
+	workerCount := int(c.Config.App.GlobalUploadSlots)
+	if workerCount <= 0 {
+		workerCount = 64
+	}
+	// Avoid spawning an extreme number of goroutines due to misconfiguration.
+	workerCount = min(workerCount, 4096)
+
+	// Bounded queue to avoid unbounded memory growth under request storms.
+	// Keep it large enough to absorb bursts while still bounded.
+	queueCap := workerCount * 256
+	queueCap = min(queueCap, 65536)
+	queueCap = max(queueCap, 1024)
+
+	c.uploadQ = make(chan uploadTask, queueCap)
+
+	for range workerCount {
+		go c.uploadWorker()
+	}
+}
+
+func (c *Client) tryEnqueueUpload(t uploadTask) bool {
+	select {
+	case c.uploadQ <- t:
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *Client) uploadWorker() {
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		case t := <-c.uploadQ:
+			d := t.d
+			p := t.peer
+
+			if d == nil || p == nil {
+				continue
+			}
+			if d.ctx.Err() != nil || p.closed.Load() {
+				continue
+			}
+			if d.GetState()&(Downloading|Seeding) == 0 {
+				continue
+			}
+
+			res := proto.PiecePool.Get()
+			res.PieceIndex = t.req.PieceIndex
+			res.Begin = t.req.Begin
+
+			if t.data != nil {
+				res.Data = append(res.Data[:0], t.data...)
+			} else {
+				res.Data = slices.Grow(res.Data[:0], int(t.req.Length))[:t.req.Length]
+
+				err := d.readPieceRangeCtx(d.ctx, t.req, res.Data)
+				if err != nil {
+					proto.PiecePool.Put(res)
+					if err == errUploadPaused || err == context.Canceled {
+						continue
+					}
+					d.setError(err)
+					p.close()
+					continue
+				}
+			}
+
+			if p.Response(res) {
+				d.ioUp.Update(len(res.Data))
+				d.c.ioUp.Update(len(res.Data))
+				d.uploaded.Add(int64(len(res.Data)))
+			}
+			proto.PiecePool.Put(res)
+		}
+	}
+}

--- a/internal/core/d_tracker.go
+++ b/internal/core/d_tracker.go
@@ -8,8 +8,11 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net/netip"
+	"net/url"
+	"path"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-resty/resty/v2"
@@ -344,15 +347,31 @@ func (t *Tracker) announceStop(d *Download) error {
 
 // ScrapeURL return enabled tracker url for scrape request.
 func (d *Download) ScrapeURL() string {
-	// TODO : todo
-	panic("not implemented")
-	// d.m.RLock()
-	// defer d.m.RUnlock()
+	d.m.RLock()
+	defer d.m.RUnlock()
 
-	// for _, tier := range d.trackers {
-	//	for _, t := range tier.trackers {
-	//}
-	//}
+	for _, tier := range d.trackers {
+		for _, t := range tier.trackers {
+			u, err := url.Parse(t.url)
+			if err != nil {
+				continue
+			}
+
+			parts := strings.Split(u.Path, "/")
+			if len(parts) == 0 {
+				continue
+			}
+
+			last := parts[len(parts)-1]
+			if last == "announce" {
+				parts[len(parts)-1] = "scrape"
+				u.Path = path.Join(parts...)
+				return u.String()
+			}
+		}
+	}
+
+	return ""
 }
 
 type peerWithPriority struct {

--- a/internal/core/d_upload.go
+++ b/internal/core/d_upload.go
@@ -10,19 +10,17 @@ import (
 	"io"
 	"net/netip"
 	"slices"
+	"sort"
 	"time"
 
-	"github.com/sourcegraph/conc"
-
-	"neptune/internal/metainfo"
 	"neptune/internal/pkg/empty"
 	"neptune/internal/pkg/mempool"
 	"neptune/internal/proto"
 )
 
-type cacheKey struct {
-	hash  metainfo.Hash
-	index uint32
+type uploadReq struct {
+	peer *Peer
+	req  proto.ChunkRequest
 }
 
 var errUploadPaused = errors.New("upload paused")
@@ -34,7 +32,7 @@ const (
 )
 
 // unchokeLoop periodically selects which peers get upload slots.
-// Based on libtorrent's choking algorithm:
+// Based on libtorrent\'s choking algorithm:
 // - Sort interested peers by upload rate (descending)
 // - Unchoke top N peers
 // - Reserve 1 slot for optimistic unchoke (round-robin).
@@ -51,7 +49,7 @@ func (d *Download) unchokeLoop() {
 		case <-timer.C:
 			timer.Reset(unchokeInterval)
 
-			if !d.wait(Downloading | Seeding) {
+			if d.GetState()&(Downloading|Seeding) == 0 {
 				continue
 			}
 
@@ -134,135 +132,156 @@ func (d *Download) recalculateUnchokeSlots(optimisticIdx *int) {
 	}
 }
 
-// backgroundReqHandler processes upload requests from peers in FIFO order.
-// Unlike the previous implementation, it:
-// - Respects choking (only serves unchoked peers)
-// - Processes multiple pieces per cycle
-// - Uses piece caching to avoid redundant disk reads.
+// backgroundReqHandler processes upload requests from peers.
+// It collects requests from unchoked peers, groups them by piece,
+// caches piece data to avoid redundant disk reads, and dispatches
+// to the upload pool for bounded concurrent processing.
 func (d *Download) backgroundReqHandler() {
+	var requestsByPiece = make(map[uint32][]uploadReq, 64)
+	var pieceOrder []struct {
+		index uint32
+		count int
+	}
+
+	const maxResponsesPerWake = 1024
+	const maxRequestsToConsiderPerWake = maxResponsesPerWake * 8
+
 	for {
 		select {
 		case <-d.ctx.Done():
 			return
 		case <-d.scheduleResponseSignal:
-			if !d.wait(Downloading | Seeding) {
+			if !d.HasState(Downloading | Seeding) {
 				continue
 			}
 
-			d.processUploadRequests()
+			pieceOrder = pieceOrder[:0]
+			clear(requestsByPiece)
+
+			considered := 0
+			d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {
+				if considered >= maxRequestsToConsiderPerWake {
+					return false
+				}
+
+				if p.closed.Load() || p.ourChoking.Load() {
+					return true
+				}
+
+				if p.peerRequests.Size() == 0 {
+					return true
+				}
+
+				p.peerRequests.Range(func(key proto.ChunkRequest, _ empty.Empty) bool {
+					requestsByPiece[key.PieceIndex] = append(requestsByPiece[key.PieceIndex], uploadReq{peer: p, req: key})
+					considered++
+					return considered < maxRequestsToConsiderPerWake
+				})
+
+				return considered < maxRequestsToConsiderPerWake
+			})
+
+			if len(requestsByPiece) == 0 {
+				continue
+			}
+
+			for pieceIndex, reqs := range requestsByPiece {
+				pieceOrder = append(pieceOrder, struct {
+					index uint32
+					count int
+				}{index: pieceIndex, count: len(reqs)})
+			}
+
+			sort.SliceStable(pieceOrder, func(i, j int) bool {
+				if pieceOrder[i].count == pieceOrder[j].count {
+					return pieceOrder[i].index < pieceOrder[j].index
+				}
+				return pieceOrder[i].count > pieceOrder[j].count
+			})
+
+			responses := 0
+		pieceLoop:
+			for _, po := range pieceOrder {
+				reqs := requestsByPiece[po.index]
+				if len(reqs) > 1 {
+					if err := d.dispatchCachedPiece(po.index, reqs, &responses, maxResponsesPerWake); err != nil {
+						d.setError(err)
+					}
+				} else {
+					for _, item := range reqs {
+						if !d.dispatchUpload(item, &responses, maxResponsesPerWake) {
+							continue pieceLoop
+						}
+					}
+				}
+				if responses >= maxResponsesPerWake {
+					break
+				}
+			}
 		}
 	}
 }
 
-func (d *Download) processUploadRequests() {
-	// collect all requests from unchoked, interested peers
-	type peerRequest struct {
-		peer  *Peer
-		req   proto.ChunkRequest
-		order int // FIFO order
+func (d *Download) dispatchUpload(item uploadReq, responses *int, maxResponses int) bool {
+	if *responses >= maxResponses {
+		select {
+		case d.scheduleResponseSignal <- empty.Empty{}:
+		default:
+		}
+		return false
 	}
 
-	var requests []peerRequest
-	order := 0
-
-	d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {
-		if p.closed.Load() {
-			return true
+	if !d.c.tryEnqueueUpload(uploadTask{d: d, peer: item.peer, req: item.req}) {
+		select {
+		case d.scheduleResponseSignal <- empty.Empty{}:
+		default:
 		}
-		// only serve unchoked peers
-		if p.ourChoking.Load() {
-			return true
-		}
-		p.peerRequests.Range(func(req proto.ChunkRequest, _ empty.Empty) bool {
-			requests = append(requests, peerRequest{peer: p, req: req, order: order})
-			order++
-			return true
-		})
-		return true
-	})
-
-	if len(requests) == 0 {
-		return
+		*responses = maxResponses
+		return false
 	}
 
-	// sort by FIFO order (first requested, first served)
-	slices.SortFunc(requests, func(a, b peerRequest) int {
-		return a.order - b.order
-	})
+	*responses++
+	return true
+}
 
-	// group by piece for efficient disk reads
-	type pieceRequest struct {
-		requests []peerRequest
-		index    uint32
+func (d *Download) dispatchCachedPiece(index uint32, reqs []uploadReq, responses *int, maxResponses int) error {
+	buf := mempool.GetWithCap(int(d.pieceLength(index)))
+	defer mempool.Put(buf)
+
+	if err := d.readPiece(index, buf.B); err != nil {
+		return err
 	}
 
-	pieceMap := make(map[uint32]*pieceRequest)
-	var pieceOrder []uint32
-	for _, r := range requests {
-		idx := r.req.PieceIndex
-		if _, ok := pieceMap[idx]; !ok {
-			pieceMap[idx] = &pieceRequest{index: idx}
-			pieceOrder = append(pieceOrder, idx)
+	for _, item := range reqs {
+		data := make([]byte, item.req.Length)
+		copy(data, buf.B[item.req.Begin:item.req.Begin+item.req.Length])
+		if !d.dispatchUploadWithData(item, data, responses, maxResponses) {
+			break
 		}
-		pieceMap[idx].requests = append(pieceMap[idx].requests, r)
+	}
+	return nil
+}
+
+func (d *Download) dispatchUploadWithData(item uploadReq, data []byte, responses *int, maxResponses int) bool {
+	if *responses >= maxResponses {
+		select {
+		case d.scheduleResponseSignal <- empty.Empty{}:
+		default:
+		}
+		return false
 	}
 
-	// process pieces in FIFO order (by first request arrival)
-	var cachedPieceIdx uint32
-	var cachedBuf *mempool.Buffer
-	cachedPieceIdx = ^uint32(0) // invalid sentinel
-
-	defer func() {
-		if cachedBuf != nil {
-			mempool.Put(cachedBuf)
+	if !d.c.tryEnqueueUpload(uploadTask{d: d, peer: item.peer, req: item.req, data: data}) {
+		select {
+		case d.scheduleResponseSignal <- empty.Empty{}:
+		default:
 		}
-	}()
-
-	for _, pieceIdx := range pieceOrder {
-		pr := pieceMap[pieceIdx]
-
-		// read piece (use cache if same piece requested consecutively)
-		if cachedPieceIdx != pieceIdx || cachedBuf == nil {
-			if cachedBuf != nil {
-				mempool.Put(cachedBuf)
-			}
-			cachedBuf = mempool.GetWithCap(int(d.pieceLength(pieceIdx)))
-			cachedBuf.Reset()
-
-			if err := d.readPiece(pieceIdx, cachedBuf.B); err != nil {
-				d.setError(err)
-				mempool.Put(cachedBuf)
-				cachedBuf = nil
-				continue
-			}
-			cachedPieceIdx = pieceIdx
-		}
-
-		// serve all requests for this piece
-		var g conc.WaitGroup
-		for _, r := range pr.requests {
-			p := r.peer
-			req := r.req
-
-			// verify request is still valid
-			if _, ok := p.peerRequests.LoadAndDelete(req); !ok {
-				continue // already served or cancelled
-			}
-
-			d.ioUp.Update(int(req.Length))
-			d.c.ioUp.Update(int(req.Length))
-			d.uploaded.Add(int64(req.Length))
-
-			g.Go(func() {
-				p.Response(&proto.ChunkResponse{
-					Data:       cachedBuf.B[req.Begin : req.Begin+req.Length],
-					Begin:      req.Begin,
-					PieceIndex: pieceIdx,
-				})
-			})
-		}
-		g.Wait()
+		*responses = maxResponses
+		return false
 	}
+
+	*responses++
+	return true
 }
 
 // buf must be big enough to read whole piece.


### PR DESCRIPTION
## Changes

### Upload Pool
- Add bounded worker pool for concurrent upload processing with configurable `GlobalUploadSlots`
- Replace `processUploadRequests` with dispatch-to-pool model that groups requests by piece
- Add `readPieceRangeCtx` for context-aware piece reading

### Other
- Add `GlobalUploadSlots` config option

## Extracted PRs
- #258: streaming SHA1 hashing
- #259: bitwise OR vs AND fix (HasState)
- #260: ref-counted file pool
- #261: path traversal validation
- #262: readPieceRangeCtx
- #263: Response() returns bool
- #264: ScrapeURL implementation