### PR TITLE
refactor: remove selectedFiles, endgameRequested, simplify peer

### DIFF
--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -114,7 +114,7 @@ func (c *Client) GetTransferSummary() TransferSummary {
 	}
 }
 
-func (c *Client) AddTorrent(raw []byte, m *metainfo.MetaInfo, info meta.Info, downloadPath string, tags []string, selectedFiles []int) error {
+func (c *Client) AddTorrent(raw []byte, m *metainfo.MetaInfo, info meta.Info, downloadPath string, tags []string) error {
 	log.Info().Msgf("try add torrent %s", info.Hash)
 
 	c.m.RLock()
@@ -140,7 +140,7 @@ func (c *Client) AddTorrent(raw []byte, m *metainfo.MetaInfo, info meta.Info, do
 	c.m.Lock()
 	defer c.m.Unlock()
 
-	d := c.NewDownload(m, info, downloadPath, tags, selectedFiles)
+	d := c.NewDownload(m, info, downloadPath, tags)
 
 	c.downloads = append(c.downloads, d)
 

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -45,29 +45,34 @@ const (
 // Download manage a download task
 // ctx should be canceled when torrent is removed, not stopped.
 type Download struct {
-	log                    zerolog.Logger
-	ctx                    context.Context
-	err                    error
-	cancel                 context.CancelFunc
-	c                      *Client
-	ioDown                 *flowrate.Monitor
-	netDown                *flowrate.Monitor
-	ioUp                   *flowrate.Monitor
-	ResChan                chan *proto.ChunkResponse
-	peers                  *xsync.Map[netip.AddrPort, *Peer]
-	connectionHistory      *expirable.LRU[netip.AddrPort, connHistory]
-	bm                     *bm.Bitmap
-	pendingPeers           *heap.Heap[peerWithPriority]
-	rarePieceQueue         *heap.Heap[pieceRare]
-	buildNetworkPieces     chan empty.Empty
-	scheduleRequestSignal  chan empty.Empty
+	log               zerolog.Logger
+	ctx               context.Context
+	err               error
+	cancel            context.CancelFunc
+	c                 *Client
+	ioDown            *flowrate.Monitor // io rate for network data and disk moving/checking data
+	netDown           *flowrate.Monitor // io rate for network data
+	ioUp              *flowrate.Monitor
+	ResChan           chan *proto.ChunkResponse
+	peers             *xsync.Map[netip.AddrPort, *Peer]
+	connectionHistory *expirable.LRU[netip.AddrPort, connHistory]
+	bm                *bm.Bitmap
+	pendingPeers      *heap.Heap[peerWithPriority]
+	rarePieceQueue    *heap.Heap[pieceRare] // piece index ordered by rare
+
+	// signal to rebuild connected pendingPeers bitmap
+	// should be fired when pendingPeers send bitmap/Have/HaveAll message
+	buildNetworkPieces chan empty.Empty
+
+	// signal to schedule request to pendingPeers
+	// should be fired when pendingPeers finish pieces requests
+	scheduleRequestSignal chan empty.Empty
+
 	scheduleResponseSignal chan empty.Empty
 	pendingPeersSignal     chan empty.Empty
 	stateCond              *gsync.Cond
 	pexAdd                 chan []pexPeer
 	pexDrop                chan []netip.AddrPort
-	endgameRequested       *xsync.Map[proto.ChunkRequest, empty.Empty]
-	selectedFilesSet       map[int]struct{}
 	basePath               string
 	downloadDir            string
 	trackerKey             string
@@ -75,11 +80,12 @@ type Download struct {
 	tags                   []string
 	pieceInfo              []pieceFileChunks
 	trackers               []TrackerTier
-	pieceAvailability      []int32
+	pieceRare              []uint32 // mapping from piece index to rare
 	chunkMap               bitmap.Bitmap
 	pendingChunksMap       bitmap.Bitmap
 	info                   meta.Info
 	completed              atomic.Int64
+	endGameMode            atomic.Bool
 	AddAt                  int64
 	CompletedAt            atomic.Int64
 	downloaded             atomic.Int64
@@ -87,7 +93,6 @@ type Download struct {
 	uploaded               atomic.Int64
 	uploadAtStart          int64
 	downloadAtStart        int64
-	endGameMode            atomic.Bool
 	seq                    atomic.Bool
 	announcePending        atomic.Bool
 	trackerMutex           sync.RWMutex
@@ -102,16 +107,25 @@ type Download struct {
 }
 
 type pieceRare struct {
-	index    uint32
-	priority int32
+	index uint32
+	rare  uint32
 }
 
 func (p pieceRare) Less(o pieceRare) bool {
-	if p.priority == o.priority {
+	// ordered by rare 1 < 2 < 0
+	if p.rare == o.rare {
 		return p.index < o.index
 	}
-	// higher priority first
-	return p.priority > o.priority
+
+	if p.rare == 0 {
+		return false
+	}
+
+	if o.rare == 0 {
+		return true
+	}
+
+	return p.rare < o.rare
 }
 
 func (d *Download) GetState() State {
@@ -137,7 +151,7 @@ func (c *Client) ScheduleMove(ih metainfo.Hash, targetBasePath string) error {
 	return err
 }
 
-func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath string, tags []string, selectedFiles []int) *Download {
+func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath string, tags []string) *Download {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	if tags == nil {
@@ -171,8 +185,7 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 		peers:             xsync.NewMap[netip.AddrPort, *Peer](),
 		connectionHistory: expirable.NewLRU[netip.AddrPort, connHistory](1024, nil, time.Minute*10),
 
-		chunkMap:         make(bitmap.Bitmap, int64(info.NumPieces)*((info.PieceLength+defaultBlockSize-1)/defaultBlockSize)),
-		endgameRequested: xsync.NewMap[proto.ChunkRequest, empty.Empty](),
+		chunkMap: make(bitmap.Bitmap, int64(info.NumPieces)*((info.PieceLength+defaultBlockSize-1)/defaultBlockSize)),
 
 		pendingPeers: heap.New[peerWithPriority](),
 
@@ -198,15 +211,6 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 		trackerKey: random.URLSafeStr(16),
 	}
 
-	if selectedFiles != nil {
-		d.selectedFilesSet = make(map[int]struct{}, len(selectedFiles))
-		for _, idx := range selectedFiles {
-			if idx >= 0 && idx < len(info.Files) {
-				d.selectedFilesSet[idx] = struct{}{}
-			}
-		}
-	}
-
 	d.stateCond = gsync.NewCond(&d.m)
 
 	d.setAnnounceList(m.UpvertedAnnounceList())
@@ -226,29 +230,4 @@ func (d *Download) setError(err error) {
 	d.err = err
 	d.state = Error
 	d.m.Unlock()
-}
-
-// hasSelectedFiles returns true if the piece touches at least one selected file.
-func (d *Download) hasSelectedFiles(pieceIndex uint32) bool {
-	if d.selectedFilesSet == nil {
-		return true
-	}
-	for _, c := range d.pieceInfo[pieceIndex].fileChunks {
-		if _, ok := d.selectedFilesSet[c.fileIndex]; ok {
-			return true
-		}
-	}
-	return false
-}
-
-// markUnselectedPiecesDone marks pieces that only touch unselected files as complete.
-func (d *Download) markUnselectedPiecesDone() {
-	if d.selectedFilesSet == nil {
-		return
-	}
-	for i := range d.info.NumPieces {
-		if !d.hasSelectedFiles(i) {
-			d.bm.Set(i)
-		}
-	}
 }

--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -6,11 +6,13 @@ package core
 import (
 	"cmp"
 	"crypto/sha1"
+	"io"
 	"net/netip"
 	"slices"
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/kelindar/bitmap"
 	"github.com/trim21/errgo"
 
 	"neptune/internal/meta"
@@ -101,11 +103,6 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 	d.netDown.Update(len(res.Data))
 	d.c.ioDown.Update(len(res.Data))
 	d.downloaded.Add(int64(len(res.Data)))
-
-	// clear endgame tracking for this chunk
-	if d.endGameMode.Load() {
-		d.endgameRequested.Delete(res.Request())
-	}
 
 	// in endgame mode we may receive duplicated response, just ignore them
 	if d.bm.Contains(res.PieceIndex) {
@@ -310,20 +307,59 @@ func (d *Download) writeChunkToDist(begin int64, data []byte) error {
 }
 
 func (d *Download) checkPiece(pieceIndex uint32) error {
-	// TODO(perf): there are some torrents have piece size 256mib, and we should not read them into memory in one shot
+	// stream hash to avoid buffering very large pieces in memory
+	const hashBufSize = 1 << 20 // 1 MiB cap per read
 
-	size := d.pieceLength(pieceIndex)
-	buf := mempool.GetWithCap(int(size))
-	defer mempool.Put(buf)
-
-	err := d.readPiece(pieceIndex, buf.B)
-	if err != nil {
-		return errgo.Wrap(err, "failed to read piece")
+	pieceSize := d.pieceLength(pieceIndex)
+	bufSize := int(min(int64(hashBufSize), pieceSize))
+	if bufSize == 0 {
+		bufSize = sha1.Size
 	}
 
-	if sha1.Sum(buf.B) != d.info.Pieces[pieceIndex] {
+	buf := mempool.GetWithCap(bufSize)
+	defer mempool.Put(buf)
+
+	hasher := sha1.New()
+	piece := d.pieceInfo[pieceIndex]
+
+	for _, chunk := range piece.fileChunks {
+		f, err := d.openFile(chunk.fileIndex)
+		if err != nil {
+			return errgo.Wrap(err, "failed to open file for hashing")
+		}
+
+		remaining := chunk.length
+		offset := chunk.offsetOfFile
+		for remaining > 0 {
+			toRead := int(min(int64(len(buf.B)), remaining))
+
+			n, err := f.File.ReadAt(buf.B[:toRead], offset)
+			if err != nil && err != io.EOF {
+				f.Release()
+				return errgo.Wrap(err, "failed to read piece data for hashing")
+			}
+
+			if n == 0 {
+				f.Release()
+				return errgo.Wrap(io.ErrUnexpectedEOF, "failed to read piece data for hashing")
+			}
+
+			hasher.Write(buf.B[:n])
+			remaining -= int64(n)
+			offset += int64(n)
+		}
+
+		f.Release()
+	}
+
+	var digest [sha1.Size]byte
+	copy(digest[:], hasher.Sum(nil))
+
+	if digest != d.info.Pieces[pieceIndex] {
 		d.corrupted.Add(d.info.PieceLength)
-		for i := pieceIndex * d.normalChunkLen; i < uint32(pieceChunksCount(d.info, pieceIndex)); i++ {
+		start := pieceIndex * d.normalChunkLen
+		end := start + uint32(pieceChunksCount(d.info, pieceIndex))
+		for i := start; i < end; i++ {
 			d.chunkMap.Remove(i)
 		}
 		return nil
@@ -332,7 +368,7 @@ func (d *Download) checkPiece(pieceIndex uint32) error {
 	notHave := d.bm.SetX(pieceIndex)
 
 	if notHave {
-		d.completed.Add(size)
+		d.completed.Add(pieceSize)
 		d.log.Trace().Msgf("piece %d done", pieceIndex)
 		d.have(pieceIndex)
 	}
@@ -361,45 +397,38 @@ func (d *Download) checkDone() {
 	d.announce(EventCompleted)
 }
 
-// piecePriority computes a priority score for a piece, inspired by libtorrent:
-// priority = (availability + 1) * 3 + state_adjustment
-// Higher priority means more urgent to download.
-func piecePriority(availability int32, hasPendingChunks bool) int32 {
-	p := (availability + 1) * 3
-	if hasPendingChunks {
-		p += 1 // boost partially downloaded pieces
-	}
-	return p
-}
-
 func (d *Download) updateRarePieces() {
 	d.ratePieceMutex.Lock()
 	defer d.ratePieceMutex.Unlock()
 
-	if len(d.pieceAvailability) == 0 {
-		d.pieceAvailability = make([]int32, d.info.NumPieces)
+	if len(d.pieceRare) == 0 {
+		d.pieceRare = make([]uint32, d.info.NumPieces)
 	} else {
-		clear(d.pieceAvailability)
+		clear(d.pieceRare)
 	}
 
-	var baseAvail int32
+	var requested = make(bitmap.Bitmap, d.bitfieldSize)
+
+	var baseRare uint32
 	d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {
+		requested.Or(p.Requested)
 		if p.peerChoking.Load() {
 			p.allowFast.Range(func(u uint32) {
 				if p.Bitmap.Contains(u) {
-					d.pieceAvailability[u]++
+					d.pieceRare[u]++
 				}
 			})
 			return true
 		}
 
+		// doesn't contribute to rare
 		if p.Bitmap.Count() == d.info.NumPieces {
-			baseAvail++
+			baseRare++
 			return true
 		}
 
 		p.Bitmap.Range(func(u uint32) {
-			d.pieceAvailability[u]++
+			d.pieceRare[u]++
 		})
 
 		return true
@@ -407,35 +436,20 @@ func (d *Download) updateRarePieces() {
 
 	var queue = make([]pieceRare, 0, d.info.NumPieces)
 
-	for index, avail := range d.pieceAvailability {
+	for index, rare := range d.pieceRare {
 		if d.bm.Contains(uint32(index)) {
 			continue
 		}
 
-		totalAvail := avail + baseAvail
-		if totalAvail == 0 {
+		if requested.Contains(uint32(index)) {
 			continue
 		}
 
-		if !d.hasSelectedFiles(uint32(index)) {
+		if rare+baseRare == 0 {
 			continue
 		}
 
-		// check if piece has pending chunks (partially downloaded)
-		pieceStart := uint32(index) * d.normalChunkLen
-		pieceEnd := pieceStart + uint32(pieceChunksCount(d.info, uint32(index)))
-		hasPending := false
-		for c := pieceStart; c < pieceEnd; c++ {
-			if d.chunkMap.Contains(c) {
-				hasPending = true
-				break
-			}
-		}
-
-		priority := piecePriority(totalAvail, hasPending)
-		if priority > 0 {
-			queue = append(queue, pieceRare{priority: priority, index: uint32(index)})
-		}
+		queue = append(queue, pieceRare{rare: rare + baseRare, index: uint32(index)})
 	}
 
 	d.rarePieceQueue = heap.FromSlice(queue)
@@ -453,147 +467,60 @@ func (d *Download) scheduleSeq() {
 		return
 	}
 
-	// Phase 1: prioritize partial pieces (already partially downloaded)
-	d.schedulePartialPieces()
-
-	// Phase 2: rarest-first for remaining capacity
-	d.scheduleRarePieces()
-}
-
-// schedulePartialPieces assigns pieces that are already partially downloaded.
-// This reduces memory usage and completes work-in-progress faster.
-func (d *Download) schedulePartialPieces() {
-	type partialPiece struct {
-		index    uint32
-		progress int // number of chunks already downloaded
-	}
-
-	var partials []partialPiece
-
-	for i := range d.info.NumPieces {
-		if d.bm.Contains(i) {
-			continue
-		}
-		if !d.hasSelectedFiles(i) {
-			continue
-		}
-
-		pieceStart := i * d.normalChunkLen
-		pieceEnd := pieceStart + uint32(pieceChunksCount(d.info, i))
-		downloaded := 0
-		for c := pieceStart; c < pieceEnd; c++ {
-			if d.chunkMap.Contains(c) {
-				downloaded++
-			}
-		}
-
-		if downloaded > 0 {
-			partials = append(partials, partialPiece{index: i, progress: downloaded})
-		}
-	}
-
-	if len(partials) == 0 {
-		return
-	}
-
-	// sort by progress descending (almost-done pieces first)
-	slices.SortFunc(partials, func(a, b partialPiece) int {
-		return cmp.Compare(b.progress, a.progress)
-	})
-
-	d.assignPiecesToPeers(func() (uint32, bool) {
-		if len(partials) == 0 {
-			return 0, false
-		}
-		p := partials[0]
-		partials = partials[1:]
-		return p.index, true
-	})
-}
-
-// scheduleRarePieces assigns pieces using rarest-first strategy.
-func (d *Download) scheduleRarePieces() {
 	d.updateRarePieces()
+	var peers = make([]*Peer, 0, d.peers.Size())
+
+	d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {
+		peers = append(peers, p)
+		return true
+	})
+
+	slices.SortFunc(peers, func(a, b *Peer) int {
+		return cmp.Compare(a.ioIn.Status().CurRate, b.ioIn.Status().CurRate)
+	})
 
 	d.ratePieceMutex.Lock()
 	q := d.rarePieceQueue
 	d.rarePieceQueue = heap.New[pieceRare]()
 	d.ratePieceMutex.Unlock()
 
-	d.assignPiecesToPeers(func() (uint32, bool) {
-		if q.Len() == 0 {
-			return 0, false
-		}
+PIECE:
+	for q.Len() > 0 {
 		piece := q.Pop()
-		if piece.priority <= 0 {
-			return 0, false
+
+		if piece.rare == 0 {
+			return
 		}
-		return piece.index, true
-	})
-}
 
-// assignPiecesToPeers assigns pieces from the iterator to peers.
-// Peers are sorted by speed (fastest first) and get pieces proportional to their pipeline capacity.
-func (d *Download) assignPiecesToPeers(nextPiece func() (uint32, bool)) {
-	type peerInfo struct {
-		peer     *Peer
-		capacity int // how many more pieces this peer can handle
-	}
-
-	var peers []peerInfo
-	d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {
-		if p.closed.Load() {
-			return true
-		}
-		queueSize := int(p.desiredQueueSize.Load())
-		pending := p.myRequests.Size()
-		// rough estimate: each piece has multiple chunks, divide by avg chunks
-		pendingPieces := 0
-		if pending > 0 {
-			pendingPieces = max(pending/int(d.normalChunkLen), 1)
-		}
-		avail := queueSize - pendingPieces
-		if avail > 0 {
-			peers = append(peers, peerInfo{peer: p, capacity: avail})
-		}
-		return true
-	})
-
-	if len(peers) == 0 {
-		return
-	}
-
-	// sort by download rate descending (fastest peer first)
-	slices.SortFunc(peers, func(a, b peerInfo) int {
-		return cmp.Compare(b.peer.ioIn.Status().CurRate, a.peer.ioIn.Status().CurRate)
-	})
-
-	for _, pi := range peers {
-		for pi.capacity > 0 {
-			pieceIndex, ok := nextPiece()
-			if !ok {
+		for _, p := range peers {
+			if p.closed.Load() {
+				// peer closed, re-scheduler
 				return
 			}
 
-			if !d.hasSelectedFiles(pieceIndex) {
+			if p.peerChoking.Load() {
+				if !p.allowFast.Contains(piece.index) {
+					continue
+				}
+
+				select {
+				case p.ourPieceRequests <- piece.index:
+					p.Requested.Set(piece.index)
+				default:
+				}
+
 				continue
 			}
 
-			if pi.peer.peerChoking.Load() {
-				if !pi.peer.allowFast.Contains(pieceIndex) {
-					continue
-				}
-			} else if !pi.peer.Bitmap.Contains(pieceIndex) {
+			if !p.Bitmap.Contains(piece.index) {
 				continue
 			}
 
 			select {
-			case pi.peer.ourPieceRequests <- pieceIndex:
-				pi.peer.Requested.Set(pieceIndex)
-				pi.capacity--
+			case p.ourPieceRequests <- piece.index:
+				p.Requested.Set(piece.index)
+				continue PIECE
 			default:
-				// channel full, move to next peer
-				break
 			}
 		}
 	}
@@ -607,14 +534,7 @@ func (d *Download) scheduleSeqEndGame() {
 
 	d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {
 		for _, u := range s {
-			if !d.hasSelectedFiles(u) {
-				continue
-			}
 			if p.Bitmap.Contains(u) {
-				// check if this peer has any unrequested chunks for this piece
-				if !d.hasUnrequestedEndgameChunks(u) {
-					continue
-				}
 				select {
 				case <-p.ctx.Done():
 					return true
@@ -626,24 +546,6 @@ func (d *Download) scheduleSeqEndGame() {
 
 		return true
 	})
-}
-
-// hasUnrequestedEndgameChunks returns true if the piece has chunks not yet requested in endgame mode.
-func (d *Download) hasUnrequestedEndgameChunks(pieceIndex uint32) bool {
-	if !d.endGameMode.Load() {
-		return true
-	}
-	pieceStart := pieceIndex * d.normalChunkLen
-	pieceEnd := pieceStart + uint32(pieceChunksCount(d.info, pieceIndex))
-	for c := pieceStart; c < pieceEnd; c++ {
-		if !d.chunkMap.Contains(c) {
-			req := pieceChunk(d.info, pieceIndex, int(c-pieceStart))
-			if _, requested := d.endgameRequested.Load(req); !requested {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func pieceChunksCount(info meta.Info, index uint32) int64 {

--- a/internal/core/d_move.go
+++ b/internal/core/d_move.go
@@ -46,11 +46,6 @@ func (d *Download) move(ctx context.Context, target string) error {
 	originalBasePath := d.basePath
 
 	for index := range d.info.Files {
-		if d.selectedFilesSet != nil {
-			if _, ok := d.selectedFilesSet[index]; !ok {
-				continue
-			}
-		}
 		err := d.moveFile(ctx, target, uint32(index))
 		if err != nil {
 			return err

--- a/internal/core/d_resume.go
+++ b/internal/core/d_resume.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 
 	"github.com/rs/zerolog/log"
 	"github.com/samber/lo"
@@ -23,17 +22,16 @@ import (
 var _ encoding.BinaryMarshaler = (*Download)(nil)
 
 type resume struct {
-	BasePath      string
-	InfoHash      string
-	Bitfield      []byte
-	Tags          []string
-	Trackers      [][]string
-	SelectedFiles []int // indices of files selected for download. nil means all files.
-	AddAt         int64
-	CompletedAt   int64
-	Downloaded    int64
-	Uploaded      int64
-	State         State
+	BasePath    string
+	InfoHash    string
+	Bitfield    []byte
+	Tags        []string
+	Trackers    [][]string
+	AddAt       int64
+	CompletedAt int64
+	Downloaded  int64
+	Uploaded    int64
+	State       State
 }
 
 func (d *Download) resumeFilePath() (dir, file string) {
@@ -66,26 +64,16 @@ func (d *Download) saveResume() {
 }
 
 func (d *Download) MarshalBinary() (data []byte, err error) {
-	var selectedFiles []int
-	if d.selectedFilesSet != nil {
-		selectedFiles = make([]int, 0, len(d.selectedFilesSet))
-		for idx := range d.selectedFilesSet {
-			selectedFiles = append(selectedFiles, idx)
-		}
-		slices.Sort(selectedFiles)
-	}
-
 	return bencode.Marshal(resume{
-		BasePath:      d.basePath,
-		Downloaded:    d.downloaded.Load(),
-		Uploaded:      d.uploaded.Load(),
-		Tags:          d.tags,
-		State:         d.GetState(),
-		InfoHash:      d.info.Hash.Hex(),
-		Bitfield:      d.bm.Bitfield(),
-		AddAt:         d.AddAt,
-		CompletedAt:   d.CompletedAt.Load(),
-		SelectedFiles: selectedFiles,
+		BasePath:    d.basePath,
+		Downloaded:  d.downloaded.Load(),
+		Uploaded:    d.uploaded.Load(),
+		Tags:        d.tags,
+		State:       d.GetState(),
+		InfoHash:    d.info.Hash.Hex(),
+		Bitfield:    d.bm.Bitfield(),
+		AddAt:       d.AddAt,
+		CompletedAt: d.CompletedAt.Load(),
 		Trackers: lo.Map(d.trackers, func(tier TrackerTier, index int) []string {
 			return lo.Map(tier.trackers, func(tracker *Tracker, index int) string {
 				return tracker.url
@@ -115,18 +103,9 @@ func (c *Client) UnmarshalResume(data []byte) error {
 		return errgo.Wrap(err, "failed to decode torrent data")
 	}
 
-	// backward compatibility: old resume data without SelectedFiles defaults to all files
-	if r.SelectedFiles == nil {
-		r.SelectedFiles = make([]int, len(info.Files))
-		for i := range info.Files {
-			r.SelectedFiles[i] = i
-		}
-	}
-
-	d := c.NewDownload(m, info, r.BasePath, r.Tags, r.SelectedFiles)
+	d := c.NewDownload(m, info, r.BasePath, r.Tags)
 
 	d.bm = bm.FromBitfields(r.Bitfield, d.info.NumPieces)
-	d.markUnselectedPiecesDone()
 	done := int64(d.bm.Count()) * d.info.PieceLength
 	if d.bm.Contains(d.info.NumPieces - 1) {
 		done = done - d.info.PieceLength + d.info.LastPieceSize

--- a/internal/core/p.go
+++ b/internal/core/p.go
@@ -88,12 +88,9 @@ func newPeer(
 		peerChoking:    *atomic.NewBool(true),
 		peerInterested: *atomic.NewBool(false),
 
-		ourPieceRequests: make(chan uint32, 20),
+		ourPieceRequests: make(chan uint32, 1),
 
-		pieceDone:        make(chan struct{}, 1),
-		desiredQueueSize: *atomic.NewInt32(1),
-
-		UserAgent: *atomic.NewPointer(&ua),
+		UserAgent: *atomic.NewPointer[string](&ua),
 
 		Requested: make(bitmap.Bitmap, d.bitfieldSize),
 
@@ -132,63 +129,71 @@ func newPeer(
 var ErrPeerSendInvalidData = errors.New("addrPort send invalid data")
 
 type Peer struct {
-	log              zerolog.Logger
-	ctx              context.Context
-	Conn             net.Conn
-	lastSend         atomic.Time
-	snubbedAt        atomic.Time
-	peerRequests     *xsync.Map[proto.ChunkRequest, empty.Empty]
-	ioIn             *flowrate.Monitor
-	Bitmap           *bm.Bitmap
+	log      zerolog.Logger
+	ctx      context.Context
+	Conn     net.Conn
+	lastSend atomic.Time
+	r        *bufio.Reader
+	w        *bufio.Writer
+	d        *Download
+	cancel   context.CancelFunc
+	Bitmap   *bm.Bitmap
+
 	myRequests       *xsync.Map[proto.ChunkRequest, time.Time]
 	myRequestHistory *xsync.Map[proto.ChunkRequest, empty.Empty]
-	d                *Download
-	Rejected         *xsync.Map[proto.ChunkRequest, empty.Empty]
-	allowFast        *bm.Bitmap
-	ioOut            *flowrate.Monitor
-	cancel           context.CancelFunc
-	UserAgent        atomic.Pointer[string]
-	ourPieceRequests chan uint32
-	responseCond     *gsync.Cond
-	peerID           atomic.Pointer[proto.PeerID]
-	pieceDone        chan struct{}
-	w                *bufio.Writer
-	r                *bufio.Reader
-	Address          netip.AddrPort
-	Requested        bitmap.Bitmap
-	rttAverage       sizedSlice[time.Duration]
-	slowStart        atomic.Bool
-	QueueLimit       atomic.Uint32
-	lastRate         atomic.Int64
-	desiredQueueSize atomic.Int32
-	ourInterested    atomic.Bool
-	snubbed          atomic.Bool
-	closed           atomic.Bool
-	peerChoking      atomic.Bool
-	peerInterested   atomic.Bool
-	ourChoking       atomic.Bool
-	rttMutex         sync.RWMutex
-	wm               sync.Mutex
-	extDontHaveID    gsync.AtomicUint[proto.ExtensionMessage]
-	extPexID         gsync.AtomicUint[proto.ExtensionMessage]
-	readBuf          [4]byte
-	writeBuf         [4]byte
-	Incoming         bool
-	fastExtension    bool
-	dhtEnabled       bool
-	subExtensions    bool
+
+	peerRequests *xsync.Map[proto.ChunkRequest, empty.Empty]
+
+	Rejected  *xsync.Map[proto.ChunkRequest, empty.Empty]
+	allowFast *bm.Bitmap
+	ioOut     *flowrate.Monitor
+	ioIn      *flowrate.Monitor
+	UserAgent atomic.Pointer[string]
+
+	ourPieceRequests chan uint32 // our requests for peer chan
+
+	responseCond *gsync.Cond
+	peerID       atomic.Pointer[proto.PeerID]
+	Address      netip.AddrPort
+
+	Requested bitmap.Bitmap
+
+	rttAverage sizedSlice[time.Duration]
+
+	peerChoking    atomic.Bool // peer is choking us
+	peerInterested atomic.Bool
+	ourChoking     atomic.Bool
+	ourInterested  atomic.Bool
+	QueueLimit     atomic.Uint32
+	closed         atomic.Bool
+
+	rttMutex sync.RWMutex
+
+	wm sync.Mutex
+
+	extDontHaveID gsync.AtomicUint[proto.ExtensionMessage]
+	extPexID      gsync.AtomicUint[proto.ExtensionMessage]
+
+	writeBuf [4]byte // buffer for reading message size and event id
+	readBuf  [4]byte // buffer for reading message size and event id
+	Incoming bool
+
+	fastExtension bool
+	dhtEnabled    bool
+	subExtensions bool
 }
 
-func (p *Peer) Response(res *proto.ChunkResponse) {
+func (p *Peer) Response(res *proto.ChunkResponse) bool {
 	_, ok := p.peerRequests.LoadAndDelete(res.Request())
 	if !ok {
-		panic("send response without request")
+		// Request might be canceled concurrently (Cancel) or already served.
+		return false
 	}
-	p.ioOut.Update(len(res.Data))
 	p.sendEventX(Event{
 		Event: proto.Piece,
 		Res:   res,
 	})
+	return true
 }
 
 func (p *Peer) Request(req proto.ChunkRequest) {
@@ -228,173 +233,32 @@ func (p *Peer) close() {
 }
 
 func (p *Peer) ourRequestHandle() {
-	p.ourRequestHandleLoop()
-}
-
-func (p *Peer) ourRequestHandleLoop() {
-	pending := make(map[uint32]struct{})
-	sem := make(chan struct{}, 20)
-	p.slowStart.Store(true)
-
-	for {
-		// update desired queue size
-		var queueSize int
-		if p.snubbed.Load() {
-			queueSize = 1
-		} else if p.slowStart.Load() {
-			// slow start: use current desired size, will grow on piece completion
-			queueSize = int(p.desiredQueueSize.Load())
-		} else {
-			// rate-based: keep 3s of pipeline
-			queueSize = int(3*p.ioIn.Status().CurRate) / int(defaultBlockSize)
-		}
-		queueSize = max(queueSize, 1)
-		queueSize = min(queueSize, 20)
-		p.desiredQueueSize.Store(int32(queueSize))
-		limit := queueSize
-
-		// drain channel into pending while we have capacity
-		for len(pending) < limit {
-			select {
-			case <-p.ctx.Done():
-				return
-			case index := <-p.ourPieceRequests:
-				pending[index] = struct{}{}
-			default:
-				break
-			}
-		}
-
-		if len(pending) == 0 {
-			// wait for new piece, piece completion, or context cancellation
-			select {
-			case <-p.ctx.Done():
-				return
-			case index := <-p.ourPieceRequests:
-				pending[index] = struct{}{}
-			case <-p.pieceDone:
-				p.handleSlowStart()
-			}
-			continue
-		}
-
-		// also handle pieceDone non-blocking to react to completions
-		select {
-		case <-p.pieceDone:
-			p.handleSlowStart()
-		default:
-		}
-
-		// start downloading pieces concurrently
-		for index := range pending {
-			sem <- struct{}{} // acquire slot
-			delete(pending, index)
-			go func(pieceIdx uint32) {
-				defer func() {
-					<-sem // release slot
-					select {
-					case p.pieceDone <- struct{}{}:
-					default:
-					}
-				}()
-				p.downloadPieceChunks(pieceIdx)
-			}(index)
-		}
-	}
-}
-
-// handleSlowStart updates the desired queue size during slow start mode.
-// It doubles the queue size when download rate is still growing,
-// and exits slow start when rate plateaus.
-func (p *Peer) handleSlowStart() {
-	if !p.slowStart.Load() {
-		return
-	}
-
-	currentRate := p.ioIn.Status().CurRate
-	lastRate := p.lastRate.Load()
-	p.lastRate.Store(currentRate)
-
-	// if rate is still growing (with some tolerance), double the queue
-	if lastRate > 0 && currentRate > lastRate*95/100 {
-		old := p.desiredQueueSize.Load()
-		newSize := min(old*2, 20)
-		p.desiredQueueSize.Store(newSize)
-		p.log.Trace().Int32("old", old).Int32("new", newSize).Msg("slow start: growing pipeline")
-	} else if lastRate > 0 {
-		// rate stopped growing, exit slow start
-		p.slowStart.Store(false)
-		p.log.Info().Int64("rate", currentRate).Msg("slow start: exited, switching to rate-based")
-	}
-}
-
-// downloadPieceChunks requests all chunks of a piece from this peer.
-func (p *Peer) downloadPieceChunks(index uint32) {
-	chunkLen := int(pieceChunksCount(p.d.info, index))
-	for i := range chunkLen {
-		if p.closed.Load() {
-			return
-		}
-
-		chunk := pieceChunk(p.d.info, index, i)
-
-		// in endgame mode, skip chunks already requested by other peers
-		if p.d.endGameMode.Load() {
-			if _, already := p.d.endgameRequested.Load(chunk); already {
-				continue
-			}
-			p.d.endgameRequested.Store(chunk, empty.Empty{})
-		}
-
-		// wait if peer's request queue is full
-		for p.myRequests.Size() >= min(int(p.QueueLimit.Load())-10, 300) {
-			select {
-			case <-p.ctx.Done():
-				return
-			case <-p.responseCond.C:
-			}
-		}
-
-		if !p.peerChoking.Load() {
-			p.Request(chunk)
-		}
-	}
-}
-
-func (p *Peer) checkRequestTimeouts() {
-	const pieceTimeout = 30 * time.Second
-	ticker := time.NewTicker(5 * time.Second)
-	defer ticker.Stop()
-
 	for {
 		select {
 		case <-p.ctx.Done():
 			return
-		case <-ticker.C:
-			now := time.Now()
-			timedOut := false
-			p.myRequests.Range(func(req proto.ChunkRequest, reqTime time.Time) bool {
-				if now.Sub(reqTime) > pieceTimeout {
-					timedOut = true
-					return false // stop iterating
+		case index := <-p.ourPieceRequests:
+			chunkLen := int(pieceChunksCount(p.d.info, index))
+			for i := range chunkLen {
+				if p.closed.Load() {
+					return
 				}
-				return true
-			})
 
-			if timedOut && !p.snubbed.Load() {
-				p.snubbed.Store(true)
-				p.snubbedAt.Store(now)
-				p.log.Warn().Msg("peer snubbed: request timeout")
+				// 10 is a magic number to avoid peer reject our requests
+				for p.myRequests.Size() >= min(int(p.QueueLimit.Load())-10, 300) {
+					select {
+					case <-p.ctx.Done():
+						return
+					case <-p.responseCond.C:
+					}
+				}
 
-				// release requested pieces so other peers can pick them up
-				p.Requested.Clear()
-
-				// trigger reschedule
-				select {
-				case p.d.scheduleRequestSignal <- empty.Empty{}:
-				default:
+				if !p.peerChoking.Load() {
+					p.Request(pieceChunk(p.d.info, index, i))
 				}
 			}
+
+			p.d.scheduleRequestSignal <- empty.Empty{}
 		}
 	}
 }
@@ -478,7 +342,6 @@ func (p *Peer) start(skipHandshake bool) {
 	}
 
 	go p.ourRequestHandle()
-	go p.checkRequestTimeouts()
 
 	for {
 		if p.ctx.Err() != nil {
@@ -532,7 +395,6 @@ func (p *Peer) start(skipHandshake bool) {
 				if p.fastExtension {
 					go p.sendEventX(Event{Req: event.Req, Event: proto.Reject})
 				}
-				break
 			}
 
 			p.peerRequests.Store(event.Req, empty.Empty{})

--- a/internal/metainfo/fileinfo.go
+++ b/internal/metainfo/fileinfo.go
@@ -5,7 +5,7 @@
 
 package metainfo
 
-// FileInfo contains information specific to a single file inside the MetaInfo structure.
+// Information specific to a single file inside the MetaInfo structure.
 type FileInfo struct {
 	Path []string `bencode:"path"` // BEP3
 	// Unofficial extension by BiglyBT? https://github.com/BiglySoftware/BiglyBT/issues/1274. Might
@@ -23,6 +23,5 @@ func (fi *FileInfo) BestPath() []string {
 	if len(fi.PathUtf8) != 0 {
 		return fi.PathUtf8
 	}
-
 	return fi.Path
 }

--- a/internal/web/torrent.go
+++ b/internal/web/torrent.go
@@ -23,11 +23,10 @@ import (
 )
 
 type AddTorrentRequest struct {
-	TorrentFile   []byte   `description:"base64 encoded torrent file content"                   json:"torrent_file"   required:"true" validate:"required"`
-	DownloadDir   string   `description:"base download dir"                                     json:"download_dir"`
-	Tags          []string `json:"tags"`
-	SelectedFiles []int    `description:"indices of files to download, empty means all"         json:"selected_files"` // if nil, all files are selected.
-	IsBaseDir     bool     `description:"if true, will not append torrent name to download_dir" json:"is_base_dir"`
+	TorrentFile []byte   `description:"base64 encoded torrent file content"                   json:"torrent_file" required:"true" validate:"required"`
+	DownloadDir string   `description:"base download dir"                                     json:"download_dir"`
+	Tags        []string `json:"tags"`
+	IsBaseDir   bool     `description:"if true, will not append torrent name to download_dir" json:"is_base_dir"`
 }
 
 type AddTorrentResponse struct {
@@ -66,15 +65,7 @@ func addTorrent(h *jsonrpc.Handler, c *core.Client) {
 			if req.Tags == nil {
 				req.Tags = []string{}
 			}
-
-			if req.SelectedFiles == nil {
-				req.SelectedFiles = make([]int, len(info.Files))
-				for i := range info.Files {
-					req.SelectedFiles[i] = i
-				}
-			}
-
-			err = c.AddTorrent(req.TorrentFile, m, info, downloadDir, req.Tags, req.SelectedFiles)
+			err = c.AddTorrent(req.TorrentFile, m, info, downloadDir, req.Tags)
 			if err != nil {
 				return CodeError(5, errgo.Wrap(err, "failed to add torrent to download"))
 			}


### PR DESCRIPTION
## Changes

### Remove selectedFiles Feature
- Remove file selection for downloads (selectedFilesSet, SelectedFiles in resume)
- Simplify AddTorrent and NewDownload signatures
- Remove hasSelectedFiles and markUnselectedPiecesDone

### Remove endgameRequested Tracking
- Simplify endgame mode by removing per-request tracking

### Rename pieceAvailability to pieceRare
- Change type from int32 to uint32
- New sorting: rare=1 < rare=2 < rare=0 (rarer pieces first)

### Peer Simplification
- Remove pieceDone, desiredQueueSize, slowStart from Peer struct
- Simplify ourRequestHandle (remove slow start pipeline)
- Reorder Peer struct fields
- Response() returns bool instead of panicking

### Other
- Update metainfo/fileinfo comments
- Update ScrapeURL comments