### PR TITLE
fix: bitwise OR vs AND in state checks

### DIFF
--- a/internal/core/c_scrape.go
+++ b/internal/core/c_scrape.go
@@ -32,7 +32,7 @@ func (c *Client) scrape() {
 	defer c.m.RUnlock()
 
 	for h, d := range c.downloadMap {
-		if d.GetState()|Downloading|Seeding == 0 {
+		if !d.HasState(Downloading | Seeding) {
 			continue
 		}
 

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -121,6 +121,11 @@ func (d *Download) GetState() State {
 	return s
 }
 
+// HasState returns true if the download is in any of the given states.
+func (d *Download) HasState(state State) bool {
+	return d.GetState()&state != 0
+}
+
 var ErrTorrentNotFound = errors.New("torrent not found")
 
 func (c *Client) ScheduleMove(ih metainfo.Hash, targetBasePath string) error {

--- a/internal/core/d_loop.go
+++ b/internal/core/d_loop.go
@@ -94,13 +94,13 @@ func (d *Download) Init(resumed bool) {
 	d.saveResume()
 }
 
-func (d *Download) wait(state State) bool {
-	if d.GetState()|state == 0 {
+func (d *Download) wait(states State) bool {
+	if !d.HasState(states) {
 		select {
 		case <-d.ctx.Done():
 			return false
 		case <-d.stateCond.C:
-			if d.GetState()|state == 0 {
+			if !d.HasState(states) {
 				return false
 			}
 		}


### PR DESCRIPTION
GetState()|state == 0 is always false for non-zero state (OR always sets the bits).

- Add HasState() helper that correctly checks with AND
- Fix wait() in d_loop.go
- Fix scrape() in c_scrape.go

Extracted from #255.