### PR TITLE
perf: ref-counted file pool with idle/active separation

### DIFF
--- a/internal/pkg/filepool/pool.go
+++ b/internal/pkg/filepool/pool.go
@@ -5,31 +5,33 @@ package filepool
 
 import (
 	"os"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/rs/zerolog/log"
+	"go.uber.org/atomic"
 )
 
-// func init() {
-//	prometheus.MustRegister(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-//		Name: "neptune_file_pool_size",
-//	}, func() float64 {
-//		return float64(pool.Len())
-//	}))
-//}
-
+// FilePool keeps at most one live fd per cacheKey. Active handles (ref>0) are
+// pinned in the active map. When Release makes ref==0, the handle moves to the
+// idle LRU and may be closed on eviction. This avoids reopening a file that is
+// already open while still closing unused fds.
 type FilePool struct {
-	Cache expirable.LRU[cacheKey, *File]
+	idle   *expirable.LRU[cacheKey, *File]
+	active map[cacheKey]*File
+	mu     sync.Mutex
 }
 
 func New() *FilePool {
 	return &FilePool{
-		Cache: *expirable.NewLRU[cacheKey, *File](5000, onEvict, time.Minute*5),
+		idle:   expirable.NewLRU[cacheKey, *File](5000, onEvict, time.Minute*5),
+		active: make(map[cacheKey]*File, 64),
 	}
 }
 
 func onEvict(key cacheKey, value *File) {
+	// Idle entry being evicted; safe to close.
 	log.Debug().Str("path", key.path).Msg("close file")
 	_ = value.File.Close()
 	value.pool = nil
@@ -42,41 +44,81 @@ type cacheKey struct {
 	ttl  time.Duration
 }
 
-// Open creates and returns a file item with given file path, flag and opening permission.
-// It automatically creates an associated file pointer pool internally when it's called first time.
-// It retrieves a file item from the file pointer pool after then.
-func (pool *FilePool) Open(path string, flag int, perm os.FileMode, ttl time.Duration) (file *File, err error) {
+// Open returns a handle and bumps its ref. It prefers an active handle, then an
+// idle one, and only opens a new fd if none exist.
+func (pool *FilePool) Open(path string, flag int, perm os.FileMode, ttl time.Duration) (*File, error) {
 	key := cacheKey{path: path, flag: flag, perm: perm, ttl: ttl}
-	item, ok := pool.Cache.Get(key)
-	if ok {
-		return item, nil
-	}
 
-	f, err := os.OpenFile(path, flag, perm)
+	pool.mu.Lock()
+	if f, ok := pool.active[key]; ok {
+		f.ref.Add(1)
+		pool.mu.Unlock()
+		return f, nil
+	}
+	if f, ok := pool.idle.Get(key); ok {
+		pool.idle.Remove(key)
+		f.ref.Store(1)
+		pool.active[key] = f
+		pool.mu.Unlock()
+		return f, nil
+	}
+	pool.mu.Unlock()
+
+	fd, err := os.OpenFile(path, flag, perm)
 	if err != nil {
 		return nil, err
 	}
 
-	return &File{
-		File: f,
-		key:  key,
-		pool: pool,
-	}, nil
+	f := &File{File: fd, key: key, pool: pool}
+	f.ref.Store(1)
+
+	pool.mu.Lock()
+	pool.active[key] = f
+	pool.mu.Unlock()
+
+	return f, nil
 }
 
-// File is an item in the pool.
+// File wraps an *os.File with ref counting.
 type File struct {
 	File *os.File
 	pool *FilePool
 	key  cacheKey
+	ref  atomic.Int32
 }
 
+// Release decrements the ref. When it reaches zero, the fd moves to the idle
+// cache and may be closed later on eviction.
 func (f *File) Release() {
-	f.pool.Cache.Add(f.key, f)
+	if f == nil || f.pool == nil {
+		return
+	}
+
+	if f.ref.Add(-1) != 0 {
+		return
+	}
+
+	p := f.pool
+	p.mu.Lock()
+	delete(p.active, f.key)
+	// Only idle handles live in LRU; eviction will close them.
+	p.idle.Add(f.key, f)
+	p.mu.Unlock()
 }
 
+// Close forcibly closes and removes the fd from both active and idle caches.
 func (f *File) Close() {
-	f.pool.Cache.Remove(f.key)
-	f.pool = nil
+	if f == nil || f.pool == nil {
+		return
+	}
+
+	p := f.pool
+	p.mu.Lock()
+	delete(p.active, f.key)
+	p.idle.Remove(f.key)
+	p.mu.Unlock()
+
+	f.ref.Store(0)
 	_ = f.File.Close()
+	f.pool = nil
 }


### PR DESCRIPTION
Ref-counted file handles with idle/active separation:

- Active handles (ref>0) pinned in map, idle (ref==0) in LRU
- Prevents fd exhaustion and redundant file opens  
- Release decrements ref, moves to idle on zero
- Close forcibly removes from both caches

Extracted from #255.