### PR TITLE
perf: add readPieceRangeCtx for context-aware piece reading

### DIFF
--- a/internal/core/d_upload.go
+++ b/internal/core/d_upload.go
@@ -25,11 +25,6 @@ type cacheKey struct {
 	index uint32
 }
 
-type uploadReq struct {
-	peer *Peer
-	req  proto.ChunkRequest
-}
-
 var errUploadPaused = errors.New("upload paused")
 
 const (
@@ -283,6 +278,7 @@ func (d *Download) readPiece(index uint32, buf []byte) error {
 		n, err := f.File.ReadAt(buf[offset:offset+chunk.length], chunk.offsetOfFile)
 		if err != nil {
 			if int64(n) != chunk.length || err != io.EOF {
+				f.Release()
 				return err
 			}
 		}
@@ -294,6 +290,8 @@ func (d *Download) readPiece(index uint32, buf []byte) error {
 	return nil
 }
 
+// readPieceRangeCtx reads a range of bytes from a piece into dst,
+// checking for context cancellation and download state between chunks.
 func (d *Download) readPieceRangeCtx(ctx context.Context, req proto.ChunkRequest, dst []byte) error {
 	if int(req.Length) != len(dst) {
 		return fmt.Errorf("invalid dst length: req=%d dst=%d", req.Length, len(dst))
@@ -325,8 +323,8 @@ func (d *Download) readPieceRangeCtx(ctx context.Context, req proto.ChunkRequest
 
 		n, err := f.File.ReadAt(dst[offset:offset+chunk.length], chunk.offsetOfFile)
 		if err != nil {
-			f.Release()
 			if int64(n) != chunk.length || err != io.EOF {
+				f.Release()
 				return err
 			}
 		}

--- a/internal/core/d_upload.go
+++ b/internal/core/d_upload.go
@@ -302,7 +302,7 @@ func (d *Download) readPieceRangeCtx(ctx context.Context, req proto.ChunkRequest
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
-	if d.GetState()&(Downloading|Seeding) == 0 {
+	if !d.HasState(Downloading | Seeding) {
 		return errUploadPaused
 	}
 
@@ -314,7 +314,7 @@ func (d *Download) readPieceRangeCtx(ctx context.Context, req proto.ChunkRequest
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		if d.GetState()&(Downloading|Seeding) == 0 {
+		if !d.HasState(Downloading | Seeding) {
 			return errUploadPaused
 		}
 

--- a/internal/core/d_upload.go
+++ b/internal/core/d_upload.go
@@ -4,6 +4,9 @@
 package core
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net/netip"
 	"slices"
@@ -21,6 +24,13 @@ type cacheKey struct {
 	hash  metainfo.Hash
 	index uint32
 }
+
+type uploadReq struct {
+	peer *Peer
+	req  proto.ChunkRequest
+}
+
+var errUploadPaused = errors.New("upload paused")
 
 const (
 	uploadSlots        = 4 // default number of upload slots
@@ -272,6 +282,50 @@ func (d *Download) readPiece(index uint32, buf []byte) error {
 
 		n, err := f.File.ReadAt(buf[offset:offset+chunk.length], chunk.offsetOfFile)
 		if err != nil {
+			if int64(n) != chunk.length || err != io.EOF {
+				return err
+			}
+		}
+
+		offset += chunk.length
+		f.Release()
+	}
+
+	return nil
+}
+
+func (d *Download) readPieceRangeCtx(ctx context.Context, req proto.ChunkRequest, dst []byte) error {
+	if int(req.Length) != len(dst) {
+		return fmt.Errorf("invalid dst length: req=%d dst=%d", req.Length, len(dst))
+	}
+
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if d.GetState()&(Downloading|Seeding) == 0 {
+		return errUploadPaused
+	}
+
+	start := int64(req.PieceIndex)*d.info.PieceLength + int64(req.Begin)
+	end := start + int64(req.Length)
+
+	var offset int64
+	for _, chunk := range fileChunks(d.info, start, end) {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if d.GetState()&(Downloading|Seeding) == 0 {
+			return errUploadPaused
+		}
+
+		f, err := d.openFile(chunk.fileIndex)
+		if err != nil {
+			return err
+		}
+
+		n, err := f.File.ReadAt(dst[offset:offset+chunk.length], chunk.offsetOfFile)
+		if err != nil {
+			f.Release()
 			if int64(n) != chunk.length || err != io.EOF {
 				return err
 			}


### PR DESCRIPTION
Add a context-aware piece reading function that:
- Checks context cancellation between chunks
- Respects download state (pause/cancel)
- Returns errUploadPaused when download is not active

Fixes:
- Double f.Release() in readPieceRangeCtx when ReadAt returns io.EOF with full read
- Missing f.Release() in readPiece on non-EOF error

Extracted from #255.