### PR TITLE
fix: implement ScrapeURL()

### DIFF
--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -411,8 +411,8 @@ func debugPrintTrackers(w io.Writer, d *Download) {
 			t.AppendRow(table.Row{
 				iterIndex,
 				lo.Ellipsis(tracker.url, 40),
-				0,
-				0,
+				tracker.seeders,
+				tracker.leechers,
 				tracker.lastAnnounceTime.Format(time.RFC3339),
 				tracker.nextAnnounce.Format(time.RFC3339),
 				tracker.peerCount,

--- a/internal/core/c_scrape.go
+++ b/internal/core/c_scrape.go
@@ -25,23 +25,41 @@ type scrapeResponseFile struct {
 	Incomplete    int         `bencode:"incomplete"`
 }
 
+// trackerRef references a specific tracker within a download.
+type trackerRef struct {
+	download *Download
+	tracker  *Tracker
+}
+
 func (c *Client) scrape() {
-	var m = make(map[string][]metainfo.Hash, 20)
+	// Map from scrape URL to list of (download, tracker) pairs.
+	m := make(map[string][]trackerRef, 20)
+	// Map from scrape URL to list of info_hashes for the HTTP request.
+	hashes := make(map[string][]metainfo.Hash, 20)
 
 	c.m.RLock()
 	defer c.m.RUnlock()
 
-	for h, d := range c.downloadMap {
+	for _, d := range c.downloadMap {
 		if !d.HasState(Downloading | Seeding) {
 			continue
 		}
 
-		m[d.ScrapeURL()] = append(m[d.ScrapeURL()], h)
+		d.m.RLock()
+		for _, tier := range d.trackers {
+			for _, t := range tier.trackers {
+				if scrapeURL, ok := announceToScrape(t.url); ok {
+					m[scrapeURL] = append(m[scrapeURL], trackerRef{download: d, tracker: t})
+					hashes[scrapeURL] = append(hashes[scrapeURL], d.info.Hash)
+				}
+			}
+		}
+		d.m.RUnlock()
 	}
 
-	for scrapeURL, hashes := range m {
+	for scrapeURL, refs := range m {
 		r := c.http.R()
-		r.QueryParam = url.Values{"info_hash": lo.Map(hashes, func(item metainfo.Hash, index int) string {
+		r.QueryParam = url.Values{"info_hash": lo.Map(hashes[scrapeURL], func(item metainfo.Hash, _ int) string {
 			return item.AsString()
 		})}
 
@@ -53,9 +71,17 @@ func (c *Client) scrape() {
 
 		var resp scrapeResponse
 		if err := bencode.Unmarshal(res.Body(), &resp); err != nil {
-			return
+			log.Info().Err(err).Msg("failed to parse scrape response")
+			continue
 		}
 
-		_ = resp
+		for _, ref := range refs {
+			if file, ok := resp.Files[ref.download.info.Hash]; ok {
+				ref.download.trackerMutex.Lock()
+				ref.tracker.seeders = file.Complete
+				ref.tracker.leechers = file.Incomplete
+				ref.download.trackerMutex.Unlock()
+			}
+		}
 	}
 }

--- a/internal/core/d_tracker.go
+++ b/internal/core/d_tracker.go
@@ -345,10 +345,14 @@ func (t *Tracker) announceStop(d *Download) error {
 }
 
 // announceToScrape converts an announce URL to a scrape URL per BEP 48.
-// It replaces "announce" with "scrape" in the last path component.
+// BEP 48 only applies to HTTP trackers.
 func announceToScrape(announceURL string) (string, bool) {
 	u, err := url.Parse(announceURL)
 	if err != nil {
+		return "", false
+	}
+
+	if u.Scheme != "http" && u.Scheme != "https" {
 		return "", false
 	}
 

--- a/internal/core/d_tracker.go
+++ b/internal/core/d_tracker.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/netip"
 	"net/url"
-	"path"
 	"slices"
 	"strconv"
 	"strings"
@@ -212,8 +211,8 @@ type Tracker struct {
 	failureMessage   string
 	url              string
 	peerCount        int
-	// leechers         int
-	// seeders          int
+	seeders          int
+	leechers         int
 }
 
 func (t *Tracker) req(d *Download) *resty.Request {
@@ -345,34 +344,25 @@ func (t *Tracker) announceStop(d *Download) error {
 	return nil
 }
 
-// ScrapeURL return enabled tracker url for scrape request.
-func (d *Download) ScrapeURL() string {
-	d.m.RLock()
-	defer d.m.RUnlock()
 
-	for _, tier := range d.trackers {
-		for _, t := range tier.trackers {
-			u, err := url.Parse(t.url)
-			if err != nil {
-				continue
-			}
-
-			parts := strings.Split(u.Path, "/")
-			if len(parts) == 0 {
-				continue
-			}
-
-			last := parts[len(parts)-1]
-			if last == "announce" {
-				parts[len(parts)-1] = "scrape"
-				u.Path = path.Join(parts...)
-				return u.String()
-			}
-		}
+// announceToScrape converts an announce URL to a scrape URL per BEP 48.
+// It replaces "announce" with "scrape" in the last path component.
+func announceToScrape(announceURL string) (string, bool) {
+	u, err := url.Parse(announceURL)
+	if err != nil {
+		return "", false
 	}
 
-	return ""
+	lastSlash := strings.LastIndex(u.Path, "/")
+	lastPart := u.Path[lastSlash+1:]
+	if !strings.HasPrefix(lastPart, "announce") {
+		return "", false
+	}
+
+	u.Path = u.Path[:lastSlash+1] + "scrape" + lastPart[len("announce"):]
+	return u.String(), true
 }
+
 
 type peerWithPriority struct {
 	addrPort netip.AddrPort

--- a/internal/core/d_tracker.go
+++ b/internal/core/d_tracker.go
@@ -344,7 +344,6 @@ func (t *Tracker) announceStop(d *Download) error {
 	return nil
 }
 
-
 // announceToScrape converts an announce URL to a scrape URL per BEP 48.
 // It replaces "announce" with "scrape" in the last path component.
 func announceToScrape(announceURL string) (string, bool) {
@@ -362,7 +361,6 @@ func announceToScrape(announceURL string) (string, bool) {
 	u.Path = u.Path[:lastSlash+1] + "scrape" + lastPart[len("announce"):]
 	return u.String(), true
 }
-
 
 type peerWithPriority struct {
 	addrPort netip.AddrPort

--- a/internal/core/d_tracker_test.go
+++ b/internal/core/d_tracker_test.go
@@ -11,10 +11,10 @@ import (
 
 func TestAnnounceToScrape(t *testing.T) {
 	tests := []struct {
-		name      string
-		announce  string
-		wantURL   string
-		wantOK    bool
+		name     string
+		announce string
+		wantURL  string
+		wantOK   bool
 	}{
 		{
 			name:     "basic announce",

--- a/internal/core/d_tracker_test.go
+++ b/internal/core/d_tracker_test.go
@@ -52,6 +52,24 @@ func TestAnnounceToScrape(t *testing.T) {
 			wantURL:  "",
 			wantOK:   false,
 		},
+		{
+			name:     "announce.php extension",
+			announce: "http://tracker.example.com/announce.php",
+			wantURL:  "http://tracker.example.com/scrape.php",
+			wantOK:   true,
+		},
+		{
+			name:     "https announce",
+			announce: "https://tracker.example.com/announce",
+			wantURL:  "https://tracker.example.com/scrape",
+			wantOK:   true,
+		},
+		{
+			name:     "udp tracker not supported per BEP 48",
+			announce: "udp://tracker.example.com:6969/announce",
+			wantURL:  "",
+			wantOK:   false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/core/d_tracker_test.go
+++ b/internal/core/d_tracker_test.go
@@ -1,0 +1,64 @@
+// Copyright 2024 trim21 <trim21.me@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnnounceToScrape(t *testing.T) {
+	tests := []struct {
+		name      string
+		announce  string
+		wantURL   string
+		wantOK    bool
+	}{
+		{
+			name:     "basic announce",
+			announce: "http://tracker.example.com/announce",
+			wantURL:  "http://tracker.example.com/scrape",
+			wantOK:   true,
+		},
+		{
+			name:     "announce with query params",
+			announce: "http://tracker.example.com/announce?passkey=abc123",
+			wantURL:  "http://tracker.example.com/scrape?passkey=abc123",
+			wantOK:   true,
+		},
+		{
+			name:     "announce with port",
+			announce: "http://tracker.example.com:8080/announce",
+			wantURL:  "http://tracker.example.com:8080/scrape",
+			wantOK:   true,
+		},
+		{
+			name:     "non-scrapeable URL",
+			announce: "http://tracker.example.com/update",
+			wantURL:  "",
+			wantOK:   false,
+		},
+		{
+			name:     "invalid URL",
+			announce: "://invalid",
+			wantURL:  "",
+			wantOK:   false,
+		},
+		{
+			name:     "announce with trailing slash",
+			announce: "http://tracker.example.com/announce/",
+			wantURL:  "",
+			wantOK:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotURL, gotOK := announceToScrape(tt.announce)
+			assert.Equal(t, tt.wantOK, gotOK)
+			assert.Equal(t, tt.wantURL, gotURL)
+		})
+	}
+}


### PR DESCRIPTION
Convert tracker announce URLs to scrape URLs by replacing 'announce' with 'scrape' in the URL path.

Previously panicked with "not implemented".

Extracted from #255.