### PR TITLE
feat: allow overriding UserAgent and PeerIDPrefix via ldflags

### DIFF
--- a/internal/core/p.go
+++ b/internal/core/p.go
@@ -35,10 +35,16 @@ import (
 
 const ourPexExtID proto.ExtensionMessage = 22
 
-const peerIDPrefix = "-NE" +
-	string(version.MAJOR+'0') +
-	string(version.MINOR+'0') +
-	string(version.PATCH+'0') + "0-"
+var peerIDPrefix string
+
+func init() {
+	if peerIDPrefix == "" {
+		peerIDPrefix = "-NE" +
+			string(version.MAJOR+'0') +
+			string(version.MINOR+'0') +
+			string(version.PATCH+'0') + "0-"
+	}
+}
 
 func NewPeerID() (peerID proto.PeerID) {
 	copy(peerID[:], peerIDPrefix)

--- a/internal/pkg/global/release.go
+++ b/internal/pkg/global/release.go
@@ -11,6 +11,12 @@ import (
 	"neptune/internal/version"
 )
 
-var UserAgent = fmt.Sprintf("Neptune/%d.%d.%d (https://github.com/trim21/neptune)", version.MAJOR, version.MINOR, version.PATCH)
+var UserAgent string
+
+func init() {
+	if UserAgent == "" {
+		UserAgent = fmt.Sprintf("Neptune/%d.%d.%d (https://github.com/trim21/neptune)", version.MAJOR, version.MINOR, version.PATCH)
+	}
+}
 
 const Dev = false


### PR DESCRIPTION
Change `UserAgent` (release build) and `peerIDPrefix` from const/var-with-initializer to var-with-init-guard, so that `-X` ldflags can override them at build time.

This enables disguising the client identity when distributing custom builds without modifying source code.

## Usage

```bash
go build -tags release -ldflags="-s \
  -X 'neptune/internal/pkg/global.UserAgent=qBittorrent/4.6.4' \
  -X 'neptune/internal/core.peerIDPrefix=-qB4640-'"
```

When not provided, behavior is unchanged.