### PR TITLE
feat: add torrent tags, resume, and file priority RPCs

### DIFF
--- a/internal/core/c_file_priority.go
+++ b/internal/core/c_file_priority.go
@@ -1,0 +1,118 @@
+// Copyright 2024 trim21 <trim21.me@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package core
+
+import (
+	"fmt"
+
+	"neptune/internal/metainfo"
+	"neptune/internal/pkg/empty"
+)
+
+// SetFilePriority sets the download priority for the given files.
+// priority 0 means skip (don't download), priority 1 means download.
+func (c *Client) SetFilePriority(h metainfo.Hash, fileIDs []int, priority int) error {
+	c.m.RLock()
+	d, ok := c.downloadMap[h]
+	c.m.RUnlock()
+
+	if !ok {
+		return fmt.Errorf("torrent %s not exists", h)
+	}
+
+	if priority != 0 && priority != 1 {
+		return fmt.Errorf("invalid priority %d, must be 0 or 1", priority)
+	}
+
+	if len(fileIDs) == 0 {
+		return nil
+	}
+
+	for _, id := range fileIDs {
+		if id < 0 || id >= len(d.info.Files) {
+			return fmt.Errorf("invalid file id %d, torrent has %d files", id, len(d.info.Files))
+		}
+	}
+
+	d.m.Lock()
+
+	// Initialize selectedFilesSet if nil (means all files were selected).
+	if d.selectedFilesSet == nil {
+		d.selectedFilesSet = make(map[int]struct{}, len(d.info.Files))
+		for i := range d.info.Files {
+			d.selectedFilesSet[i] = struct{}{}
+		}
+	}
+
+	// When un-skipping files (priority=1), pieces that were force-marked done
+	// by markUnselectedPiecesDone need to be cleared so they get re-downloaded.
+	// A piece was force-done if it's in bm but doesn't touch any selected file.
+	if priority == 1 {
+		fileIDSet := make(map[int]struct{}, len(fileIDs))
+		for _, id := range fileIDs {
+			fileIDSet[id] = struct{}{}
+		}
+
+		for pi := range d.info.NumPieces {
+			if !d.bm.Contains(pi) {
+				continue
+			}
+
+			touchesChanged := false
+			for _, fc := range d.pieceInfo[pi].fileChunks {
+				if _, ok := fileIDSet[fc.fileIndex]; ok {
+					touchesChanged = true
+					break
+				}
+			}
+			if !touchesChanged {
+				continue
+			}
+
+			// Piece touches a changed file and is in bm.
+			// If it doesn't touch any currently-selected file, it was force-done.
+			if d.hasSelectedFiles(pi) {
+				continue
+			}
+
+			d.bm.Unset(pi)
+		}
+	}
+
+	// Update selectedFilesSet.
+	for _, id := range fileIDs {
+		if priority == 0 {
+			delete(d.selectedFilesSet, id)
+		} else {
+			d.selectedFilesSet[id] = struct{}{}
+		}
+	}
+
+	// Mark pieces that only touch unselected files as done.
+	d.markUnselectedPiecesDone()
+
+	// Recalculate completed bytes from bitmap.
+	done := int64(d.bm.Count()) * d.info.PieceLength
+	if d.bm.Contains(d.info.NumPieces - 1) {
+		done = done - d.info.PieceLength + d.info.LastPieceSize
+	}
+	d.completed.Store(done)
+
+	// Transition to Seeding if all pieces are complete.
+	if d.bm.Count() == d.info.NumPieces {
+		d.state = Seeding
+	}
+
+	d.m.Unlock()
+
+	d.saveResume()
+
+	// Signal scheduler to re-evaluate piece selection.
+	select {
+	case d.scheduleRequestSignal <- empty.Empty{}:
+	default:
+	}
+
+	return nil
+}

--- a/internal/core/c_resume.go
+++ b/internal/core/c_resume.go
@@ -1,0 +1,28 @@
+// Copyright 2024 trim21 <trim21.me@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package core
+
+import (
+	"fmt"
+
+	"neptune/internal/metainfo"
+)
+
+func (c *Client) ResumeTorrent(h metainfo.Hash) error {
+	c.m.RLock()
+	d, ok := c.downloadMap[h]
+	c.m.RUnlock()
+
+	if !ok {
+		return fmt.Errorf("torrent %s not exists", h)
+	}
+
+	if !d.HasState(Stopped) {
+		return fmt.Errorf("torrent %s is not stopped", h)
+	}
+
+	d.Start()
+
+	return nil
+}

--- a/internal/core/c_tags.go
+++ b/internal/core/c_tags.go
@@ -1,0 +1,54 @@
+// Copyright 2024 trim21 <trim21.me@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package core
+
+import (
+	"fmt"
+	"slices"
+
+	"neptune/internal/metainfo"
+	"neptune/internal/pkg/gslice"
+)
+
+func (c *Client) AddTags(h metainfo.Hash, tags []string) error {
+	c.m.RLock()
+	d, ok := c.downloadMap[h]
+	c.m.RUnlock()
+
+	if !ok {
+		return fmt.Errorf("torrent %s not exists", h)
+	}
+
+	d.m.Lock()
+	for _, tag := range tags {
+		if !slices.Contains(d.tags, tag) {
+			d.tags = append(d.tags, tag)
+		}
+	}
+	d.m.Unlock()
+
+	d.saveResume()
+
+	return nil
+}
+
+func (c *Client) RemoveTags(h metainfo.Hash, tags []string) error {
+	c.m.RLock()
+	d, ok := c.downloadMap[h]
+	c.m.RUnlock()
+
+	if !ok {
+		return fmt.Errorf("torrent %s not exists", h)
+	}
+
+	d.m.Lock()
+	for _, tag := range tags {
+		d.tags = gslice.Remove(d.tags, tag)
+	}
+	d.m.Unlock()
+
+	d.saveResume()
+
+	return nil
+}

--- a/internal/web/torrent_file_priority.go
+++ b/internal/web/torrent_file_priority.go
@@ -1,0 +1,49 @@
+// Copyright 2024 trim21 <trim21.me@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package web
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+
+	"github.com/swaggest/usecase"
+	"github.com/trim21/errgo"
+
+	"neptune/internal/core"
+	"neptune/internal/metainfo"
+	"neptune/internal/web/jsonrpc"
+)
+
+type setFilePriorityRequest struct {
+	InfoHash string `description:"torrent file hash"                 json:"info_hash" required:"true"`
+	FileIDs  []int  `description:"indices of files to set"           json:"file_ids"  required:"true"`
+	Priority int    `description:"file priority, 0=skip, 1=download" json:"priority"  required:"true"`
+}
+
+type setFilePriorityResponse struct{}
+
+func setFilePriority(h *jsonrpc.Handler, c *core.Client) {
+	u := usecase.NewInteractor(
+		func(ctx context.Context, req *setFilePriorityRequest, res *setFilePriorityResponse) error {
+			if len(req.InfoHash) != sha1.Size*2 {
+				return errInvalidInfoHash
+			}
+
+			raw, err := hex.DecodeString(req.InfoHash)
+			if err != nil {
+				return errInvalidInfoHash
+			}
+
+			err = c.SetFilePriority(metainfo.Hash(raw), req.FileIDs, req.Priority)
+			if err != nil {
+				return CodeError(1, errgo.Wrap(err, "failed to set file priority"))
+			}
+
+			return nil
+		},
+	)
+	u.SetName("torrent.set_file_priority")
+	h.Add(u)
+}

--- a/internal/web/torrent_resume.go
+++ b/internal/web/torrent_resume.go
@@ -1,0 +1,41 @@
+// Copyright 2024 trim21 <trim21.me@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package web
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+
+	"github.com/swaggest/usecase"
+
+	"neptune/internal/core"
+	"neptune/internal/metainfo"
+	"neptune/internal/web/jsonrpc"
+)
+
+type resumeTorrentRequest struct {
+	InfoHash string `description:"torrent file hash" json:"info_hash" required:"true"`
+}
+
+type resumeTorrentResponse struct{}
+
+func resumeTorrent(h *jsonrpc.Handler, c *core.Client) {
+	u := usecase.NewInteractor(
+		func(ctx context.Context, req *resumeTorrentRequest, res *resumeTorrentResponse) error {
+			if len(req.InfoHash) != sha1.Size*2 {
+				return errInvalidInfoHash
+			}
+
+			raw, err := hex.DecodeString(req.InfoHash)
+			if err != nil {
+				return errInvalidInfoHash
+			}
+
+			return c.ResumeTorrent(metainfo.Hash(raw))
+		},
+	)
+	u.SetName("torrent.resume")
+	h.Add(u)
+}

--- a/internal/web/torrent_tags.go
+++ b/internal/web/torrent_tags.go
@@ -1,0 +1,68 @@
+// Copyright 2024 trim21 <trim21.me@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package web
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+
+	"github.com/swaggest/usecase"
+
+	"neptune/internal/core"
+	"neptune/internal/metainfo"
+	"neptune/internal/web/jsonrpc"
+)
+
+type addTagsRequest struct {
+	InfoHash string   `description:"torrent file hash" json:"info_hash" required:"true"`
+	Tags     []string `description:"tags to add"       json:"tags"      required:"true"`
+}
+
+type addTagsResponse struct{}
+
+func addTags(h *jsonrpc.Handler, c *core.Client) {
+	u := usecase.NewInteractor(
+		func(ctx context.Context, req *addTagsRequest, res *addTagsResponse) error {
+			if len(req.InfoHash) != sha1.Size*2 {
+				return errInvalidInfoHash
+			}
+
+			raw, err := hex.DecodeString(req.InfoHash)
+			if err != nil {
+				return errInvalidInfoHash
+			}
+
+			return c.AddTags(metainfo.Hash(raw), req.Tags)
+		},
+	)
+	u.SetName("torrent.add_tags")
+	h.Add(u)
+}
+
+type removeTagsRequest struct {
+	InfoHash string   `description:"torrent file hash" json:"info_hash" required:"true"`
+	Tags     []string `description:"tags to remove"    json:"tags"      required:"true"`
+}
+
+type removeTagsResponse struct{}
+
+func removeTags(h *jsonrpc.Handler, c *core.Client) {
+	u := usecase.NewInteractor(
+		func(ctx context.Context, req *removeTagsRequest, res *removeTagsResponse) error {
+			if len(req.InfoHash) != sha1.Size*2 {
+				return errInvalidInfoHash
+			}
+
+			raw, err := hex.DecodeString(req.InfoHash)
+			if err != nil {
+				return errInvalidInfoHash
+			}
+
+			return c.RemoveTags(metainfo.Hash(raw), req.Tags)
+		},
+	)
+	u.SetName("torrent.remove_tags")
+	h.Add(u)
+}

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -105,6 +105,10 @@ func New(c *core.Client, token string, enableDebug bool) http.Handler {
 	addTorrent(h, c)
 	removeTorrent(h, c)
 	getTorrent(h, c)
+	addTags(h, c)
+	removeTags(h, c)
+	resumeTorrent(h, c)
+	setFilePriority(h, c)
 	// MoveTorrent(h, c)
 
 	var auth = func(next http.Handler) http.Handler {


### PR DESCRIPTION
## Summary

Add four new JSON-RPC methods for torrent management:

### New RPCs

| Method | Params | Description |
|---|---|---|
| `torrent.add_tags` | `info_hash`, `tags: []string` | Append tags to a torrent (deduplicated) |
| `torrent.remove_tags` | `info_hash`, `tags: []string` | Remove specified tags from a torrent |
| `torrent.resume` | `info_hash` | Resume a stopped torrent |
| `torrent.set_file_priority` | `info_hash`, `file_ids: []int`, `priority: int` | Set file priority (0=skip, 1=download) |

### Implementation details

- **Tags**: `AddTags` / `RemoveTags` on `Client` — thread-safe tag mutation with `d.m` lock, dedup on add, `gslice.Remove` on remove, persists via `saveResume()`.
- **Resume**: `ResumeTorrent` on `Client` — verifies torrent is in `Stopped` state, then calls `d.Start()` which transitions to `Downloading`/`Seeding` and wakes background goroutines.
- **File priority**: `SetFilePriority` on `Client` — manages `selectedFilesSet` to control which files get downloaded. When re-enabling skipped files, correctly clears force-done pieces (set by `markUnselectedPiecesDone`) so they get re-downloaded. Recalculates `completed` and signals the scheduler.

### Files

- `internal/core/c_tags.go` — `AddTags`, `RemoveTags`
- `internal/core/c_resume.go` — `ResumeTorrent`
- `internal/core/c_file_priority.go` — `SetFilePriority`
- `internal/web/torrent_tags.go` — handlers for `torrent.add_tags`, `torrent.remove_tags`
- `internal/web/torrent_resume.go` — handler for `torrent.resume`
- `internal/web/torrent_file_priority.go` — handler for `torrent.set_file_priority`
- `internal/web/web.go` — register all four handlers