### PR TITLE
feat: add selected_size to torrent.list response

### DIFF
--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -377,7 +377,7 @@ func (c *Client) DebugHandlers() http.Handler {
 			humanize.IBytes(uint64(d.ioUp.Status().CurRate))+"/s",
 		)
 
-		fmt.Fprintf(w, "progress: %6.2f %%\n", float64(d.completed.Load())/float64(d.info.TotalLength)*100)
+		fmt.Fprintf(w, "progress: %6.2f %%\n", float64(d.completed.Load())/float64(d.SelectedSize())*100)
 
 		debugPrintTrackers(w, d)
 		debugPrintPeers(w, d)

--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -47,6 +47,7 @@ type MainDataTorrent struct {
 	ConnectionCount int      `json:"connection_count"`
 	Completed       int64    `json:"completed"`
 	TotalLength     int64    `json:"total_length"`
+	SelectedSize    int64    `json:"selected_size"`
 	AddedAt         int64    `json:"add_at"`
 	Private         bool     `json:"private"`
 }
@@ -79,6 +80,7 @@ func (c *Client) GetTorrentList() TorrentList {
 			UploadTotal:     d.uploaded.Load(),
 			Completed:       d.completed.Load(),
 			TotalLength:     d.info.TotalLength,
+			SelectedSize:    d.SelectedSize(),
 			Comment:         d.info.Comment,
 			AddedAt:         d.AddAt,
 			DirectoryBase:   d.downloadDir,

--- a/internal/core/c_file_priority.go
+++ b/internal/core/c_file_priority.go
@@ -88,6 +88,7 @@ func (c *Client) SetFilePriority(h metainfo.Hash, fileIDs []int, priority int) e
 			d.selectedFilesSet[id] = struct{}{}
 		}
 	}
+	d.selectedSize.Store(d.computeSelectedSize())
 
 	// Mark pieces that only touch unselected files as done.
 	d.markUnselectedPiecesDone()

--- a/internal/core/c_file_priority.go
+++ b/internal/core/c_file_priority.go
@@ -72,7 +72,7 @@ func (c *Client) SetFilePriority(h metainfo.Hash, fileIDs []int, priority int) e
 
 			// Piece touches a changed file and is in bm.
 			// If it doesn't touch any currently-selected file, it was force-done.
-			if d.hasSelectedFiles(pi) {
+			if d.selectedPiecesBm.Contains(pi) {
 				continue
 			}
 
@@ -89,16 +89,12 @@ func (c *Client) SetFilePriority(h metainfo.Hash, fileIDs []int, priority int) e
 		}
 	}
 	d.selectedSize.Store(d.computeSelectedSize())
+	d.buildSelectedPiecesBm()
 
 	// Mark pieces that only touch unselected files as done.
 	d.markUnselectedPiecesDone()
 
-	// Recalculate completed bytes from bitmap.
-	done := int64(d.bm.Count()) * d.info.PieceLength
-	if d.bm.Contains(d.info.NumPieces - 1) {
-		done = done - d.info.PieceLength + d.info.LastPieceSize
-	}
-	d.completed.Store(done)
+	d.completed.Store(d.computeCompleted())
 
 	// Transition to Seeding if all pieces are complete.
 	if d.bm.Count() == d.info.NumPieces {

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -57,6 +57,7 @@ type Download struct {
 	peers                  *xsync.Map[netip.AddrPort, *Peer]
 	connectionHistory      *expirable.LRU[netip.AddrPort, connHistory]
 	bm                     *bm.Bitmap
+	selectedPiecesBm       *bm.Bitmap
 	pendingPeers           *heap.Heap[peerWithPriority]
 	rarePieceQueue         *heap.Heap[pieceRare]
 	buildNetworkPieces     chan empty.Empty
@@ -213,6 +214,7 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 		}
 	}
 	d.selectedSize.Store(d.computeSelectedSize())
+	d.buildSelectedPiecesBm()
 
 	d.stateCond = gsync.NewCond(&d.m)
 
@@ -263,13 +265,44 @@ func (d *Download) computeSelectedSize() int64 {
 	return size
 }
 
+func (d *Download) buildSelectedPiecesBm() {
+	if d.selectedPiecesBm == nil {
+		d.selectedPiecesBm = bm.New(d.info.NumPieces)
+	}
+	if d.selectedFilesSet == nil {
+		d.selectedPiecesBm.Fill()
+		return
+	}
+	d.selectedPiecesBm.Clear()
+	for i := range d.info.NumPieces {
+		if d.hasSelectedFiles(i) {
+			d.selectedPiecesBm.Set(i)
+		}
+	}
+}
+
+func (d *Download) computeCompleted() int64 {
+	if d.selectedFilesSet == nil {
+		done := int64(d.bm.Count()) * d.info.PieceLength
+		if d.bm.Contains(d.info.NumPieces - 1) {
+			done = done - d.info.PieceLength + d.info.LastPieceSize
+		}
+		return done
+	}
+	done := int64(d.bm.WithAnd(d.selectedPiecesBm).Count()) * d.info.PieceLength
+	if d.bm.Contains(d.info.NumPieces-1) && d.selectedPiecesBm.Contains(d.info.NumPieces-1) {
+		done = done - d.info.PieceLength + d.info.LastPieceSize
+	}
+	return done
+}
+
 // markUnselectedPiecesDone marks pieces that only touch unselected files as complete.
 func (d *Download) markUnselectedPiecesDone() {
 	if d.selectedFilesSet == nil {
 		return
 	}
 	for i := range d.info.NumPieces {
-		if !d.hasSelectedFiles(i) {
+		if !d.selectedPiecesBm.Contains(i) {
 			d.bm.Set(i)
 		}
 	}

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -80,6 +80,7 @@ type Download struct {
 	pendingChunksMap       bitmap.Bitmap
 	info                   meta.Info
 	completed              atomic.Int64
+	selectedSize           atomic.Int64
 	AddAt                  int64
 	CompletedAt            atomic.Int64
 	downloaded             atomic.Int64
@@ -211,6 +212,7 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 			}
 		}
 	}
+	d.selectedSize.Store(d.computeSelectedSize())
 
 	d.stateCond = gsync.NewCond(&d.m)
 
@@ -244,6 +246,21 @@ func (d *Download) hasSelectedFiles(pieceIndex uint32) bool {
 		}
 	}
 	return false
+}
+
+func (d *Download) SelectedSize() int64 {
+	return d.selectedSize.Load()
+}
+
+func (d *Download) computeSelectedSize() int64 {
+	if d.selectedFilesSet == nil {
+		return d.info.TotalLength
+	}
+	var size int64
+	for idx := range d.selectedFilesSet {
+		size += d.info.Files[idx].Length
+	}
+	return size
 }
 
 // markUnselectedPiecesDone marks pieces that only touch unselected files as complete.

--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -457,7 +457,7 @@ func (d *Download) updateRarePieces() {
 			continue
 		}
 
-		if !d.hasSelectedFiles(uint32(index)) {
+		if !d.selectedPiecesBm.Contains(uint32(index)) {
 			continue
 		}
 
@@ -487,7 +487,7 @@ func (d *Download) scheduleSeq() {
 		return
 	}
 
-	if d.info.TotalLength-d.completed.Load() <= units.MiB*100 {
+	if d.SelectedSize()-d.completed.Load() <= units.MiB*100 {
 		d.endGameMode.Store(true)
 		d.scheduleSeqEndGame()
 		return
@@ -514,7 +514,7 @@ func (d *Download) schedulePartialPieces() {
 		if d.bm.Contains(i) {
 			continue
 		}
-		if !d.hasSelectedFiles(i) {
+		if !d.selectedPiecesBm.Contains(i) {
 			continue
 		}
 
@@ -615,7 +615,7 @@ func (d *Download) assignPiecesToPeers(nextPiece func() (uint32, bool)) {
 				return
 			}
 
-			if !d.hasSelectedFiles(pieceIndex) {
+			if !d.selectedPiecesBm.Contains(pieceIndex) {
 				continue
 			}
 
@@ -647,7 +647,7 @@ func (d *Download) scheduleSeqEndGame() {
 
 	d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {
 		for _, u := range s {
-			if !d.hasSelectedFiles(u) {
+			if !d.selectedPiecesBm.Contains(u) {
 				continue
 			}
 			if p.Bitmap.Contains(u) {

--- a/internal/core/d_loop.go
+++ b/internal/core/d_loop.go
@@ -64,6 +64,7 @@ func (d *Download) Init(resumed bool) {
 			d.log.Err(err).Msg("failed to initCheck torrent data")
 		}
 		d.markUnselectedPiecesDone()
+		d.completed.Store(d.computeCompleted())
 		d.ioDown.Reset()
 
 		d.log.Debug().Msgf("done size %s", humanize.IBytes(uint64(d.bm.Count())*uint64(d.info.PieceLength)))

--- a/internal/core/d_resume.go
+++ b/internal/core/d_resume.go
@@ -127,11 +127,7 @@ func (c *Client) UnmarshalResume(data []byte) error {
 
 	d.bm = bm.FromBitfields(r.Bitfield, d.info.NumPieces)
 	d.markUnselectedPiecesDone()
-	done := int64(d.bm.Count()) * d.info.PieceLength
-	if d.bm.Contains(d.info.NumPieces - 1) {
-		done = done - d.info.PieceLength + d.info.LastPieceSize
-	}
-	d.completed.Store(done)
+	d.completed.Store(d.computeCompleted())
 
 	d.state = r.State
 	d.AddAt = r.AddAt

--- a/internal/core/d_tracker.go
+++ b/internal/core/d_tracker.go
@@ -224,7 +224,7 @@ func (t *Tracker) req(d *Download) *resty.Request {
 		SetQueryParam("key", d.trackerKey).
 		SetQueryParam("uploaded", strconv.FormatInt(d.uploaded.Load()-d.uploadAtStart, 10)).
 		SetQueryParam("downloaded", strconv.FormatInt(d.downloaded.Load()-d.downloadAtStart, 10)).
-		SetQueryParam("left", strconv.FormatInt(d.info.TotalLength-d.completed.Load(), 10))
+		SetQueryParam("left", strconv.FormatInt(d.SelectedSize()-d.completed.Load(), 10))
 
 	if v4 := d.c.ipv4.Load(); v4 != nil {
 		req.SetQueryParam("ipv4", v4.String())


### PR DESCRIPTION
## Summary
- Add `SelectedSize` field to `MainDataTorrent` and `torrent.list` JSON-RPC response
- Cache `selectedSize` on `Download` via `atomic.Int64`, computed at creation and updated on `SetFilePriority`
- `selected_size` reflects the total size of files selected for download (or `total_length` when all files are selected)