### PR TITLE
feat: add per-torrent and global download/upload rate limiting

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,7 +21,11 @@ type Application struct {
 	// hard global upload slot limit (across all torrents)
 	// 0 means auto (derived from GlobalConnectionLimit).
 	GlobalUploadSlots uint16 `toml:"global-upload-slots"`
-	Fallocate         bool   `toml:"fallocate"`
+	// Global download speed limit in bytes per second. 0 means unlimited.
+	GlobalDownloadSpeedLimit int64 `toml:"global-download-speed-limit"`
+	// Global upload speed limit in bytes per second. 0 means unlimited.
+	GlobalUploadSpeedLimit int64 `toml:"global-upload-speed-limit"`
+	Fallocate              bool  `toml:"fallocate"`
 }
 
 type Config struct {

--- a/internal/core/c.go
+++ b/internal/core/c.go
@@ -29,6 +29,7 @@ import (
 	"neptune/internal/pkg/flowrate"
 	"neptune/internal/pkg/global"
 	"neptune/internal/pkg/random"
+	"neptune/internal/pkg/ratelimit"
 	"neptune/internal/pkg/unsafe"
 	"neptune/internal/util"
 )
@@ -76,6 +77,9 @@ func New(cfg config.Config, sessionPath string, debug bool) *Client {
 
 		ioUp:   flowrate.New(time.Second, time.Second),
 		ioDown: flowrate.New(time.Second, time.Second),
+
+		downloadLimiter: ratelimit.New(cfg.App.GlobalDownloadSpeedLimit),
+		uploadLimiter:   ratelimit.New(cfg.App.GlobalUploadSpeedLimit),
 
 		http: resty.NewWithClient(&http.Client{
 			Transport: &http.Transport{
@@ -131,6 +135,9 @@ type Client struct {
 
 	ioDown *flowrate.Monitor
 	ioUp   *flowrate.Monitor
+
+	downloadLimiter *ratelimit.Limiter
+	uploadLimiter   *ratelimit.Limiter
 
 	filePool *filepool.FilePool
 

--- a/internal/core/c_speed_limit.go
+++ b/internal/core/c_speed_limit.go
@@ -9,7 +9,7 @@ import (
 	"neptune/internal/metainfo"
 )
 
-func (c *Client) SetSpeedLimit(h metainfo.Hash, downloadLimit, uploadLimit int64) error {
+func (c *Client) SetDownloadLimit(h metainfo.Hash, limit int64) error {
 	c.m.RLock()
 	d, ok := c.downloadMap[h]
 	c.m.RUnlock()
@@ -18,14 +18,31 @@ func (c *Client) SetSpeedLimit(h metainfo.Hash, downloadLimit, uploadLimit int64
 		return fmt.Errorf("torrent %s not exists", h)
 	}
 
-	d.downloadLimiter.Update(downloadLimit)
-	d.uploadLimiter.Update(uploadLimit)
+	d.downloadLimiter.Update(limit)
 	d.saveResume()
 
 	return nil
 }
 
-func (c *Client) SetGlobalSpeedLimit(downloadLimit, uploadLimit int64) {
-	c.downloadLimiter.Update(downloadLimit)
-	c.uploadLimiter.Update(uploadLimit)
+func (c *Client) SetUploadLimit(h metainfo.Hash, limit int64) error {
+	c.m.RLock()
+	d, ok := c.downloadMap[h]
+	c.m.RUnlock()
+
+	if !ok {
+		return fmt.Errorf("torrent %s not exists", h)
+	}
+
+	d.uploadLimiter.Update(limit)
+	d.saveResume()
+
+	return nil
+}
+
+func (c *Client) SetGlobalDownloadLimit(limit int64) {
+	c.downloadLimiter.Update(limit)
+}
+
+func (c *Client) SetGlobalUploadLimit(limit int64) {
+	c.uploadLimiter.Update(limit)
 }

--- a/internal/core/c_speed_limit.go
+++ b/internal/core/c_speed_limit.go
@@ -1,0 +1,31 @@
+// Copyright 2024 trim21 <trim21.me@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package core
+
+import (
+	"fmt"
+
+	"neptune/internal/metainfo"
+)
+
+func (c *Client) SetSpeedLimit(h metainfo.Hash, downloadLimit, uploadLimit int64) error {
+	c.m.RLock()
+	d, ok := c.downloadMap[h]
+	c.m.RUnlock()
+
+	if !ok {
+		return fmt.Errorf("torrent %s not exists", h)
+	}
+
+	d.downloadLimiter.Update(downloadLimit)
+	d.uploadLimiter.Update(uploadLimit)
+	d.saveResume()
+
+	return nil
+}
+
+func (c *Client) SetGlobalSpeedLimit(downloadLimit, uploadLimit int64) {
+	c.downloadLimiter.Update(downloadLimit)
+	c.uploadLimiter.Update(uploadLimit)
+}

--- a/internal/core/c_upload_pool.go
+++ b/internal/core/c_upload_pool.go
@@ -87,6 +87,10 @@ func (c *Client) uploadWorker() {
 				}
 			}
 
+			// Rate limit: block before sending to the network.
+			_ = d.uploadLimiter.Wait(d.ctx, len(res.Data))
+			_ = d.c.uploadLimiter.Wait(d.ctx, len(res.Data))
+
 			if p.Response(res) {
 				d.ioUp.Update(len(res.Data))
 				d.c.ioUp.Update(len(res.Data))

--- a/internal/core/c_upload_pool.go
+++ b/internal/core/c_upload_pool.go
@@ -88,8 +88,14 @@ func (c *Client) uploadWorker() {
 			}
 
 			// Rate limit: block before sending to the network.
-			_ = d.uploadLimiter.Wait(d.ctx, len(res.Data))
-			_ = d.c.uploadLimiter.Wait(d.ctx, len(res.Data))
+			if err := d.uploadLimiter.Wait(d.ctx, len(res.Data)); err != nil {
+				proto.PiecePool.Put(res)
+				continue
+			}
+			if err := d.c.uploadLimiter.Wait(d.ctx, len(res.Data)); err != nil {
+				proto.PiecePool.Put(res)
+				continue
+			}
 
 			if p.Response(res) {
 				d.ioUp.Update(len(res.Data))

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -27,6 +27,7 @@ import (
 	"neptune/internal/pkg/gsync"
 	"neptune/internal/pkg/heap"
 	"neptune/internal/pkg/random"
+	"neptune/internal/pkg/ratelimit"
 	"neptune/internal/proto"
 )
 
@@ -54,6 +55,8 @@ type Download struct {
 	netDown                *flowrate.Monitor
 	ioUp                   *flowrate.Monitor
 	ResChan                chan *proto.ChunkResponse
+	downloadLimiter        *ratelimit.Limiter
+	uploadLimiter          *ratelimit.Limiter
 	peers                  *xsync.Map[netip.AddrPort, *Peer]
 	connectionHistory      *expirable.LRU[netip.AddrPort, connHistory]
 	bm                     *bm.Bitmap
@@ -201,6 +204,9 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 		downloadDir: basePath,
 
 		trackerKey: random.URLSafeStr(16),
+
+		downloadLimiter: ratelimit.New(0),
+		uploadLimiter:   ratelimit.New(0),
 	}
 
 	if selectedFiles != nil {

--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -98,6 +98,11 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 		Uint32("piece", res.PieceIndex).
 		Msg("res received")
 
+	// Rate limit: block until allowed, which backpressures the peer read loop
+	// and ultimately slows TCP reception via flow control.
+	_ = d.downloadLimiter.Wait(d.ctx, len(res.Data))
+	_ = d.c.downloadLimiter.Wait(d.ctx, len(res.Data))
+
 	d.ioDown.Update(len(res.Data))
 	d.netDown.Update(len(res.Data))
 	d.c.ioDown.Update(len(res.Data))

--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -100,8 +100,12 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 
 	// Rate limit: block until allowed, which backpressures the peer read loop
 	// and ultimately slows TCP reception via flow control.
-	_ = d.downloadLimiter.Wait(d.ctx, len(res.Data))
-	_ = d.c.downloadLimiter.Wait(d.ctx, len(res.Data))
+	if err := d.downloadLimiter.Wait(d.ctx, len(res.Data)); err != nil {
+		return
+	}
+	if err := d.c.downloadLimiter.Wait(d.ctx, len(res.Data)); err != nil {
+		return
+	}
 
 	d.ioDown.Update(len(res.Data))
 	d.netDown.Update(len(res.Data))

--- a/internal/core/d_resume.go
+++ b/internal/core/d_resume.go
@@ -29,11 +29,14 @@ type resume struct {
 	Tags          []string
 	Trackers      [][]string
 	SelectedFiles []int // indices of files selected for download. nil means all files.
-	AddAt         int64
-	CompletedAt   int64
-	Downloaded    int64
-	Uploaded      int64
-	State         State
+	// Per-torrent speed limits in bytes per second. 0 means unlimited.
+	DownloadSpeedLimit int64
+	UploadSpeedLimit   int64
+	AddAt              int64
+	CompletedAt        int64
+	Downloaded         int64
+	Uploaded           int64
+	State              State
 }
 
 func (d *Download) resumeFilePath() (dir, file string) {
@@ -76,16 +79,18 @@ func (d *Download) MarshalBinary() (data []byte, err error) {
 	}
 
 	return bencode.Marshal(resume{
-		BasePath:      d.basePath,
-		Downloaded:    d.downloaded.Load(),
-		Uploaded:      d.uploaded.Load(),
-		Tags:          d.tags,
-		State:         d.GetState(),
-		InfoHash:      d.info.Hash.Hex(),
-		Bitfield:      d.bm.Bitfield(),
-		AddAt:         d.AddAt,
-		CompletedAt:   d.CompletedAt.Load(),
-		SelectedFiles: selectedFiles,
+		BasePath:           d.basePath,
+		Downloaded:         d.downloaded.Load(),
+		Uploaded:           d.uploaded.Load(),
+		Tags:               d.tags,
+		State:              d.GetState(),
+		InfoHash:           d.info.Hash.Hex(),
+		Bitfield:           d.bm.Bitfield(),
+		AddAt:              d.AddAt,
+		CompletedAt:        d.CompletedAt.Load(),
+		SelectedFiles:      selectedFiles,
+		DownloadSpeedLimit: d.downloadLimiter.Rate(),
+		UploadSpeedLimit:   d.uploadLimiter.Rate(),
 		Trackers: lo.Map(d.trackers, func(tier TrackerTier, index int) []string {
 			return lo.Map(tier.trackers, func(tracker *Tracker, index int) string {
 				return tracker.url
@@ -142,6 +147,9 @@ func (c *Client) UnmarshalResume(data []byte) error {
 
 	d.uploaded.Store(r.Uploaded)
 	d.uploadAtStart = r.Uploaded
+
+	d.downloadLimiter.Update(r.DownloadSpeedLimit)
+	d.uploadLimiter.Update(r.UploadSpeedLimit)
 
 	c.m.Lock()
 	defer c.m.Unlock()

--- a/internal/pkg/ratelimit/ratelimit.go
+++ b/internal/pkg/ratelimit/ratelimit.go
@@ -1,0 +1,146 @@
+// Copyright 2024 trim21 <trim21.me@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+// Package ratelimit provides a simple token-bucket rate limiter for byte streams.
+// A zero Limiter is a no-op (unlimited).
+package ratelimit
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.uber.org/atomic"
+)
+
+// Limiter controls the rate of byte transfers using a token bucket algorithm.
+// Tokens represent bytes and are replenished at the configured rate.
+// A zero value Limiter imposes no limit.
+type Limiter struct {
+	last   time.Time
+	rate   atomic.Int64
+	tokens float64
+	burst  float64
+	mu     sync.Mutex
+}
+
+func computeBurst(rate float64) float64 {
+	burst := rate
+	if burst < 256*1024 {
+		burst = 256 * 1024
+	}
+	return burst
+}
+
+// New creates a Limiter that allows rate bytes per second.
+// If rate <= 0, the returned Limiter imposes no limit.
+func New(rate int64) *Limiter {
+	if rate <= 0 {
+		return &Limiter{}
+	}
+
+	r := float64(rate)
+	burst := computeBurst(r)
+
+	return &Limiter{
+		rate:   *atomic.NewInt64(rate),
+		tokens: burst,
+		burst:  burst,
+		last:   time.Now(),
+	}
+}
+
+// Update dynamically changes the rate limit.
+// If rate <= 0, the limiter becomes unlimited.
+func (l *Limiter) Update(rate int64) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if rate <= 0 {
+		l.rate.Store(0)
+		l.tokens = 0
+		l.burst = 0
+		return
+	}
+
+	r := float64(rate)
+	burst := computeBurst(r)
+
+	l.rate.Store(rate)
+	l.burst = burst
+	if l.tokens > burst {
+		l.tokens = burst
+	}
+}
+
+// Wait blocks until n bytes worth of tokens are available or ctx is canceled.
+// A zero-value Limiter returns immediately.
+func (l *Limiter) Wait(ctx context.Context, n int) error {
+	if l.rate.Load() <= 0 {
+		return nil
+	}
+
+	l.mu.Lock()
+	l.refill()
+
+	if l.tokens >= float64(n) {
+		l.tokens -= float64(n)
+		l.mu.Unlock()
+		return nil
+	}
+
+	timer := time.NewTimer(time.Hour)
+	defer timer.Stop()
+
+	for {
+		deficit := float64(n) - l.tokens
+		wait := max(time.Duration(deficit/float64(l.rate.Load())*float64(time.Second)), time.Millisecond)
+
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timer.Reset(wait)
+
+		l.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			l.mu.Lock()
+			return ctx.Err()
+		case <-timer.C:
+		}
+
+		l.mu.Lock()
+		l.refill()
+
+		if l.rate.Load() <= 0 {
+			return nil
+		}
+
+		if l.tokens >= float64(n) {
+			l.tokens -= float64(n)
+			l.mu.Unlock()
+			return nil
+		}
+	}
+}
+
+// refill replenishes tokens based on elapsed time. Caller must hold l.mu.
+func (l *Limiter) refill() {
+	now := time.Now()
+	elapsed := now.Sub(l.last).Seconds()
+	l.last = now
+
+	l.tokens += elapsed * float64(l.rate.Load())
+	if l.tokens > l.burst {
+		l.tokens = l.burst
+	}
+}
+
+// Rate returns the configured rate in bytes per second. 0 means unlimited.
+func (l *Limiter) Rate() int64 {
+	return l.rate.Load()
+}

--- a/internal/pkg/ratelimit/ratelimit.go
+++ b/internal/pkg/ratelimit/ratelimit.go
@@ -93,8 +93,14 @@ func (l *Limiter) Wait(ctx context.Context, n int) error {
 	defer timer.Stop()
 
 	for {
+		r := float64(l.rate.Load())
+		if r <= 0 {
+			l.mu.Unlock()
+			return nil
+		}
+
 		deficit := float64(n) - l.tokens
-		wait := max(time.Duration(deficit/float64(l.rate.Load())*float64(time.Second)), time.Millisecond)
+		wait := max(time.Duration(deficit/r*float64(time.Second)), time.Millisecond)
 
 		if !timer.Stop() {
 			select {

--- a/internal/pkg/ratelimit/ratelimit_test.go
+++ b/internal/pkg/ratelimit/ratelimit_test.go
@@ -1,0 +1,97 @@
+// Copyright 2024 trim21 <trim21.me@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package ratelimit
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestZeroLimiterIsUnlimited(t *testing.T) {
+	var l Limiter
+	start := time.Now()
+	err := l.Wait(context.Background(), 1024*1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if time.Since(start) > 10*time.Millisecond {
+		t.Fatal("zero limiter should not block")
+	}
+}
+
+func TestNewZeroRateIsUnlimited(t *testing.T) {
+	l := New(0)
+	start := time.Now()
+	err := l.Wait(context.Background(), 1024*1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if time.Since(start) > 10*time.Millisecond {
+		t.Fatal("zero-rate limiter should not block")
+	}
+}
+
+func TestRate(t *testing.T) {
+	if r := New(1000).Rate(); r != 1000 {
+		t.Fatalf("expected rate 1000, got %d", r)
+	}
+	if r := New(0).Rate(); r != 0 {
+		t.Fatalf("expected rate 0, got %d", r)
+	}
+	if r := new(Limiter).Rate(); r != 0 {
+		t.Fatalf("expected rate 0, got %d", r)
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	l := New(1000)
+	if r := l.Rate(); r != 1000 {
+		t.Fatalf("expected rate 1000, got %d", r)
+	}
+
+	l.Update(2000)
+	if r := l.Rate(); r != 2000 {
+		t.Fatalf("expected rate 2000, got %d", r)
+	}
+
+	l.Update(0)
+	if r := l.Rate(); r != 0 {
+		t.Fatalf("expected rate 0, got %d", r)
+	}
+}
+
+func TestLimiterBlocks(t *testing.T) {
+	l := New(100)
+
+	start := time.Now()
+	err := l.Wait(context.Background(), 256*1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if time.Since(start) > 50*time.Millisecond {
+		t.Fatal("first call should not block significantly")
+	}
+
+	start = time.Now()
+	err = l.Wait(context.Background(), 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	elapsed := time.Since(start)
+	if elapsed < 500*time.Millisecond {
+		t.Fatalf("expected ~1s block, got %v", elapsed)
+	}
+}
+
+func TestLimiterContextCancel(t *testing.T) {
+	l := New(1)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := l.Wait(ctx, 256*1024+1)
+	if err != context.Canceled {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}

--- a/internal/pkg/ratelimit/ratelimit_test.go
+++ b/internal/pkg/ratelimit/ratelimit_test.go
@@ -95,3 +95,24 @@ func TestLimiterContextCancel(t *testing.T) {
 		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 }
+
+func TestUpdateToUnlimitedWhileWaiting(t *testing.T) {
+	l := New(1)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- l.Wait(context.Background(), 256*1024+1)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	l.Update(0)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Wait did not return after Update(0)")
+	}
+}

--- a/internal/web/torrent_speed_limit.go
+++ b/internal/web/torrent_speed_limit.go
@@ -17,9 +17,9 @@ import (
 )
 
 type setSpeedLimitRequest struct {
-	InfoHash      string `description:"torrent file hash"                            json:"info_hash"      required:"true"`
-	DownloadLimit int64  `description:"download speed limit in bytes/s, 0=unlimited" json:"download_limit"`
-	UploadLimit   int64  `description:"upload speed limit in bytes/s, 0=unlimited"   json:"upload_limit"`
+	InfoHash      string `description:"torrent file hash"                              json:"info_hash"      required:"true"`
+	DownloadLimit int64  `description:"download speed limit in bytes/s, <=0=unlimited" json:"download_limit"`
+	UploadLimit   int64  `description:"upload speed limit in bytes/s, <=0=unlimited"   json:"upload_limit"`
 }
 
 type setSpeedLimitResponse struct{}
@@ -49,8 +49,8 @@ func setSpeedLimit(h *jsonrpc.Handler, c *core.Client) {
 }
 
 type setGlobalSpeedLimitRequest struct {
-	DownloadLimit int64 `description:"global download speed limit in bytes/s, 0=no change, -1=unlimited" json:"download_limit"`
-	UploadLimit   int64 `description:"global upload speed limit in bytes/s, 0=no change, -1=unlimited"   json:"upload_limit"`
+	DownloadLimit int64 `description:"global download speed limit in bytes/s, 0=unlimited" json:"download_limit"`
+	UploadLimit   int64 `description:"global upload speed limit in bytes/s, 0=unlimited"   json:"upload_limit"`
 }
 
 type setGlobalSpeedLimitResponse struct{}

--- a/internal/web/torrent_speed_limit.go
+++ b/internal/web/torrent_speed_limit.go
@@ -16,52 +16,111 @@ import (
 	"neptune/internal/web/jsonrpc"
 )
 
-type setSpeedLimitRequest struct {
-	InfoHash      string `description:"torrent file hash"                              json:"info_hash"      required:"true"`
-	DownloadLimit int64  `description:"download speed limit in bytes/s, <=0=unlimited" json:"download_limit"`
-	UploadLimit   int64  `description:"upload speed limit in bytes/s, <=0=unlimited"   json:"upload_limit"`
+func checkInfoHash(infoHash string) (metainfo.Hash, error) {
+	if len(infoHash) != sha1.Size*2 {
+		return metainfo.Hash{}, errInvalidInfoHash
+	}
+
+	raw, err := hex.DecodeString(infoHash)
+	if err != nil {
+		return metainfo.Hash{}, errInvalidInfoHash
+	}
+
+	return metainfo.Hash(raw), nil
 }
 
-type setSpeedLimitResponse struct{}
+// torrent.set_download_limit
 
-func setSpeedLimit(h *jsonrpc.Handler, c *core.Client) {
-	u := usecase.NewInteractor[*setSpeedLimitRequest, setSpeedLimitResponse](
-		func(ctx context.Context, req *setSpeedLimitRequest, res *setSpeedLimitResponse) error {
-			if len(req.InfoHash) != sha1.Size*2 {
-				return errInvalidInfoHash
+type setDownloadLimitRequest struct {
+	InfoHash string `description:"torrent file hash"                              json:"info_hash" required:"true"`
+	Limit    int64  `description:"download speed limit in bytes/s, <=0=unlimited" json:"limit"`
+}
+
+type setDownloadLimitResponse struct{}
+
+func setDownloadLimit(h *jsonrpc.Handler, c *core.Client) {
+	u := usecase.NewInteractor[*setDownloadLimitRequest, setDownloadLimitResponse](
+		func(ctx context.Context, req *setDownloadLimitRequest, res *setDownloadLimitResponse) error {
+			h, err := checkInfoHash(req.InfoHash)
+			if err != nil {
+				return err
 			}
 
-			raw, err := hex.DecodeString(req.InfoHash)
+			err = c.SetDownloadLimit(h, req.Limit)
 			if err != nil {
-				return errInvalidInfoHash
-			}
-
-			err = c.SetSpeedLimit(metainfo.Hash(raw), req.DownloadLimit, req.UploadLimit)
-			if err != nil {
-				return CodeError(1, errgo.Wrap(err, "failed to set speed limit"))
+				return CodeError(1, errgo.Wrap(err, "failed to set download limit"))
 			}
 
 			return nil
 		},
 	)
-	u.SetName("torrent.set_speed_limit")
+	u.SetName("torrent.set_download_limit")
 	h.Add(u)
 }
 
-type setGlobalSpeedLimitRequest struct {
-	DownloadLimit int64 `description:"global download speed limit in bytes/s, 0=unlimited" json:"download_limit"`
-	UploadLimit   int64 `description:"global upload speed limit in bytes/s, 0=unlimited"   json:"upload_limit"`
+// torrent.set_upload_limit
+
+type setUploadLimitRequest struct {
+	InfoHash string `description:"torrent file hash"                            json:"info_hash" required:"true"`
+	Limit    int64  `description:"upload speed limit in bytes/s, <=0=unlimited" json:"limit"`
 }
 
-type setGlobalSpeedLimitResponse struct{}
+type setUploadLimitResponse struct{}
 
-func setGlobalSpeedLimit(h *jsonrpc.Handler, c *core.Client) {
-	u := usecase.NewInteractor[*setGlobalSpeedLimitRequest, setGlobalSpeedLimitResponse](
-		func(ctx context.Context, req *setGlobalSpeedLimitRequest, res *setGlobalSpeedLimitResponse) error {
-			c.SetGlobalSpeedLimit(req.DownloadLimit, req.UploadLimit)
+func setUploadLimit(h *jsonrpc.Handler, c *core.Client) {
+	u := usecase.NewInteractor[*setUploadLimitRequest, setUploadLimitResponse](
+		func(ctx context.Context, req *setUploadLimitRequest, res *setUploadLimitResponse) error {
+			h, err := checkInfoHash(req.InfoHash)
+			if err != nil {
+				return err
+			}
+
+			err = c.SetUploadLimit(h, req.Limit)
+			if err != nil {
+				return CodeError(1, errgo.Wrap(err, "failed to set upload limit"))
+			}
+
 			return nil
 		},
 	)
-	u.SetName("system.set_speed_limit")
+	u.SetName("torrent.set_upload_limit")
+	h.Add(u)
+}
+
+// system.set_download_limit
+
+type setGlobalDownloadLimitRequest struct {
+	Limit int64 `description:"global download speed limit in bytes/s, <=0=unlimited" json:"limit"`
+}
+
+type setGlobalDownloadLimitResponse struct{}
+
+func setGlobalDownloadLimit(h *jsonrpc.Handler, c *core.Client) {
+	u := usecase.NewInteractor[*setGlobalDownloadLimitRequest, setGlobalDownloadLimitResponse](
+		func(ctx context.Context, req *setGlobalDownloadLimitRequest, res *setGlobalDownloadLimitResponse) error {
+			c.SetGlobalDownloadLimit(req.Limit)
+			return nil
+		},
+	)
+	u.SetName("system.set_download_limit")
+	h.Add(u)
+}
+
+// system.set_upload_limit
+
+type setGlobalUploadLimitRequest struct {
+	Limit int64 `description:"global upload speed limit in bytes/s, <=0=unlimited" json:"limit"`
+}
+
+type setGlobalUploadLimitResponse struct{}
+
+func setGlobalUploadLimit(h *jsonrpc.Handler, c *core.Client) {
+	u := usecase.NewInteractor[*setGlobalUploadLimitRequest, setGlobalUploadLimitResponse](
+		func(ctx context.Context, req *setGlobalUploadLimitRequest, res *setGlobalUploadLimitResponse) error {
+			c.SetGlobalUploadLimit(req.Limit)
+			return nil
+		},
+	)
+	u.SetName("system.set_upload_limit")
 	h.Add(u)
 }

--- a/internal/web/torrent_speed_limit.go
+++ b/internal/web/torrent_speed_limit.go
@@ -87,7 +87,7 @@ func setUploadLimit(h *jsonrpc.Handler, c *core.Client) {
 	h.Add(u)
 }
 
-// system.set_download_limit
+// client.set_download_limit
 
 type setGlobalDownloadLimitRequest struct {
 	Limit int64 `description:"global download speed limit in bytes/s, <=0=unlimited" json:"limit"`
@@ -96,17 +96,17 @@ type setGlobalDownloadLimitRequest struct {
 type setGlobalDownloadLimitResponse struct{}
 
 func setGlobalDownloadLimit(h *jsonrpc.Handler, c *core.Client) {
-	u := usecase.NewInteractor[*setGlobalDownloadLimitRequest, setGlobalDownloadLimitResponse](
+	u := usecase.NewInteractor(
 		func(ctx context.Context, req *setGlobalDownloadLimitRequest, res *setGlobalDownloadLimitResponse) error {
 			c.SetGlobalDownloadLimit(req.Limit)
 			return nil
 		},
 	)
-	u.SetName("system.set_download_limit")
+	u.SetName("client.set_download_limit")
 	h.Add(u)
 }
 
-// system.set_upload_limit
+// client.set_upload_limit
 
 type setGlobalUploadLimitRequest struct {
 	Limit int64 `description:"global upload speed limit in bytes/s, <=0=unlimited" json:"limit"`
@@ -115,12 +115,12 @@ type setGlobalUploadLimitRequest struct {
 type setGlobalUploadLimitResponse struct{}
 
 func setGlobalUploadLimit(h *jsonrpc.Handler, c *core.Client) {
-	u := usecase.NewInteractor[*setGlobalUploadLimitRequest, setGlobalUploadLimitResponse](
+	u := usecase.NewInteractor(
 		func(ctx context.Context, req *setGlobalUploadLimitRequest, res *setGlobalUploadLimitResponse) error {
 			c.SetGlobalUploadLimit(req.Limit)
 			return nil
 		},
 	)
-	u.SetName("system.set_upload_limit")
+	u.SetName("client.set_upload_limit")
 	h.Add(u)
 }

--- a/internal/web/torrent_speed_limit.go
+++ b/internal/web/torrent_speed_limit.go
@@ -1,0 +1,67 @@
+// Copyright 2024 trim21 <trim21.me@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package web
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+
+	"github.com/swaggest/usecase"
+	"github.com/trim21/errgo"
+
+	"neptune/internal/core"
+	"neptune/internal/metainfo"
+	"neptune/internal/web/jsonrpc"
+)
+
+type setSpeedLimitRequest struct {
+	InfoHash      string `description:"torrent file hash"                            json:"info_hash"      required:"true"`
+	DownloadLimit int64  `description:"download speed limit in bytes/s, 0=unlimited" json:"download_limit"`
+	UploadLimit   int64  `description:"upload speed limit in bytes/s, 0=unlimited"   json:"upload_limit"`
+}
+
+type setSpeedLimitResponse struct{}
+
+func setSpeedLimit(h *jsonrpc.Handler, c *core.Client) {
+	u := usecase.NewInteractor[*setSpeedLimitRequest, setSpeedLimitResponse](
+		func(ctx context.Context, req *setSpeedLimitRequest, res *setSpeedLimitResponse) error {
+			if len(req.InfoHash) != sha1.Size*2 {
+				return errInvalidInfoHash
+			}
+
+			raw, err := hex.DecodeString(req.InfoHash)
+			if err != nil {
+				return errInvalidInfoHash
+			}
+
+			err = c.SetSpeedLimit(metainfo.Hash(raw), req.DownloadLimit, req.UploadLimit)
+			if err != nil {
+				return CodeError(1, errgo.Wrap(err, "failed to set speed limit"))
+			}
+
+			return nil
+		},
+	)
+	u.SetName("torrent.set_speed_limit")
+	h.Add(u)
+}
+
+type setGlobalSpeedLimitRequest struct {
+	DownloadLimit int64 `description:"global download speed limit in bytes/s, 0=no change, -1=unlimited" json:"download_limit"`
+	UploadLimit   int64 `description:"global upload speed limit in bytes/s, 0=no change, -1=unlimited"   json:"upload_limit"`
+}
+
+type setGlobalSpeedLimitResponse struct{}
+
+func setGlobalSpeedLimit(h *jsonrpc.Handler, c *core.Client) {
+	u := usecase.NewInteractor[*setGlobalSpeedLimitRequest, setGlobalSpeedLimitResponse](
+		func(ctx context.Context, req *setGlobalSpeedLimitRequest, res *setGlobalSpeedLimitResponse) error {
+			c.SetGlobalSpeedLimit(req.DownloadLimit, req.UploadLimit)
+			return nil
+		},
+	)
+	u.SetName("system.set_speed_limit")
+	h.Add(u)
+}

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -109,6 +109,8 @@ func New(c *core.Client, token string, enableDebug bool) http.Handler {
 	removeTags(h, c)
 	resumeTorrent(h, c)
 	setFilePriority(h, c)
+	setSpeedLimit(h, c)
+	setGlobalSpeedLimit(h, c)
 	// MoveTorrent(h, c)
 
 	var auth = func(next http.Handler) http.Handler {

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -109,8 +109,10 @@ func New(c *core.Client, token string, enableDebug bool) http.Handler {
 	removeTags(h, c)
 	resumeTorrent(h, c)
 	setFilePriority(h, c)
-	setSpeedLimit(h, c)
-	setGlobalSpeedLimit(h, c)
+	setDownloadLimit(h, c)
+	setUploadLimit(h, c)
+	setGlobalDownloadLimit(h, c)
+	setGlobalUploadLimit(h, c)
 	// MoveTorrent(h, c)
 
 	var auth = func(next http.Handler) http.Handler {


### PR DESCRIPTION
## Summary

Add a token-bucket rate limiter (`internal/pkg/ratelimit`) supporting per-torrent and global speed limits for both download and upload.

### Rate Limiter (`internal/pkg/ratelimit`)
- Token-bucket algorithm with `atomic.Int64` hot-path fast return when rate=0
- Timer reuse via `time.NewTimer` + `Reset()` avoids per-iteration allocations
- `computeBurst()` helper, min burst = 256KB
- Defensive rate check inside `Wait()` loop prevents busy-spin / divide-by-zero on concurrent `Update(0)`
- `Update()` dynamically changes limits; `<=0` means unlimited

### Config
- `GlobalDownloadSpeedLimit` / `GlobalUploadSpeedLimit` (`int64`, bytes/sec, 0=unlimited) in `[application]` TOML

### Hot Path Integration
- Download: `handleRes()` calls `Wait()` on per-torrent + global download limiters; errors (context canceled) cause early return
- Upload: `uploadWorker()` calls `Wait()` on per-torrent + global upload limiters; errors cause `continue`

### Resume
- `DownloadSpeedLimit` / `UploadSpeedLimit` fields in bencode resume (backward compatible, 0=unlimited default)

### RPC Methods
| RPC | Description |
|---|---|
| `torrent.set_download_limit` | Set per-torrent download limit (info_hash + limit) |
| `torrent.set_upload_limit` | Set per-torrent upload limit (info_hash + limit) |
| `client.set_download_limit` | Set global download limit |
| `client.set_upload_limit` | Set global upload limit |