### PR TITLE
refactor: split speed limit RPCs into separate download/upload methods

### DIFF
--- a/internal/core/c_speed_limit.go
+++ b/internal/core/c_speed_limit.go
@@ -9,7 +9,7 @@ import (
 	"neptune/internal/metainfo"
 )
 
-func (c *Client) SetSpeedLimit(h metainfo.Hash, downloadLimit, uploadLimit int64) error {
+func (c *Client) SetDownloadLimit(h metainfo.Hash, limit int64) error {
 	c.m.RLock()
 	d, ok := c.downloadMap[h]
 	c.m.RUnlock()
@@ -18,14 +18,31 @@ func (c *Client) SetSpeedLimit(h metainfo.Hash, downloadLimit, uploadLimit int64
 		return fmt.Errorf("torrent %s not exists", h)
 	}
 
-	d.downloadLimiter.Update(downloadLimit)
-	d.uploadLimiter.Update(uploadLimit)
+	d.downloadLimiter.Update(limit)
 	d.saveResume()
 
 	return nil
 }
 
-func (c *Client) SetGlobalSpeedLimit(downloadLimit, uploadLimit int64) {
-	c.downloadLimiter.Update(downloadLimit)
-	c.uploadLimiter.Update(uploadLimit)
+func (c *Client) SetUploadLimit(h metainfo.Hash, limit int64) error {
+	c.m.RLock()
+	d, ok := c.downloadMap[h]
+	c.m.RUnlock()
+
+	if !ok {
+		return fmt.Errorf("torrent %s not exists", h)
+	}
+
+	d.uploadLimiter.Update(limit)
+	d.saveResume()
+
+	return nil
+}
+
+func (c *Client) SetGlobalDownloadLimit(limit int64) {
+	c.downloadLimiter.Update(limit)
+}
+
+func (c *Client) SetGlobalUploadLimit(limit int64) {
+	c.uploadLimiter.Update(limit)
 }

--- a/internal/web/torrent_speed_limit.go
+++ b/internal/web/torrent_speed_limit.go
@@ -16,52 +16,111 @@ import (
 	"neptune/internal/web/jsonrpc"
 )
 
-type setSpeedLimitRequest struct {
-	InfoHash      string `description:"torrent file hash"                              json:"info_hash"      required:"true"`
-	DownloadLimit int64  `description:"download speed limit in bytes/s, <=0=unlimited" json:"download_limit"`
-	UploadLimit   int64  `description:"upload speed limit in bytes/s, <=0=unlimited"   json:"upload_limit"`
+func checkInfoHash(infoHash string) (metainfo.Hash, error) {
+	if len(infoHash) != sha1.Size*2 {
+		return metainfo.Hash{}, errInvalidInfoHash
+	}
+
+	raw, err := hex.DecodeString(infoHash)
+	if err != nil {
+		return metainfo.Hash{}, errInvalidInfoHash
+	}
+
+	return metainfo.Hash(raw), nil
 }
 
-type setSpeedLimitResponse struct{}
+// torrent.set_download_limit
 
-func setSpeedLimit(h *jsonrpc.Handler, c *core.Client) {
-	u := usecase.NewInteractor[*setSpeedLimitRequest, setSpeedLimitResponse](
-		func(ctx context.Context, req *setSpeedLimitRequest, res *setSpeedLimitResponse) error {
-			if len(req.InfoHash) != sha1.Size*2 {
-				return errInvalidInfoHash
+type setDownloadLimitRequest struct {
+	InfoHash string `description:"torrent file hash"                              json:"info_hash" required:"true"`
+	Limit    int64  `description:"download speed limit in bytes/s, <=0=unlimited" json:"limit"`
+}
+
+type setDownloadLimitResponse struct{}
+
+func setDownloadLimit(h *jsonrpc.Handler, c *core.Client) {
+	u := usecase.NewInteractor(
+		func(ctx context.Context, req *setDownloadLimitRequest, res *setDownloadLimitResponse) error {
+			h, err := checkInfoHash(req.InfoHash)
+			if err != nil {
+				return err
 			}
 
-			raw, err := hex.DecodeString(req.InfoHash)
+			err = c.SetDownloadLimit(h, req.Limit)
 			if err != nil {
-				return errInvalidInfoHash
-			}
-
-			err = c.SetSpeedLimit(metainfo.Hash(raw), req.DownloadLimit, req.UploadLimit)
-			if err != nil {
-				return CodeError(1, errgo.Wrap(err, "failed to set speed limit"))
+				return CodeError(1, errgo.Wrap(err, "failed to set download limit"))
 			}
 
 			return nil
 		},
 	)
-	u.SetName("torrent.set_speed_limit")
+	u.SetName("torrent.set_download_limit")
 	h.Add(u)
 }
 
-type setGlobalSpeedLimitRequest struct {
-	DownloadLimit int64 `description:"global download speed limit in bytes/s, 0=unlimited" json:"download_limit"`
-	UploadLimit   int64 `description:"global upload speed limit in bytes/s, 0=unlimited"   json:"upload_limit"`
+// torrent.set_upload_limit
+
+type setUploadLimitRequest struct {
+	InfoHash string `description:"torrent file hash"                            json:"info_hash" required:"true"`
+	Limit    int64  `description:"upload speed limit in bytes/s, <=0=unlimited" json:"limit"`
 }
 
-type setGlobalSpeedLimitResponse struct{}
+type setUploadLimitResponse struct{}
 
-func setGlobalSpeedLimit(h *jsonrpc.Handler, c *core.Client) {
-	u := usecase.NewInteractor[*setGlobalSpeedLimitRequest, setGlobalSpeedLimitResponse](
-		func(ctx context.Context, req *setGlobalSpeedLimitRequest, res *setGlobalSpeedLimitResponse) error {
-			c.SetGlobalSpeedLimit(req.DownloadLimit, req.UploadLimit)
+func setUploadLimit(h *jsonrpc.Handler, c *core.Client) {
+	u := usecase.NewInteractor(
+		func(ctx context.Context, req *setUploadLimitRequest, res *setUploadLimitResponse) error {
+			h, err := checkInfoHash(req.InfoHash)
+			if err != nil {
+				return err
+			}
+
+			err = c.SetUploadLimit(h, req.Limit)
+			if err != nil {
+				return CodeError(1, errgo.Wrap(err, "failed to set upload limit"))
+			}
+
 			return nil
 		},
 	)
-	u.SetName("system.set_speed_limit")
+	u.SetName("torrent.set_upload_limit")
+	h.Add(u)
+}
+
+// client.set_download_limit
+
+type setGlobalDownloadLimitRequest struct {
+	Limit int64 `description:"global download speed limit in bytes/s, <=0=unlimited" json:"limit"`
+}
+
+type setGlobalDownloadLimitResponse struct{}
+
+func setGlobalDownloadLimit(h *jsonrpc.Handler, c *core.Client) {
+	u := usecase.NewInteractor(
+		func(ctx context.Context, req *setGlobalDownloadLimitRequest, res *setGlobalDownloadLimitResponse) error {
+			c.SetGlobalDownloadLimit(req.Limit)
+			return nil
+		},
+	)
+	u.SetName("client.set_download_limit")
+	h.Add(u)
+}
+
+// client.set_upload_limit
+
+type setGlobalUploadLimitRequest struct {
+	Limit int64 `description:"global upload speed limit in bytes/s, <=0=unlimited" json:"limit"`
+}
+
+type setGlobalUploadLimitResponse struct{}
+
+func setGlobalUploadLimit(h *jsonrpc.Handler, c *core.Client) {
+	u := usecase.NewInteractor(
+		func(ctx context.Context, req *setGlobalUploadLimitRequest, res *setGlobalUploadLimitResponse) error {
+			c.SetGlobalUploadLimit(req.Limit)
+			return nil
+		},
+	)
+	u.SetName("client.set_upload_limit")
 	h.Add(u)
 }

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -109,8 +109,10 @@ func New(c *core.Client, token string, enableDebug bool) http.Handler {
 	removeTags(h, c)
 	resumeTorrent(h, c)
 	setFilePriority(h, c)
-	setSpeedLimit(h, c)
-	setGlobalSpeedLimit(h, c)
+	setDownloadLimit(h, c)
+	setUploadLimit(h, c)
+	setGlobalDownloadLimit(h, c)
+	setGlobalUploadLimit(h, c)
 	// MoveTorrent(h, c)
 
 	var auth = func(next http.Handler) http.Handler {


### PR DESCRIPTION
## Summary

Split the combined `torrent.set_speed_limit` and `system.set_speed_limit` RPCs into separate, single-responsibility methods.

### RPC Changes

| Before | After |
|---|---|
| `torrent.set_speed_limit` (download + upload) | `torrent.set_download_limit` (download only) |
| | `torrent.set_upload_limit` (upload only) |
| `system.set_speed_limit` (download + upload) | `client.set_download_limit` (download only) |
| | `client.set_upload_limit` (upload only) |

Each new RPC takes a single `limit` field; `<=0` means unlimited.

### Why
- Each method has a single responsibility
- Cleaner API — callers don't need to specify limits they don't want to change
- `client.*` prefix is more descriptive than `system.*` for global speed limits
- Matches common BitTorrent client API conventions