### PR TITLE
refactor: add Unsafe suffix to internal methods that require caller-held locks

### DIFF
--- a/internal/core/c_file_priority.go
+++ b/internal/core/c_file_priority.go
@@ -46,7 +46,7 @@ func (c *Client) SetFilePriority(h metainfo.Hash, fileIDs []int, priority int) e
 	}
 
 	// When un-skipping files (priority=1), pieces that were force-marked done
-	// by markUnselectedPiecesDone need to be cleared so they get re-downloaded.
+	// by markUnselectedPiecesDoneUnsafe need to be cleared so they get re-downloaded.
 	// A piece was force-done if it's in bm but doesn't touch any selected file.
 	if priority == 1 {
 		fileIDSet := make(map[int]struct{}, len(fileIDs))
@@ -88,13 +88,13 @@ func (c *Client) SetFilePriority(h metainfo.Hash, fileIDs []int, priority int) e
 			d.selectedFilesSet[id] = struct{}{}
 		}
 	}
-	d.selectedSize.Store(d.computeSelectedSize())
-	d.buildSelectedPiecesBm()
+	d.selectedSize.Store(d.computeSelectedSizeUnsafe())
+	d.buildSelectedPiecesBmUnsafe()
 
 	// Mark pieces that only touch unselected files as done.
-	d.markUnselectedPiecesDone()
+	d.markUnselectedPiecesDoneUnsafe()
 
-	d.completed.Store(d.computeCompleted())
+	d.completed.Store(d.computeCompletedUnsafe())
 
 	// Transition to Seeding if all pieces are complete.
 	if d.bm.Count() == d.info.NumPieces {

--- a/internal/core/c_start.go
+++ b/internal/core/c_start.go
@@ -73,7 +73,7 @@ func (c *Client) Start() error {
 			time.Sleep(time.Minute * 10)
 			c.m.RLock()
 			log.Info().Msg("save session")
-			err := c.saveSession()
+			err := c.saveSessionUnsafe()
 			c.m.RUnlock()
 			if err != nil {
 				fmt.Println(string(err.Stack)) //nolint: forbidigo

--- a/internal/core/c_stop.go
+++ b/internal/core/c_stop.go
@@ -18,12 +18,12 @@ func (c *Client) Shutdown() {
 	c.m.RLock()
 	defer c.m.RUnlock()
 
-	c.saveSession()
+	c.saveSessionUnsafe()
 
 	c.cancel()
 }
 
-func (c *Client) saveSession() *panics.Recovered {
+func (c *Client) saveSessionUnsafe() *panics.Recovered {
 	var w = conc.NewWaitGroup()
 
 	var sem = semaphore.NewWeighted(5)

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -219,8 +219,8 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 			}
 		}
 	}
-	d.selectedSize.Store(d.computeSelectedSize())
-	d.buildSelectedPiecesBm()
+	d.selectedSize.Store(d.computeSelectedSizeUnsafe())
+	d.buildSelectedPiecesBmUnsafe()
 
 	d.stateCond = gsync.NewCond(&d.m)
 
@@ -243,8 +243,8 @@ func (d *Download) setError(err error) {
 	d.m.Unlock()
 }
 
-// hasSelectedFiles returns true if the piece touches at least one selected file.
-func (d *Download) hasSelectedFiles(pieceIndex uint32) bool {
+// hasSelectedFilesUnsafe returns true if the piece touches at least one selected file.
+func (d *Download) hasSelectedFilesUnsafe(pieceIndex uint32) bool {
 	if d.selectedFilesSet == nil {
 		return true
 	}
@@ -260,7 +260,7 @@ func (d *Download) SelectedSize() int64 {
 	return d.selectedSize.Load()
 }
 
-func (d *Download) computeSelectedSize() int64 {
+func (d *Download) computeSelectedSizeUnsafe() int64 {
 	if d.selectedFilesSet == nil {
 		return d.info.TotalLength
 	}
@@ -271,7 +271,7 @@ func (d *Download) computeSelectedSize() int64 {
 	return size
 }
 
-func (d *Download) buildSelectedPiecesBm() {
+func (d *Download) buildSelectedPiecesBmUnsafe() {
 	if d.selectedPiecesBm == nil {
 		d.selectedPiecesBm = bm.New(d.info.NumPieces)
 	}
@@ -281,13 +281,13 @@ func (d *Download) buildSelectedPiecesBm() {
 	}
 	d.selectedPiecesBm.Clear()
 	for i := range d.info.NumPieces {
-		if d.hasSelectedFiles(i) {
+		if d.hasSelectedFilesUnsafe(i) {
 			d.selectedPiecesBm.Set(i)
 		}
 	}
 }
 
-func (d *Download) computeCompleted() int64 {
+func (d *Download) computeCompletedUnsafe() int64 {
 	if d.selectedFilesSet == nil {
 		done := int64(d.bm.Count()) * d.info.PieceLength
 		if d.bm.Contains(d.info.NumPieces - 1) {
@@ -302,8 +302,8 @@ func (d *Download) computeCompleted() int64 {
 	return done
 }
 
-// markUnselectedPiecesDone marks pieces that only touch unselected files as complete.
-func (d *Download) markUnselectedPiecesDone() {
+// markUnselectedPiecesDoneUnsafe marks pieces that only touch unselected files as complete.
+func (d *Download) markUnselectedPiecesDoneUnsafe() {
 	if d.selectedFilesSet == nil {
 		return
 	}

--- a/internal/core/d_loop.go
+++ b/internal/core/d_loop.go
@@ -63,8 +63,9 @@ func (d *Download) Init(resumed bool) {
 			d.setError(err)
 			d.log.Err(err).Msg("failed to initCheck torrent data")
 		}
-		d.markUnselectedPiecesDone()
-		d.completed.Store(d.computeCompleted())
+		// unsafe methods are safe here because d hasn't been shared with other goroutines yet.
+		d.markUnselectedPiecesDoneUnsafe()
+		d.completed.Store(d.computeCompletedUnsafe())
 		d.ioDown.Reset()
 
 		d.log.Debug().Msgf("done size %s", humanize.IBytes(uint64(d.bm.Count())*uint64(d.info.PieceLength)))

--- a/internal/core/d_resume.go
+++ b/internal/core/d_resume.go
@@ -130,10 +130,10 @@ func (c *Client) UnmarshalResume(data []byte) error {
 
 	d := c.NewDownload(m, info, r.BasePath, r.Tags, r.SelectedFiles)
 
+	// unsafe methods are safe here because d hasn't been shared with other goroutines yet.
 	d.bm = bm.FromBitfields(r.Bitfield, d.info.NumPieces)
-	d.markUnselectedPiecesDone()
-	d.completed.Store(d.computeCompleted())
-
+	d.markUnselectedPiecesDoneUnsafe()
+	d.completed.Store(d.computeCompletedUnsafe())
 	d.state = r.State
 	d.AddAt = r.AddAt
 	d.CompletedAt.Store(d.CompletedAt.Load())


### PR DESCRIPTION
## Summary
- Rename 6 internal methods with `Unsafe` suffix to indicate they require the caller to hold the relevant mutex (`d.m` or `c.m`)
- Add comments at two construction-phase call sites where unsafe methods are safe without locks because the download hasn't been shared with other goroutines yet

### Renamed methods

| Original | New |
|---|---|
| `d.computeSelectedSize()` | `d.computeSelectedSizeUnsafe()` |
| `d.computeCompleted()` | `d.computeCompletedUnsafe()` |
| `d.buildSelectedPiecesBm()` | `d.buildSelectedPiecesBmUnsafe()` |
| `d.markUnselectedPiecesDone()` | `d.markUnselectedPiecesDoneUnsafe()` |
| `d.hasSelectedFiles()` | `d.hasSelectedFilesUnsafe()` |
| `c.saveSession()` | `c.saveSessionUnsafe()` |

All public API methods (called from RPC handlers) already acquire their own locks and keep their original names.