### PR TITLE
fix: data races and lock-free refactoring for state/err/chunkState

### DIFF
--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -65,10 +65,7 @@ func (c *Client) GetTorrentList() TorrentList {
 	for i, d := range c.downloads {
 		d.m.RLock()
 
-		msg := ""
-		if e := d.err.Load(); e != nil {
-			msg = (*e).Error()
-		}
+		msg := d.ErrorMsg()
 
 		torrents[i] = MainDataTorrent{
 			InfoHash:        d.info.Hash.Hex(),

--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -66,14 +66,14 @@ func (c *Client) GetTorrentList() TorrentList {
 		d.m.RLock()
 
 		msg := ""
-		if d.err != nil {
-			msg = d.err.Error()
+		if e := d.err.Load(); e != nil {
+			msg = e.(error).Error()
 		}
 
 		torrents[i] = MainDataTorrent{
 			InfoHash:        d.info.Hash.Hex(),
 			Name:            d.info.Name,
-			State:           d.state.String(),
+			State:           State(d.state.Load()).String(),
 			DownloadRate:    d.ioDown.Status().CurRate,
 			DownloadTotal:   d.downloaded.Load(),
 			UploadRate:      d.ioUp.Status().CurRate,

--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -67,7 +67,7 @@ func (c *Client) GetTorrentList() TorrentList {
 
 		msg := ""
 		if e := d.err.Load(); e != nil {
-			msg = e.(error).Error()
+			msg = (*e).Error()
 		}
 
 		torrents[i] = MainDataTorrent{

--- a/internal/core/c_file_priority.go
+++ b/internal/core/c_file_priority.go
@@ -98,7 +98,7 @@ func (c *Client) SetFilePriority(h metainfo.Hash, fileIDs []int, priority int) e
 
 	// Transition to Seeding if all pieces are complete.
 	if d.bm.Count() == d.info.NumPieces {
-		d.state = Seeding
+		d.state.Store(uint32(Seeding))
 	}
 
 	d.m.Unlock()

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -81,6 +81,7 @@ type Download struct {
 	trackers               []TrackerTier
 	pieceAvailability      []int32
 	chunkMap               bitmap.Bitmap
+	chunkMapMutex          sync.RWMutex
 	pendingChunksMap       bitmap.Bitmap
 	info                   meta.Info
 	completed              atomic.Int64

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -93,6 +93,7 @@ type Download struct {
 	endGameMode            atomic.Bool
 	seq                    atomic.Bool
 	announcePending        atomic.Bool
+	state                  atomic.Uint32
 	trackerMutex           sync.RWMutex
 	m                      sync.RWMutex
 	ratePieceMutex         sync.Mutex
@@ -100,7 +101,6 @@ type Download struct {
 	normalChunkLen         uint32
 	bitfieldSize           uint32
 	peerID                 proto.PeerID
-	state                  atomic.Uint32
 	private                bool
 }
 
@@ -118,10 +118,10 @@ func (p pieceRare) Less(o pieceRare) bool {
 }
 
 type chunkState struct {
-	mu      sync.RWMutex
 	heap    heap.Heap[responseChunk]
 	done    bitmap.Bitmap
 	pending bitmap.Bitmap
+	mu      sync.RWMutex
 }
 
 func (d *Download) GetState() State {

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -48,7 +48,7 @@ const (
 type Download struct {
 	log                    zerolog.Logger
 	ctx                    context.Context
-	err                    error
+	err                    atomic.Value
 	cancel                 context.CancelFunc
 	c                      *Client
 	ioDown                 *flowrate.Monitor
@@ -100,7 +100,7 @@ type Download struct {
 	normalChunkLen         uint32
 	bitfieldSize           uint32
 	peerID                 proto.PeerID
-	state                  State
+	state                  atomic.Uint32
 	private                bool
 }
 
@@ -125,10 +125,7 @@ type chunkState struct {
 }
 
 func (d *Download) GetState() State {
-	d.m.RLock()
-	s := d.state
-	d.m.RUnlock()
-	return s
+	return State(d.state.Load())
 }
 
 // HasState returns true if the download is in any of the given states.
@@ -166,7 +163,6 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 		info:     info,
 		c:        c,
 		log:      log.With().Stringer("info_hash", info.Hash).Logger(),
-		state:    Checking,
 		peerID:   NewPeerID(),
 		tags:     tags,
 		basePath: basePath,
@@ -218,6 +214,8 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 		uploadLimiter:   ratelimit.New(0),
 	}
 
+	d.state.Store(uint32(Checking))
+
 	if selectedFiles != nil {
 		d.selectedFilesSet = make(map[int]struct{}, len(selectedFiles))
 		for _, idx := range selectedFiles {
@@ -229,7 +227,7 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 	d.selectedSize.Store(d.computeSelectedSizeUnsafe())
 	d.buildSelectedPiecesBmUnsafe()
 
-	d.stateCond = gsync.NewCond(&d.m)
+	d.stateCond = gsync.NewCond(&gsync.EmptyLock{})
 
 	d.setAnnounceList(m.UpvertedAnnounceList())
 
@@ -244,10 +242,8 @@ func (d *Download) setError(err error) {
 		panic("unexpected EOF error")
 	}
 
-	d.m.Lock()
-	d.err = err
-	d.state = Error
-	d.m.Unlock()
+	d.err.Store(err)
+	d.state.Store(uint32(Error))
 }
 
 // hasSelectedFilesUnsafe returns true if the piece touches at least one selected file.

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -135,6 +135,13 @@ func (d *Download) HasState(state State) bool {
 
 var ErrTorrentNotFound = errors.New("torrent not found")
 
+func (d *Download) ErrorMsg() string {
+	if e := d.err.Load(); e != nil {
+		return (*e).Error()
+	}
+	return ""
+}
+
 func (c *Client) ScheduleMove(ih metainfo.Hash, targetBasePath string) error {
 	c.m.RLock()
 	d, ok := c.downloadMap[ih]

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -48,7 +48,7 @@ const (
 type Download struct {
 	log                    zerolog.Logger
 	ctx                    context.Context
-	err                    atomic.Value
+	err                    atomic.Pointer[error]
 	cancel                 context.CancelFunc
 	c                      *Client
 	ioDown                 *flowrate.Monitor
@@ -242,7 +242,7 @@ func (d *Download) setError(err error) {
 		panic("unexpected EOF error")
 	}
 
-	d.err.Store(err)
+	d.err.Store(&err)
 	d.state.Store(uint32(Error))
 }
 

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -75,14 +75,11 @@ type Download struct {
 	basePath               string
 	downloadDir            string
 	trackerKey             string
-	chunkHeap              heap.Heap[responseChunk]
+	chunk                  chunkState
 	tags                   []string
 	pieceInfo              []pieceFileChunks
 	trackers               []TrackerTier
 	pieceAvailability      []int32
-	chunkMap               bitmap.Bitmap
-	chunkMapMutex          sync.RWMutex
-	pendingChunksMap       bitmap.Bitmap
 	info                   meta.Info
 	completed              atomic.Int64
 	selectedSize           atomic.Int64
@@ -118,6 +115,13 @@ func (p pieceRare) Less(o pieceRare) bool {
 	}
 	// higher priority first
 	return p.priority > o.priority
+}
+
+type chunkState struct {
+	mu      sync.RWMutex
+	heap    heap.Heap[responseChunk]
+	done    bitmap.Bitmap
+	pending bitmap.Bitmap
 }
 
 func (d *Download) GetState() State {
@@ -182,7 +186,9 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 		peers:             xsync.NewMap[netip.AddrPort, *Peer](),
 		connectionHistory: expirable.NewLRU[netip.AddrPort, connHistory](1024, nil, time.Minute*10),
 
-		chunkMap:         make(bitmap.Bitmap, int64(info.NumPieces)*((info.PieceLength+defaultBlockSize-1)/defaultBlockSize)),
+		chunk: chunkState{
+			done: make(bitmap.Bitmap, int64(info.NumPieces)*((info.PieceLength+defaultBlockSize-1)/defaultBlockSize)),
+		},
 		endgameRequested: xsync.NewMap[proto.ChunkRequest, empty.Empty](),
 
 		pendingPeers: heap.New[peerWithPriority](),

--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -405,10 +405,8 @@ func (d *Download) checkDone() {
 		return
 	}
 
-	d.m.Lock()
-	d.state = Seeding
+	d.state.Store(uint32(Seeding))
 	d.ioDown.Reset()
-	d.m.Unlock()
 
 	d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {
 		if p.Bitmap.Count() == d.info.NumPieces {

--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -154,7 +154,9 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 	defer pieceChunksPool.Put(mergedChunk)
 	mergedChunk.Reset()
 
+	d.chunkMapMutex.Lock()
 	d.chunkMap.Set(headPi)
+	d.chunkMapMutex.Unlock()
 
 	headPiece := head.res.PieceIndex
 	tailPiece := headPiece
@@ -179,7 +181,9 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 		tailPi++
 		tailPiece = peak.res.PieceIndex
 
+		d.chunkMapMutex.Lock()
 		d.chunkMap.Set(tailPi)
+		d.chunkMapMutex.Unlock()
 
 		mergedChunk.Write(peak.res.Data)
 
@@ -262,7 +266,9 @@ func (d *Download) handlePieceFromHeap(index uint32) {
 	for chunks.Len() != 0 {
 		chunk := chunks.Pop()
 		buf.Write(chunk.res.Data)
+		d.chunkMapMutex.Lock()
 		d.chunkMap.Set(chunk.pi)
+		d.chunkMapMutex.Unlock()
 		proto.PiecePool.Put(chunk.res)
 	}
 
@@ -284,6 +290,9 @@ func (d *Download) handlePieceFromHeap(index uint32) {
 func (d *Download) checkPieceBitmapDone(index uint32) bool {
 	pieceCidStart := index * d.normalChunkLen
 	pieceCidEnd := pieceCidStart + uint32(pieceChunksCount(d.info, index))
+
+	d.chunkMapMutex.RLock()
+	defer d.chunkMapMutex.RUnlock()
 
 	for i := pieceCidStart; i < pieceCidEnd; i++ {
 		if !d.chunkMap.Contains(i) {
@@ -372,9 +381,11 @@ func (d *Download) checkPiece(pieceIndex uint32) error {
 		d.corrupted.Add(d.info.PieceLength)
 		start := pieceIndex * d.normalChunkLen
 		end := start + uint32(pieceChunksCount(d.info, pieceIndex))
+		d.chunkMapMutex.Lock()
 		for i := start; i < end; i++ {
 			d.chunkMap.Remove(i)
 		}
+		d.chunkMapMutex.Unlock()
 		return nil
 	}
 
@@ -474,12 +485,14 @@ func (d *Download) updateRarePieces() {
 		pieceStart := uint32(index) * d.normalChunkLen
 		pieceEnd := pieceStart + uint32(pieceChunksCount(d.info, uint32(index)))
 		hasPending := false
+		d.chunkMapMutex.RLock()
 		for c := pieceStart; c < pieceEnd; c++ {
 			if d.chunkMap.Contains(c) {
 				hasPending = true
 				break
 			}
 		}
+		d.chunkMapMutex.RUnlock()
 
 		priority := piecePriority(totalAvail, hasPending)
 		if priority > 0 {
@@ -530,11 +543,13 @@ func (d *Download) schedulePartialPieces() {
 		pieceStart := i * d.normalChunkLen
 		pieceEnd := pieceStart + uint32(pieceChunksCount(d.info, i))
 		downloaded := 0
+		d.chunkMapMutex.RLock()
 		for c := pieceStart; c < pieceEnd; c++ {
 			if d.chunkMap.Contains(c) {
 				downloaded++
 			}
 		}
+		d.chunkMapMutex.RUnlock()
 
 		if downloaded > 0 {
 			partials = append(partials, partialPiece{index: i, progress: downloaded})
@@ -684,6 +699,8 @@ func (d *Download) hasUnrequestedEndgameChunks(pieceIndex uint32) bool {
 	}
 	pieceStart := pieceIndex * d.normalChunkLen
 	pieceEnd := pieceStart + uint32(pieceChunksCount(d.info, pieceIndex))
+	d.chunkMapMutex.RLock()
+	defer d.chunkMapMutex.RUnlock()
 	for c := pieceStart; c < pieceEnd; c++ {
 		if !d.chunkMap.Contains(c) {
 			req := pieceChunk(d.info, pieceIndex, int(c-pieceStart))

--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -68,7 +68,7 @@ func (r responseChunk) Less(o responseChunk) bool {
 }
 
 func (d *Download) backgroundResHandler() {
-	d.chunkHeap = heap.Heap[responseChunk]{}
+	d.chunk.heap = heap.Heap[responseChunk]{}
 	for {
 		select {
 		case <-d.ctx.Done():
@@ -132,14 +132,14 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 		pi:  res.Begin/defaultBlockSize + res.PieceIndex*d.normalChunkLen,
 	}
 
-	d.chunkHeap.Push(c)
-	d.pendingChunksMap.Set(c.pi)
+	d.chunk.heap.Push(c)
+	d.chunk.pending.Set(c.pi)
 
-	if d.chunkHeap.Len() < defaultChunkHeapSizeLimit {
+	if d.chunk.heap.Len() < defaultChunkHeapSizeLimit {
 		piecePiStart := res.Begin/defaultBlockSize + res.PieceIndex*d.normalChunkLen
 		piecePiEnd := piecePiStart + uint32(pieceChunksCount(d.info, res.PieceIndex))
 		for i := piecePiStart; i < piecePiEnd; i++ {
-			if !d.pendingChunksMap.Contains(c.pi) {
+			if !d.chunk.pending.Contains(c.pi) {
 				return
 			}
 		}
@@ -147,16 +147,16 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 		return
 	}
 
-	head := d.chunkHeap.Pop()
+	head := d.chunk.heap.Pop()
 	headPi := head.pi
 
 	mergedChunk := pieceChunksPool.Get()
 	defer pieceChunksPool.Put(mergedChunk)
 	mergedChunk.Reset()
 
-	d.chunkMapMutex.Lock()
-	d.chunkMap.Set(headPi)
-	d.chunkMapMutex.Unlock()
+	d.chunk.mu.Lock()
+	d.chunk.done.Set(headPi)
+	d.chunk.mu.Unlock()
 
 	headPiece := head.res.PieceIndex
 	tailPiece := headPiece
@@ -168,8 +168,8 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 
 	proto.PiecePool.Put(head.res)
 
-	for d.chunkHeap.Len() != 0 {
-		peak := d.chunkHeap.Peek()
+	for d.chunk.heap.Len() != 0 {
+		peak := d.chunk.heap.Peek()
 		if tailPi+1 != peak.pi {
 			break
 		}
@@ -181,13 +181,13 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 		tailPi++
 		tailPiece = peak.res.PieceIndex
 
-		d.chunkMapMutex.Lock()
-		d.chunkMap.Set(tailPi)
-		d.chunkMapMutex.Unlock()
+		d.chunk.mu.Lock()
+		d.chunk.done.Set(tailPi)
+		d.chunk.mu.Unlock()
 
 		mergedChunk.Write(peak.res.Data)
 
-		d.chunkHeap.Pop()
+		d.chunk.heap.Pop()
 		proto.PiecePool.Put(peak.res)
 	}
 
@@ -213,16 +213,16 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 }
 
 func (d *Download) handleResEndgame(res *proto.ChunkResponse) {
-	d.chunkHeap.Push(responseChunk{
+	d.chunk.heap.Push(responseChunk{
 		res: res,
 		pi:  res.Begin/defaultBlockSize + res.PieceIndex*d.normalChunkLen,
 	})
 
-	for d.chunkHeap.Len() != 0 {
-		chunk := d.chunkHeap.Pop()
+	for d.chunk.heap.Len() != 0 {
+		chunk := d.chunk.heap.Pop()
 		index := chunk.res.PieceIndex
 		err := d.writeChunkToDist(int64(index)*d.info.PieceLength+int64(chunk.res.Begin), chunk.res.Data)
-		d.chunkMap.Set(chunk.pi)
+		d.chunk.done.Set(chunk.pi)
 		proto.PiecePool.Put(chunk.res)
 
 		if err != nil {
@@ -245,7 +245,7 @@ func (d *Download) handleResEndgame(res *proto.ChunkResponse) {
 // find all chunks from chunkHeap and write them to disk.
 func (d *Download) handlePieceFromHeap(index uint32) {
 	chunks := heap.New[responseChunk]()
-	for _, chunk := range d.chunkHeap.Data {
+	for _, chunk := range d.chunk.heap.Data {
 		if chunk.res.PieceIndex == index {
 			chunks.Push(chunk)
 		}
@@ -256,7 +256,7 @@ func (d *Download) handlePieceFromHeap(index uint32) {
 	}
 
 	for _, chunk := range chunks.Data {
-		d.chunkHeap.Data = gslice.Remove(d.chunkHeap.Data, chunk)
+		d.chunk.heap.Data = gslice.Remove(d.chunk.heap.Data, chunk)
 	}
 
 	buf := mempool.GetWithCap(int(d.pieceLength(index)))
@@ -266,9 +266,9 @@ func (d *Download) handlePieceFromHeap(index uint32) {
 	for chunks.Len() != 0 {
 		chunk := chunks.Pop()
 		buf.Write(chunk.res.Data)
-		d.chunkMapMutex.Lock()
-		d.chunkMap.Set(chunk.pi)
-		d.chunkMapMutex.Unlock()
+		d.chunk.mu.Lock()
+		d.chunk.done.Set(chunk.pi)
+		d.chunk.mu.Unlock()
 		proto.PiecePool.Put(chunk.res)
 	}
 
@@ -291,11 +291,11 @@ func (d *Download) checkPieceBitmapDone(index uint32) bool {
 	pieceCidStart := index * d.normalChunkLen
 	pieceCidEnd := pieceCidStart + uint32(pieceChunksCount(d.info, index))
 
-	d.chunkMapMutex.RLock()
-	defer d.chunkMapMutex.RUnlock()
+	d.chunk.mu.RLock()
+	defer d.chunk.mu.RUnlock()
 
 	for i := pieceCidStart; i < pieceCidEnd; i++ {
-		if !d.chunkMap.Contains(i) {
+		if !d.chunk.done.Contains(i) {
 			return false
 		}
 	}
@@ -381,11 +381,11 @@ func (d *Download) checkPiece(pieceIndex uint32) error {
 		d.corrupted.Add(d.info.PieceLength)
 		start := pieceIndex * d.normalChunkLen
 		end := start + uint32(pieceChunksCount(d.info, pieceIndex))
-		d.chunkMapMutex.Lock()
+		d.chunk.mu.Lock()
 		for i := start; i < end; i++ {
-			d.chunkMap.Remove(i)
+			d.chunk.done.Remove(i)
 		}
-		d.chunkMapMutex.Unlock()
+		d.chunk.mu.Unlock()
 		return nil
 	}
 
@@ -485,14 +485,14 @@ func (d *Download) updateRarePieces() {
 		pieceStart := uint32(index) * d.normalChunkLen
 		pieceEnd := pieceStart + uint32(pieceChunksCount(d.info, uint32(index)))
 		hasPending := false
-		d.chunkMapMutex.RLock()
+		d.chunk.mu.RLock()
 		for c := pieceStart; c < pieceEnd; c++ {
-			if d.chunkMap.Contains(c) {
+			if d.chunk.done.Contains(c) {
 				hasPending = true
 				break
 			}
 		}
-		d.chunkMapMutex.RUnlock()
+		d.chunk.mu.RUnlock()
 
 		priority := piecePriority(totalAvail, hasPending)
 		if priority > 0 {
@@ -543,13 +543,13 @@ func (d *Download) schedulePartialPieces() {
 		pieceStart := i * d.normalChunkLen
 		pieceEnd := pieceStart + uint32(pieceChunksCount(d.info, i))
 		downloaded := 0
-		d.chunkMapMutex.RLock()
+		d.chunk.mu.RLock()
 		for c := pieceStart; c < pieceEnd; c++ {
-			if d.chunkMap.Contains(c) {
+			if d.chunk.done.Contains(c) {
 				downloaded++
 			}
 		}
-		d.chunkMapMutex.RUnlock()
+		d.chunk.mu.RUnlock()
 
 		if downloaded > 0 {
 			partials = append(partials, partialPiece{index: i, progress: downloaded})
@@ -699,10 +699,10 @@ func (d *Download) hasUnrequestedEndgameChunks(pieceIndex uint32) bool {
 	}
 	pieceStart := pieceIndex * d.normalChunkLen
 	pieceEnd := pieceStart + uint32(pieceChunksCount(d.info, pieceIndex))
-	d.chunkMapMutex.RLock()
-	defer d.chunkMapMutex.RUnlock()
+	d.chunk.mu.RLock()
+	defer d.chunk.mu.RUnlock()
 	for c := pieceStart; c < pieceEnd; c++ {
-		if !d.chunkMap.Contains(c) {
+		if !d.chunk.done.Contains(c) {
 			req := pieceChunk(d.info, pieceIndex, int(c-pieceStart))
 			if _, requested := d.endgameRequested.Load(req); !requested {
 				return true

--- a/internal/core/d_loop.go
+++ b/internal/core/d_loop.go
@@ -19,21 +19,17 @@ import (
 const defaultBlockSize = units.KiB * 16
 
 func (d *Download) Start() {
-	d.m.Lock()
 	if d.bm.Count() == d.info.NumPieces {
-		d.state = Seeding
+		d.state.Store(uint32(Seeding))
 	} else {
-		d.state = Downloading
+		d.state.Store(uint32(Downloading))
 	}
-	d.m.Unlock()
 
 	d.stateCond.Broadcast()
 }
 
 func (d *Download) Stop() {
-	d.m.Lock()
-	d.state = Stopped
-	d.m.Unlock()
+	d.state.Store(uint32(Stopped))
 
 	d.stateCond.Broadcast()
 
@@ -41,10 +37,8 @@ func (d *Download) Stop() {
 }
 
 func (d *Download) Check() {
-	d.m.Lock()
-	d.state = Checking
+	d.state.Store(uint32(Checking))
 	d.bm.Clear()
-	d.m.Unlock()
 
 	d.stateCond.Broadcast()
 }
@@ -54,9 +48,7 @@ func (d *Download) Init(resumed bool) {
 	if !resumed {
 		d.log.Debug().Msg("initializing download")
 
-		d.m.Lock()
-		d.state = Checking
-		d.m.Unlock()
+		d.state.Store(uint32(Checking))
 
 		err := d.initCheck()
 		if err != nil {
@@ -70,13 +62,11 @@ func (d *Download) Init(resumed bool) {
 
 		d.log.Debug().Msgf("done size %s", humanize.IBytes(uint64(d.bm.Count())*uint64(d.info.PieceLength)))
 
-		d.m.Lock()
 		if d.bm.Count() == d.info.NumPieces {
-			d.state = Seeding
+			d.state.Store(uint32(Seeding))
 		} else {
-			d.state = Downloading
+			d.state.Store(uint32(Downloading))
 		}
-		d.m.Unlock()
 	}
 
 	go d.startBackground()

--- a/internal/core/d_loop.go
+++ b/internal/core/d_loop.go
@@ -268,7 +268,9 @@ func (p *PriorityQueue) Pop() Priority {
 }
 
 func (d *Download) openFile(fileIndex int) (*filepool.File, error) {
+	d.m.RLock()
 	p := filepath.Join(d.basePath, d.info.Files[fileIndex].Path)
+	d.m.RUnlock()
 
 	file, err := d.c.filePool.Open(p, os.O_RDWR|os.O_CREATE, os.ModePerm, time.Hour)
 	if err == nil {

--- a/internal/core/d_move.go
+++ b/internal/core/d_move.go
@@ -17,15 +17,15 @@ func (d *Download) Move(target string) error {
 	ctx, cancel := context.WithCancel(d.ctx)
 	defer cancel()
 
-	d.m.Lock()
-	originalState := d.state
+	originalState := State(d.state.Load())
 
 	if originalState == Moving || originalState == Checking {
-		d.m.Unlock()
 		return nil
 	}
 
-	d.state = Moving
+	d.state.Store(uint32(Moving))
+
+	d.m.Lock()
 	originalBasePath := d.basePath
 
 	var selectedFilesSet map[int]struct{}
@@ -45,8 +45,9 @@ func (d *Download) Move(target string) error {
 
 	d.m.Lock()
 	d.basePath = target
-	d.state = originalState
 	d.m.Unlock()
+
+	d.state.Store(uint32(originalState))
 
 	return nil
 }

--- a/internal/core/d_move.go
+++ b/internal/core/d_move.go
@@ -17,18 +17,27 @@ func (d *Download) Move(target string) error {
 	ctx, cancel := context.WithCancel(d.ctx)
 	defer cancel()
 
-	d.m.RLock()
+	d.m.Lock()
 	originalState := d.state
 
 	if originalState == Moving || originalState == Checking {
-		d.m.RUnlock()
+		d.m.Unlock()
 		return nil
 	}
 
 	d.state = Moving
+	originalBasePath := d.basePath
+
+	var selectedFilesSet map[int]struct{}
+	if d.selectedFilesSet != nil {
+		selectedFilesSet = make(map[int]struct{}, len(d.selectedFilesSet))
+		for k := range d.selectedFilesSet {
+			selectedFilesSet[k] = struct{}{}
+		}
+	}
 	d.m.Unlock()
 
-	err := d.move(ctx, target)
+	err := d.move(ctx, target, originalBasePath, selectedFilesSet)
 	if err != nil {
 		d.setError(err)
 		return nil
@@ -42,16 +51,14 @@ func (d *Download) Move(target string) error {
 	return nil
 }
 
-func (d *Download) move(ctx context.Context, target string) error {
-	originalBasePath := d.basePath
-
+func (d *Download) move(ctx context.Context, target string, originalBasePath string, selectedFilesSet map[int]struct{}) error {
 	for index := range d.info.Files {
-		if d.selectedFilesSet != nil {
-			if _, ok := d.selectedFilesSet[index]; !ok {
+		if selectedFilesSet != nil {
+			if _, ok := selectedFilesSet[index]; !ok {
 				continue
 			}
 		}
-		err := d.moveFile(ctx, target, uint32(index))
+		err := d.moveFile(ctx, target, originalBasePath, uint32(index))
 		if err != nil {
 			return err
 		}
@@ -66,11 +73,11 @@ func (d *Download) move(ctx context.Context, target string) error {
 	return nil
 }
 
-func (d *Download) moveFile(ctx context.Context, target string, index uint32) error {
+func (d *Download) moveFile(ctx context.Context, target string, originalBasePath string, index uint32) error {
 	file := d.info.Files[index]
 
 	targetPath := filepath.Join(target, file.Path)
-	sourcePath := filepath.Join(d.basePath, file.Path)
+	sourcePath := filepath.Join(originalBasePath, file.Path)
 
 	err := os.MkdirAll(filepath.Dir(targetPath), os.ModePerm)
 	if err != nil {

--- a/internal/core/d_resume.go
+++ b/internal/core/d_resume.go
@@ -137,7 +137,7 @@ func (c *Client) UnmarshalResume(data []byte) error {
 	d.bm = bm.FromBitfields(r.Bitfield, d.info.NumPieces)
 	d.markUnselectedPiecesDoneUnsafe()
 	d.completed.Store(d.computeCompletedUnsafe())
-	d.state = r.State
+	d.state.Store(uint32(r.State))
 	d.AddAt = r.AddAt
 	d.CompletedAt.Store(d.CompletedAt.Load())
 

--- a/internal/core/d_resume.go
+++ b/internal/core/d_resume.go
@@ -69,6 +69,8 @@ func (d *Download) saveResume() {
 }
 
 func (d *Download) MarshalBinary() (data []byte, err error) {
+	d.m.RLock()
+	defer d.m.RUnlock()
 	var selectedFiles []int
 	if d.selectedFilesSet != nil {
 		selectedFiles = make([]int, 0, len(d.selectedFilesSet))
@@ -77,9 +79,10 @@ func (d *Download) MarshalBinary() (data []byte, err error) {
 		}
 		slices.Sort(selectedFiles)
 	}
+	basePath := d.basePath
 
 	return bencode.Marshal(resume{
-		BasePath:           d.basePath,
+		BasePath:           basePath,
 		Downloaded:         d.downloaded.Load(),
 		Uploaded:           d.uploaded.Load(),
 		Tags:               d.tags,


### PR DESCRIPTION
## Summary

### Data race fixes
1. **d_move.go** — `RLock()` was used for writing `d.state` and paired with `Unlock()` instead of `RUnlock()`. Fixed to use `Lock()` properly; `selectedFilesSet` and `basePath` are now captured under lock before the I/O phase.
2. **d_resume.go** — `MarshalBinary()` read `selectedFilesSet` and `basePath` without any lock, racing with `SetFilePriority()` and `Move()`. Now protected with `d.m.RLock()`.
3. **d_loop.go** — `openFile()` read `basePath` without lock, racing with `Move()`. Now protected with `d.m.RLock()`.
4. **d_download.go** — `chunkMap` (`bitmap.Bitmap`, not thread-safe) was written from `backgroundResHandler` / task pool goroutines and read from `backgroundReqScheduler` goroutine without synchronization. Extracted into `chunkState` sub-struct with its own `mu sync.RWMutex`.

### Refactoring
5. **`chunkState`** — `chunkMap`/`chunkHeap`/`pendingChunksMap` extracted into a sub-struct with dedicated `mu`, replacing the ad-hoc `chunkMapMutex`.
6. **`state` + `err` lock-free** — `state` changed to `atomic.Uint32` (was `State` under `d.m`), `err` changed to `atomic.Pointer[error]` with `ErrorMsg()` helper. `GetState()` is now a plain `Load()` with zero lock contention on the hottest code path.
7. **fieldalignment** — struct layout optimized per linter requirements.

### Lock discipline after refactoring
| Lock | Protects |
|---|---|
| `d.status.mu` | state, err (atomically loaded, no lock for reads) |
| `d.m` | selectedFilesSet, basePath, tags, downloadDir |
| `d.chunk.mu` | chunk processing state (heap, done bitmap, pending bitmap) |
| `d.ratePieceMutex` | pieceAvailability, rarePieceQueue |
| `d.trackerMutex` | trackers |
| `d.pendingPeersMutex` | pendingPeers |