### PR TITLE
ci: update golangci-lint to v2.12.2 and fix lint issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,7 +107,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.11.4
+          version: v2.12.2
 
   dprint:
     runs-on: ubuntu-latest

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,6 +25,7 @@ linters:
     - gocritic
     - gocyclo
     - godox
+    - gomodguard
     - gosec
     - ireturn
     - lll

--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -32,6 +32,8 @@ import (
 	"neptune/internal/pkg/gslice"
 )
 
+const colAddress = "address"
+
 type MainDataTorrent struct {
 	InfoHash        string   `json:"hash"`
 	Name            string   `json:"name"`
@@ -430,7 +432,7 @@ func debugPrintTrackers(w io.Writer, d *Download) {
 func debugPrintPeers(w io.Writer, d *Download) {
 	t := table.NewWriter()
 
-	t.AppendHeader(table.Row{"address", "down rate", "up rate", "our req",
+	t.AppendHeader(table.Row{colAddress, "down rate", "up rate", "our req",
 		"queue piece", "client", "progress",
 		"peer choke", "peer interest", "our choke", "our interest", "fast", "peer req", "peer id"})
 
@@ -455,7 +457,7 @@ func debugPrintPeers(w io.Writer, d *Download) {
 		return true
 	})
 
-	t.SortBy([]table.SortBy{{Name: "address"}})
+	t.SortBy([]table.SortBy{{Name: colAddress}})
 
 	_, _ = io.WriteString(w, t.Render())
 	_, _ = fmt.Fprintln(w)
@@ -466,8 +468,8 @@ func debugPrintPendingPeers(w io.Writer, d *Download) {
 	defer d.pendingPeersMutex.Unlock()
 
 	t := table.NewWriter()
-	t.AppendHeader(table.Row{"address"})
-	t.SortBy([]table.SortBy{{Name: "address"}})
+	t.AppendHeader(table.Row{colAddress})
+	t.SortBy([]table.SortBy{{Name: colAddress}})
 
 	for _, item := range d.pendingPeers.Data {
 		t.AppendRow(table.Row{item.addrPort.String()})

--- a/internal/web/e2e_test.go
+++ b/internal/web/e2e_test.go
@@ -20,6 +20,12 @@ import (
 	"neptune/internal/web"
 )
 
+const (
+	keyInfoHash = "info_hash"
+	keyTags     = "tags"
+	keyLimit    = "limit"
+)
+
 type jsonrpcReq struct {
 	Params  any    `json:"params,omitempty"`
 	JSONRPC string `json:"jsonrpc"`
@@ -151,13 +157,13 @@ func TestE2E(t *testing.T) {
 	t.Run("torrent.add", func(t *testing.T) {
 		resp := makeJSONRPCRequest(t, url, token, "torrent.add", map[string]any{
 			"torrent_file": torrentData,
-			"tags":         []string{"test", "e2e"},
+			keyTags:        []string{"test", "e2e"},
 		})
 		requireNoRPCError(t, resp)
 
 		var r map[string]string
 		require.NoError(t, json.Unmarshal(resp.Result, &r))
-		infoHash = r["info_hash"]
+		infoHash = r[keyInfoHash]
 		require.Len(t, infoHash, 40)
 	})
 
@@ -169,14 +175,14 @@ func TestE2E(t *testing.T) {
 	// ---------------------------------------------------------------------------
 	t.Run("torrent.get", func(t *testing.T) {
 		resp := makeJSONRPCRequest(t, url, token, "torrent.get", map[string]string{
-			"info_hash": infoHash,
+			keyInfoHash: infoHash,
 		})
 		requireNoRPCError(t, resp)
 
 		var r map[string]any
 		require.NoError(t, json.Unmarshal(resp.Result, &r))
 		require.Equal(t, "archlinux-2011.08.19-netinstall-i686.iso", r["name"])
-		require.NotNil(t, r["tags"])
+		require.NotNil(t, r[keyTags])
 	})
 
 	// ---------------------------------------------------------------------------
@@ -199,7 +205,7 @@ func TestE2E(t *testing.T) {
 	// ---------------------------------------------------------------------------
 	t.Run("torrent.files", func(t *testing.T) {
 		resp := makeJSONRPCRequest(t, url, token, "torrent.files", map[string]string{
-			"info_hash": infoHash,
+			keyInfoHash: infoHash,
 		})
 		requireNoRPCError(t, resp)
 	})
@@ -209,7 +215,7 @@ func TestE2E(t *testing.T) {
 	// ---------------------------------------------------------------------------
 	t.Run("torrent.peers", func(t *testing.T) {
 		resp := makeJSONRPCRequest(t, url, token, "torrent.peers", map[string]string{
-			"info_hash": infoHash,
+			keyInfoHash: infoHash,
 		})
 		requireNoRPCError(t, resp)
 	})
@@ -219,7 +225,7 @@ func TestE2E(t *testing.T) {
 	// ---------------------------------------------------------------------------
 	t.Run("torrent.trackers", func(t *testing.T) {
 		resp := makeJSONRPCRequest(t, url, token, "torrent.trackers", map[string]string{
-			"info_hash": infoHash,
+			keyInfoHash: infoHash,
 		})
 		requireNoRPCError(t, resp)
 	})
@@ -229,19 +235,19 @@ func TestE2E(t *testing.T) {
 	// ---------------------------------------------------------------------------
 	t.Run("torrent.add_tags", func(t *testing.T) {
 		resp := makeJSONRPCRequest(t, url, token, "torrent.add_tags", map[string]any{
-			"info_hash": infoHash,
-			"tags":      []string{"added"},
+			keyInfoHash: infoHash,
+			keyTags:     []string{"added"},
 		})
 		requireNoRPCError(t, resp)
 
 		// Verify tag was added
 		resp = makeJSONRPCRequest(t, url, token, "torrent.get", map[string]string{
-			"info_hash": infoHash,
+			keyInfoHash: infoHash,
 		})
 		requireNoRPCError(t, resp)
 		var r map[string]any
 		require.NoError(t, json.Unmarshal(resp.Result, &r))
-		tags, ok := r["tags"].([]any)
+		tags, ok := r[keyTags].([]any)
 		require.True(t, ok)
 		require.Contains(t, tags, "added")
 	})
@@ -251,19 +257,19 @@ func TestE2E(t *testing.T) {
 	// ---------------------------------------------------------------------------
 	t.Run("torrent.remove_tags", func(t *testing.T) {
 		resp := makeJSONRPCRequest(t, url, token, "torrent.remove_tags", map[string]any{
-			"info_hash": infoHash,
-			"tags":      []string{"added"},
+			keyInfoHash: infoHash,
+			keyTags:     []string{"added"},
 		})
 		requireNoRPCError(t, resp)
 
 		// Verify tag was removed
 		resp = makeJSONRPCRequest(t, url, token, "torrent.get", map[string]string{
-			"info_hash": infoHash,
+			keyInfoHash: infoHash,
 		})
 		requireNoRPCError(t, resp)
 		var r map[string]any
 		require.NoError(t, json.Unmarshal(resp.Result, &r))
-		tags, ok := r["tags"].([]any)
+		tags, ok := r[keyTags].([]any)
 		require.True(t, ok)
 		require.NotContains(t, tags, "added")
 	})
@@ -273,7 +279,7 @@ func TestE2E(t *testing.T) {
 	// ---------------------------------------------------------------------------
 	t.Run("torrent.set_file_priority", func(t *testing.T) {
 		resp := makeJSONRPCRequest(t, url, token, "torrent.set_file_priority", map[string]any{
-			"info_hash": infoHash,
+			keyInfoHash: infoHash,
 			"file_ids":  []int{0},
 			"priority":  0,
 		})
@@ -285,8 +291,8 @@ func TestE2E(t *testing.T) {
 	// ---------------------------------------------------------------------------
 	t.Run("torrent.set_download_limit", func(t *testing.T) {
 		resp := makeJSONRPCRequest(t, url, token, "torrent.set_download_limit", map[string]any{
-			"info_hash": infoHash,
-			"limit":     int64(1024 * 1024),
+			keyInfoHash: infoHash,
+			keyLimit:    int64(1024 * 1024),
 		})
 		requireNoRPCError(t, resp)
 	})
@@ -296,8 +302,8 @@ func TestE2E(t *testing.T) {
 	// ---------------------------------------------------------------------------
 	t.Run("torrent.set_upload_limit", func(t *testing.T) {
 		resp := makeJSONRPCRequest(t, url, token, "torrent.set_upload_limit", map[string]any{
-			"info_hash": infoHash,
-			"limit":     int64(512 * 1024),
+			keyInfoHash: infoHash,
+			keyLimit:    int64(512 * 1024),
 		})
 		requireNoRPCError(t, resp)
 	})
@@ -307,7 +313,7 @@ func TestE2E(t *testing.T) {
 	// ---------------------------------------------------------------------------
 	t.Run("torrent.stop", func(t *testing.T) {
 		resp := makeJSONRPCRequest(t, url, token, "torrent.stop", map[string]string{
-			"info_hash": infoHash,
+			keyInfoHash: infoHash,
 		})
 		requireNoRPCError(t, resp)
 	})
@@ -317,7 +323,7 @@ func TestE2E(t *testing.T) {
 	// ---------------------------------------------------------------------------
 	t.Run("torrent.start", func(t *testing.T) {
 		resp := makeJSONRPCRequest(t, url, token, "torrent.start", map[string]string{
-			"info_hash": infoHash,
+			keyInfoHash: infoHash,
 		})
 		requireNoRPCError(t, resp)
 	})
@@ -327,7 +333,7 @@ func TestE2E(t *testing.T) {
 	// ---------------------------------------------------------------------------
 	t.Run("torrent.stop_before_resume", func(t *testing.T) {
 		resp := makeJSONRPCRequest(t, url, token, "torrent.stop", map[string]string{
-			"info_hash": infoHash,
+			keyInfoHash: infoHash,
 		})
 		requireNoRPCError(t, resp)
 	})
@@ -337,7 +343,7 @@ func TestE2E(t *testing.T) {
 	// ---------------------------------------------------------------------------
 	t.Run("torrent.resume", func(t *testing.T) {
 		resp := makeJSONRPCRequest(t, url, token, "torrent.resume", map[string]string{
-			"info_hash": infoHash,
+			keyInfoHash: infoHash,
 		})
 		requireNoRPCError(t, resp)
 	})
@@ -347,7 +353,7 @@ func TestE2E(t *testing.T) {
 	// ---------------------------------------------------------------------------
 	t.Run("client.set_download_limit", func(t *testing.T) {
 		resp := makeJSONRPCRequest(t, url, token, "client.set_download_limit", map[string]any{
-			"limit": int64(2048 * 1024),
+			keyLimit: int64(2048 * 1024),
 		})
 		requireNoRPCError(t, resp)
 	})
@@ -357,7 +363,7 @@ func TestE2E(t *testing.T) {
 	// ---------------------------------------------------------------------------
 	t.Run("client.set_upload_limit", func(t *testing.T) {
 		resp := makeJSONRPCRequest(t, url, token, "client.set_upload_limit", map[string]any{
-			"limit": int64(1024 * 1024),
+			keyLimit: int64(1024 * 1024),
 		})
 		requireNoRPCError(t, resp)
 	})
@@ -367,7 +373,7 @@ func TestE2E(t *testing.T) {
 	// ---------------------------------------------------------------------------
 	t.Run("torrent.remove", func(t *testing.T) {
 		resp := makeJSONRPCRequest(t, url, token, "torrent.remove", map[string]any{
-			"info_hash":   infoHash,
+			keyInfoHash:   infoHash,
 			"delete_data": true,
 		})
 		requireNoRPCError(t, resp)
@@ -407,7 +413,7 @@ func TestE2E(t *testing.T) {
 	// ---------------------------------------------------------------------------
 	t.Run("error_invalid_infohash", func(t *testing.T) {
 		resp := makeJSONRPCRequest(t, url, token, "torrent.get", map[string]string{
-			"info_hash": "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+			keyInfoHash: "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
 		})
 		requireRPCError(t, resp, 1)
 	})


### PR DESCRIPTION
- Bump golangci-lint from v2.11.4 to v2.12.2 in CI
- Disable deprecated `gomodguard` linter (replaced by `gomodguard_v2`)
- Extract repeated string literals to constants to fix goconst warnings