### PR TITLE
feat: add soft memory budget for cache and buffer allocations

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,7 +25,11 @@ type Application struct {
 	GlobalDownloadSpeedLimit int64 `toml:"global-download-speed-limit"`
 	// Global upload speed limit in bytes per second. 0 means unlimited.
 	GlobalUploadSpeedLimit int64 `toml:"global-upload-speed-limit"`
-	Fallocate              bool  `toml:"fallocate"`
+	// Soft memory limit in bytes. When process memory approaches this limit,
+	// the client will reduce connections and upload slots to relieve pressure.
+	// 0 means auto (80% of GOMEMLIMIT set by automemlimit/cgroup).
+	SoftMemoryLimit int64 `toml:"soft-memory-limit"`
+	Fallocate       bool  `toml:"fallocate"`
 }
 
 type Config struct {

--- a/internal/core/c.go
+++ b/internal/core/c.go
@@ -101,6 +101,9 @@ func New(cfg config.Config, sessionPath string, debug bool) *Client {
 		ipv4:    *atomic.NewPointer(v4),
 		ipv6:    *atomic.NewPointer(v6),
 		debug:   debug,
+
+		softMemoryLimit: cfg.App.SoftMemoryLimit,
+		memBudget:       newMemoryBudget(cfg.App.SoftMemoryLimit),
 	}
 
 	c.startUploadPool()
@@ -116,6 +119,17 @@ func (c *Client) initMetrics() {
 	}, func() float64 {
 		return float64(c.connectionCount.Load())
 	}))
+
+	prometheus.MustRegister(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "neptune_cache_memory_used_bytes",
+		Help: "Current cache memory budget usage in bytes",
+	}, func() float64 {
+		if c.memBudget == nil {
+			return 0
+		}
+
+		return float64(c.memBudget.Used())
+	}))
 }
 
 type incomingConn struct {
@@ -124,39 +138,32 @@ type incomingConn struct {
 }
 
 type Client struct {
-	ctx         context.Context
-	http        *resty.Client
-	cancel      context.CancelFunc
-	downloadMap map[metainfo.Hash]*Download
-	connChan    chan incomingConn
-	sem         *semaphore.Weighted
-	uploadQ     chan uploadTask
-	fh          map[string]*os.File
-
-	ioDown *flowrate.Monitor
-	ioUp   *flowrate.Monitor
-
+	ctx             context.Context
+	ipv6            atomic.Pointer[netip.Addr]
 	downloadLimiter *ratelimit.Limiter
+	downloadMap     map[metainfo.Hash]*Download
+	connChan        chan incomingConn
+	sem             *semaphore.Weighted
+	uploadQ         chan uploadTask
+	fh              map[string]*os.File
+	ioDown          *flowrate.Monitor
+	ioUp            *flowrate.Monitor
+	ipv4            atomic.Pointer[netip.Addr]
 	uploadLimiter   *ratelimit.Limiter
-
-	filePool *filepool.FilePool
-
-	ipv4 atomic.Pointer[netip.Addr]
-	ipv6 atomic.Pointer[netip.Addr]
-
-	dht *dht.DHT
-
-	resumePath  string
-	torrentPath string
-
-	infoHashes []metainfo.Hash
-	downloads  []*Download
-	checkQueue []metainfo.Hash
-
-	randKey []byte
-
+	dht             *dht.DHT
+	cancel          context.CancelFunc
+	memBudget       *memoryBudget
+	filePool        *filepool.FilePool
+	http            *resty.Client
+	torrentPath     string
+	resumePath      string
+	checkQueue      []metainfo.Hash
+	downloads       []*Download
+	randKey         []byte
+	infoHashes      []metainfo.Hash
 	Config          config.Config
 	connectionCount atomic.Uint32
+	softMemoryLimit int64
 	m               sync.RWMutex
 	debug           bool
 }

--- a/internal/core/c_memory.go
+++ b/internal/core/c_memory.go
@@ -1,0 +1,78 @@
+// Copyright 2024 trim21 <trim21.me@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package core
+
+import (
+	"go.uber.org/atomic"
+)
+
+// memoryBudget is a soft memory limit enforced via atomic counter.
+// Callers acquire bytes before allocating cache/buffer memory and
+// release bytes when the cached data is flushed or consumed.
+// When the budget is exhausted, TryAcquire returns false and callers
+// should shed load (drop responses, skip uploads).
+type memoryBudget struct {
+	limit int64
+	used  atomic.Int64
+}
+
+func newMemoryBudget(limit int64) *memoryBudget {
+	return &memoryBudget{limit: limit}
+}
+
+// TryAcquire attempts to reserve n bytes. Returns false if over limit.
+func (b *memoryBudget) TryAcquire(n int64) bool {
+	if b == nil || b.limit <= 0 {
+		return true
+	}
+
+	for {
+		old := b.used.Load()
+		newVal := old + n
+		if newVal > b.limit {
+			return false
+		}
+
+		if b.used.CompareAndSwap(old, newVal) {
+			return true
+		}
+	}
+}
+
+// ForceAcquire reserves n bytes unconditionally. May exceed the limit.
+// Use when data is already allocated and cannot be dropped.
+func (b *memoryBudget) ForceAcquire(n int64) {
+	if b == nil || b.limit <= 0 {
+		return
+	}
+
+	b.used.Add(n)
+}
+
+// Release returns n bytes to the budget.
+func (b *memoryBudget) Release(n int64) {
+	if b == nil || b.limit <= 0 {
+		return
+	}
+
+	b.used.Add(-n)
+}
+
+// Available returns true if usage is under the limit.
+func (b *memoryBudget) Available() bool {
+	if b == nil || b.limit <= 0 {
+		return true
+	}
+
+	return b.used.Load() < b.limit
+}
+
+// Used returns currently reserved bytes.
+func (b *memoryBudget) Used() int64 {
+	if b == nil {
+		return 0
+	}
+
+	return b.used.Load()
+}

--- a/internal/core/c_upload_pool.go
+++ b/internal/core/c_upload_pool.go
@@ -53,56 +53,64 @@ func (c *Client) uploadWorker() {
 		case <-c.ctx.Done():
 			return
 		case t := <-c.uploadQ:
-			d := t.d
-			p := t.peer
-
-			if d == nil || p == nil {
-				continue
-			}
-			if d.ctx.Err() != nil || p.closed.Load() {
-				continue
-			}
-			if d.GetState()&(Downloading|Seeding) == 0 {
-				continue
-			}
-
-			res := proto.PiecePool.Get()
-			res.PieceIndex = t.req.PieceIndex
-			res.Begin = t.req.Begin
-
-			if t.data != nil {
-				res.Data = append(res.Data[:0], t.data...)
-			} else {
-				res.Data = slices.Grow(res.Data[:0], int(t.req.Length))[:t.req.Length]
-
-				err := d.readPieceRangeCtx(d.ctx, t.req, res.Data)
-				if err != nil {
-					proto.PiecePool.Put(res)
-					if err == errUploadPaused || err == context.Canceled {
-						continue
-					}
-					d.setError(err)
-					p.close()
-					continue
-				}
-			}
-
-			// Rate limit: block before sending to the network.
-			if err := d.uploadLimiter.Wait(d.ctx, len(res.Data)); err != nil {
-				proto.PiecePool.Put(res)
-				continue
-			}
-			if err := d.c.uploadLimiter.Wait(d.ctx, len(res.Data)); err != nil {
-				proto.PiecePool.Put(res)
-				continue
-			}
-
-			if p.Response(res) {
-				d.ioUp.Update(len(res.Data))
-				d.c.ioUp.Update(len(res.Data))
-				d.uploaded.Add(int64(len(res.Data)))
-			}
-			proto.PiecePool.Put(res)
+			c.processUploadTask(t)
 		}
 	}
+}
+
+func (c *Client) processUploadTask(t uploadTask) {
+	if t.data != nil {
+		defer c.memBudget.Release(int64(len(t.data)))
+	}
+
+	d := t.d
+	p := t.peer
+
+	if d == nil || p == nil {
+		return
+	}
+	if d.ctx.Err() != nil || p.closed.Load() {
+		return
+	}
+	if d.GetState()&(Downloading|Seeding) == 0 {
+		return
+	}
+
+	res := proto.PiecePool.Get()
+	res.PieceIndex = t.req.PieceIndex
+	res.Begin = t.req.Begin
+
+	if t.data != nil {
+		res.Data = append(res.Data[:0], t.data...)
+	} else {
+		res.Data = slices.Grow(res.Data[:0], int(t.req.Length))[:t.req.Length]
+
+		err := d.readPieceRangeCtx(d.ctx, t.req, res.Data)
+		if err != nil {
+			proto.PiecePool.Put(res)
+			if err == errUploadPaused || err == context.Canceled {
+				return
+			}
+			d.setError(err)
+			p.close()
+			return
+		}
+	}
+
+	// Rate limit: block before sending to the network.
+	if err := d.uploadLimiter.Wait(d.ctx, len(res.Data)); err != nil {
+		proto.PiecePool.Put(res)
+		return
+	}
+	if err := d.c.uploadLimiter.Wait(d.ctx, len(res.Data)); err != nil {
+		proto.PiecePool.Put(res)
+		return
+	}
+
+	if p.Response(res) {
+		d.ioUp.Update(len(res.Data))
+		d.c.ioUp.Update(len(res.Data))
+		d.uploaded.Add(int64(len(res.Data)))
+	}
+	proto.PiecePool.Put(res)
 }

--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -134,8 +134,9 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 
 	d.chunk.heap.Push(c)
 	d.chunk.pending.Set(c.pi)
+	d.c.memBudget.ForceAcquire(int64(len(res.Data)))
 
-	if d.chunk.heap.Len() < defaultChunkHeapSizeLimit {
+	if d.chunk.heap.Len() < defaultChunkHeapSizeLimit && d.c.memBudget.Available() {
 		piecePiStart := res.Begin/defaultBlockSize + res.PieceIndex*d.normalChunkLen
 		piecePiEnd := piecePiStart + uint32(pieceChunksCount(d.info, res.PieceIndex))
 		for i := piecePiStart; i < piecePiEnd; i++ {
@@ -166,6 +167,7 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 
 	mergedChunk.Write(head.res.Data)
 
+	d.c.memBudget.Release(int64(len(head.res.Data)))
 	proto.PiecePool.Put(head.res)
 
 	for d.chunk.heap.Len() != 0 {
@@ -188,6 +190,7 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 		mergedChunk.Write(peak.res.Data)
 
 		d.chunk.heap.Pop()
+		d.c.memBudget.Release(int64(len(peak.res.Data)))
 		proto.PiecePool.Put(peak.res)
 	}
 
@@ -213,6 +216,7 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 }
 
 func (d *Download) handleResEndgame(res *proto.ChunkResponse) {
+	d.c.memBudget.ForceAcquire(int64(len(res.Data)))
 	d.chunk.heap.Push(responseChunk{
 		res: res,
 		pi:  res.Begin/defaultBlockSize + res.PieceIndex*d.normalChunkLen,
@@ -223,6 +227,7 @@ func (d *Download) handleResEndgame(res *proto.ChunkResponse) {
 		index := chunk.res.PieceIndex
 		err := d.writeChunkToDist(int64(index)*d.info.PieceLength+int64(chunk.res.Begin), chunk.res.Data)
 		d.chunk.done.Set(chunk.pi)
+		d.c.memBudget.Release(int64(len(chunk.res.Data)))
 		proto.PiecePool.Put(chunk.res)
 
 		if err != nil {
@@ -269,6 +274,7 @@ func (d *Download) handlePieceFromHeap(index uint32) {
 		d.chunk.mu.Lock()
 		d.chunk.done.Set(chunk.pi)
 		d.chunk.mu.Unlock()
+		d.c.memBudget.Release(int64(len(chunk.res.Data)))
 		proto.PiecePool.Put(chunk.res)
 	}
 

--- a/internal/core/d_upload.go
+++ b/internal/core/d_upload.go
@@ -253,6 +253,10 @@ func (d *Download) dispatchCachedPiece(index uint32, reqs []uploadReq, responses
 	}
 
 	for _, item := range reqs {
+		dataSize := int64(item.req.Length)
+		if !d.c.memBudget.TryAcquire(dataSize) {
+			break
+		}
 		data := make([]byte, item.req.Length)
 		copy(data, buf.B[item.req.Begin:item.req.Begin+item.req.Length])
 		if !d.dispatchUploadWithData(item, data, responses, maxResponses) {

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
+	"runtime/debug"
 	"slices"
 	"strings"
 	"syscall"
@@ -79,6 +80,9 @@ func main() {
 	}
 
 	initResourceLimit()
+
+	softMemLimit := resolveSoftMemoryLimit(cfg.App.SoftMemoryLimit)
+	cfg.App.SoftMemoryLimit = softMemLimit
 
 	var lc net.ListenConfig
 	listener, err := lc.Listen(context.Background(), "tcp", address)
@@ -388,4 +392,22 @@ func initResourceLimit() {
 			_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		}
 	}
+}
+
+// resolveSoftMemoryLimit computes the soft memory limit in bytes.
+// If configured > 0, use the user-configured value directly.
+// Otherwise, use 80% of the current GOMEMLIMIT (set by automemlimit or env).
+// Returns 0 if no limit is available (soft memory limiting disabled).
+func resolveSoftMemoryLimit(configured int64) int64 {
+	if configured > 0 {
+		return configured
+	}
+
+	goMemLimit := debug.SetMemoryLimit(-1)
+	if goMemLimit <= 0 {
+		return 0
+	}
+
+	// Use 80% of GOMEMLIMIT as the soft limit.
+	return int64(float64(goMemLimit) * 0.8)
 }


### PR DESCRIPTION
## Summary

- Add a global `memoryBudget` that tracks bytes held in chunk heap caches and upload data buffers
- When the budget is exhausted, chunk heaps are flushed to disk more aggressively and upload data pre-allocation is skipped
- Default limit: 80% of GOMEMLIMIT (set by automemlimit/cgroup), configurable via `soft-memory-limit` TOML key

## How it works

**`memoryBudget`** (`internal/core/c_memory.go`) is an atomic byte counter with a soft limit:

- `ForceAcquire(n)` — chunk 入 heap 时无条件计入（数据已分配不能丢）
- `TryAcquire(n)` — upload data 分配时尝试计入，超预算则跳过
- `Release(n)` — chunk 写盘 / upload 完成后释放
- `Available()` — 判断是否需要激进 flush

**Chunk heap** (`d_download.go`): flush 触发条件从 `heap.Len() >= 1000` 改为 `heap.Len() >= 1000 || !memBudget.Available()`，预算耗尽时立即 flush 最老的连续 chunks 到 disk。

**Upload data** (`d_upload.go` + `c_upload_pool.go`): `dispatchCachedPiece` 分配前 `TryAcquire`，超预算则跳过；worker 通过 `defer Release()` 确保释放。

**Config** (`config.toml`):
```toml
[application]
soft-memory-limit = 0  # 0 = auto (80% of GOMEMLIMIT)
```

**Metrics**: `neptune_cache_memory_used_bytes` Prometheus gauge.