### PR TITLE
fix: use sparse file allocation for unselected files

### DIFF
--- a/internal/core/c_file_priority.go
+++ b/internal/core/c_file_priority.go
@@ -5,9 +5,12 @@ package core
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"neptune/internal/metainfo"
 	"neptune/internal/pkg/empty"
+	"neptune/internal/pkg/fallocate"
 )
 
 // SetFilePriority sets the download priority for the given files.
@@ -80,12 +83,28 @@ func (c *Client) SetFilePriority(h metainfo.Hash, fileIDs []int, priority int) e
 		}
 	}
 
-	// Update selectedFilesSet.
+	// Update selectedFilesSet and handle disk allocation.
 	for _, id := range fileIDs {
+		tf := d.info.Files[id]
+		filePath := filepath.Join(d.basePath, tf.Path)
+
 		if priority == 0 {
 			delete(d.selectedFilesSet, id)
+			if d.c.Config.App.Fallocate {
+				if f, err := os.OpenFile(filePath, os.O_WRONLY, 0); err == nil {
+					_ = f.Truncate(0)
+					_ = f.Truncate(tf.Length)
+					f.Close()
+				}
+			}
 		} else {
 			d.selectedFilesSet[id] = struct{}{}
+			if d.c.Config.App.Fallocate {
+				if f, err := os.OpenFile(filePath, os.O_WRONLY, 0); err == nil {
+					_ = fallocate.Fallocate(f, 0, tf.Length)
+					f.Close()
+				}
+			}
 		}
 	}
 	d.selectedSize.Store(d.computeSelectedSizeUnsafe())

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -254,6 +254,14 @@ func (d *Download) setError(err error) {
 	d.state.Store(uint32(Error))
 }
 
+func (d *Download) isFileSelected(fileIndex int) bool {
+	if d.selectedFilesSet == nil {
+		return true
+	}
+	_, ok := d.selectedFilesSet[fileIndex]
+	return ok
+}
+
 // hasSelectedFilesUnsafe returns true if the piece touches at least one selected file.
 func (d *Download) hasSelectedFilesUnsafe(pieceIndex uint32) bool {
 	if d.selectedFilesSet == nil {

--- a/internal/core/d_init.go
+++ b/internal/core/d_init.go
@@ -36,7 +36,7 @@ func (d *Download) initCheck() error {
 	var efs = make(map[int]*existingFile, len(d.info.Files)+1)
 	for i, tf := range d.info.Files {
 		p := tf.Path
-		f, e := tryAllocFile(i, filepath.Join(d.basePath, p), tf.Length, d.c.Config.App.Fallocate)
+		f, e := tryAllocFile(i, filepath.Join(d.basePath, p), tf.Length, d.c.Config.App.Fallocate, d.isFileSelected(i))
 		if e != nil {
 			return e
 		}
@@ -126,15 +126,11 @@ func (d *Download) buildPieceToCheck(efs map[int]*existingFile) []uint32 {
 	return r
 }
 
-func tryAllocFile(index int, path string, size int64, doAlloc bool) (*existingFile, error) {
+func tryAllocFile(index int, path string, size int64, doAlloc bool, selected bool) (*existingFile, error) {
 	f, err := os.OpenFile(path, os.O_WRONLY, 0)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return nil, err
-		}
-
-		if !doAlloc {
-			return nil, nil
 		}
 
 		if err = os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
@@ -146,7 +142,12 @@ func tryAllocFile(index int, path string, size int64, doAlloc bool) (*existingFi
 			return nil, err
 		}
 		defer f.Close()
-		return nil, fallocate.Fallocate(f, 0, size)
+
+		if doAlloc && selected {
+			return nil, fallocate.Fallocate(f, 0, size)
+		}
+
+		return nil, f.Truncate(size)
 	}
 
 	defer f.Close()
@@ -161,7 +162,7 @@ func tryAllocFile(index int, path string, size int64, doAlloc bool) (*existingFi
 		ef = &existingFile{index: index, size: fs}
 	}
 
-	if doAlloc {
+	if doAlloc && selected {
 		if fs != size {
 			return nil, errgo.Wrap(fallocate.Fallocate(f, fs, size-fs), "failed to alloc file")
 		}


### PR DESCRIPTION
## Summary

- Use sparse file allocation (`Truncate`) for unselected files instead of `fallocate`, preventing unnecessary disk space usage when users partially select files to download
- Handle dynamic file selection changes via `SetFilePriority`: selecting a file with `fallocate=true` now pre-allocates it; unselecting converts it to sparse

## Changes

**`d_init.go`** — `tryAllocFile` now accepts a `selected` parameter:
- `fallocate=true` + selected → `fallocate.Fallocate()` (full pre-allocation)
- `fallocate=true` + unselected → `f.Truncate()` (sparse)
- `fallocate=false` → always `f.Truncate()` (sparse)

**`c_file_priority.go`** — `SetFilePriority` now handles disk allocation:
- Selecting files with `fallocate=true`: calls `fallocate.Fallocate`
- Unselecting files with `fallocate=true`: `Truncate(0)` then `Truncate(size)` to convert to sparse

**`d.go`** — Added `isFileSelected` helper method.