### PR TITLE
feat: add skip_hash_check to torrent.add API

### DIFF
--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -128,7 +128,7 @@ func (c *Client) GetTransferSummary() TransferSummary {
 	}
 }
 
-func (c *Client) AddTorrent(raw []byte, m *metainfo.MetaInfo, info meta.Info, downloadPath string, tags []string, custom map[string]string, selectedFiles []int) error {
+func (c *Client) AddTorrent(raw []byte, m *metainfo.MetaInfo, info meta.Info, downloadPath string, tags []string, custom map[string]string, selectedFiles []int, skipHashCheck bool) error {
 	log.Info().Msgf("try add torrent %s", info.Hash)
 
 	if err := validateTorrentPaths(downloadPath, info); err != nil {
@@ -169,7 +169,7 @@ func (c *Client) AddTorrent(raw []byte, m *metainfo.MetaInfo, info meta.Info, do
 	c.downloadMap[info.Hash] = d
 	c.infoHashes = lo.Keys(c.downloadMap)
 
-	go d.Init(false)
+	go d.Init(false, skipHashCheck)
 
 	return nil
 }

--- a/internal/core/d_init.go
+++ b/internal/core/d_init.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/dustin/go-humanize"
 	"github.com/juju/ratelimit"
 	"github.com/trim21/errgo"
 
@@ -169,4 +170,71 @@ func tryAllocFile(index int, path string, size int64, doAlloc bool, selected boo
 	}
 
 	return ef, nil
+}
+
+// verifyFileSizes checks that all selected files exist with matching sizes.
+// No SHA-1 piece verification is performed. Bitmap is not modified.
+func (d *Download) verifyFileSizes() error {
+	d.log.Debug().Msg("verifyFileSizes")
+
+	for i, tf := range d.info.Files {
+		if !d.isFileSelected(i) {
+			continue
+		}
+
+		p := filepath.Join(d.basePath, tf.Path)
+		stat, err := os.Stat(p)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("file %q does not exist", tf.Path)
+			}
+			return errgo.Wrap(err, fmt.Sprintf("failed to stat file %q", tf.Path))
+		}
+
+		if stat.Size() != tf.Length {
+			return fmt.Errorf("file %q size mismatch: expected %d, got %d", tf.Path, tf.Length, stat.Size())
+		}
+	}
+
+	return nil
+}
+
+func (d *Download) check(resumed bool, skipHashCheck bool) {
+	if !resumed {
+		d.log.Debug().Msg("initializing download")
+		d.state.Store(uint32(Checking))
+	}
+
+	if skipHashCheck {
+		if err := d.verifyFileSizes(); err != nil {
+			if resumed {
+				d.log.Warn().Err(err).Msg("file size verification failed on resume")
+			} else {
+				d.setError(err)
+				d.log.Err(err).Msg("file size verification failed")
+			}
+		} else if !resumed {
+			d.bm.Fill()
+		}
+	} else if !resumed {
+		if err := d.initCheck(); err != nil {
+			d.setError(err)
+			d.log.Err(err).Msg("failed to initCheck torrent data")
+		}
+	}
+
+	if !resumed {
+		// unsafe methods are safe here because d hasn't been shared with other goroutines yet.
+		d.markUnselectedPiecesDoneUnsafe()
+		d.completed.Store(d.computeCompletedUnsafe())
+		d.ioDown.Reset()
+
+		d.log.Debug().Msgf("done size %s", humanize.IBytes(uint64(d.bm.Count())*uint64(d.info.PieceLength)))
+
+		if d.bm.Count() == d.info.NumPieces {
+			d.state.Store(uint32(Seeding))
+		} else {
+			d.state.Store(uint32(Downloading))
+		}
+	}
 }

--- a/internal/core/d_loop.go
+++ b/internal/core/d_loop.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
-	"github.com/dustin/go-humanize"
 
 	"neptune/internal/pkg/empty"
 	"neptune/internal/pkg/filepool"
@@ -44,30 +43,8 @@ func (d *Download) Check() {
 }
 
 // Init check existing files.
-func (d *Download) Init(resumed bool) {
-	if !resumed {
-		d.log.Debug().Msg("initializing download")
-
-		d.state.Store(uint32(Checking))
-
-		err := d.initCheck()
-		if err != nil {
-			d.setError(err)
-			d.log.Err(err).Msg("failed to initCheck torrent data")
-		}
-		// unsafe methods are safe here because d hasn't been shared with other goroutines yet.
-		d.markUnselectedPiecesDoneUnsafe()
-		d.completed.Store(d.computeCompletedUnsafe())
-		d.ioDown.Reset()
-
-		d.log.Debug().Msgf("done size %s", humanize.IBytes(uint64(d.bm.Count())*uint64(d.info.PieceLength)))
-
-		if d.bm.Count() == d.info.NumPieces {
-			d.state.Store(uint32(Seeding))
-		} else {
-			d.state.Store(uint32(Downloading))
-		}
-	}
+func (d *Download) Init(resumed bool, skipHashCheck bool) {
+	d.check(resumed, skipHashCheck)
 
 	go d.startBackground()
 

--- a/internal/core/d_resume.go
+++ b/internal/core/d_resume.go
@@ -159,7 +159,7 @@ func (c *Client) UnmarshalResume(data []byte) error {
 	c.downloadMap[info.Hash] = d
 	c.infoHashes = lo.Keys(c.downloadMap)
 
-	d.Init(true)
+	d.Init(true, true)
 
 	return nil
 }

--- a/internal/web/torrent.go
+++ b/internal/web/torrent.go
@@ -29,6 +29,7 @@ type AddTorrentRequest struct {
 	Custom        map[string]string `json:"custom"`
 	SelectedFiles []int             `description:"indices of files to download, empty means all"         json:"selected_files"` // if nil, all files are selected.
 	IsBaseDir     bool              `description:"if true, will not append torrent name to download_dir" json:"is_base_dir"`
+	SkipHashCheck bool              `description:"if true, skip piece hash check and only verify file sizes match torrent metadata" json:"skip_hash_check"`
 }
 
 type AddTorrentResponse struct {
@@ -75,7 +76,7 @@ func addTorrent(h *jsonrpc.Handler, c *core.Client) {
 				}
 			}
 
-			err = c.AddTorrent(req.TorrentFile, m, info, downloadDir, req.Tags, req.Custom, req.SelectedFiles)
+			err = c.AddTorrent(req.TorrentFile, m, info, downloadDir, req.Tags, req.Custom, req.SelectedFiles, req.SkipHashCheck)
 			if err != nil {
 				return CodeError(5, errgo.Wrap(err, "failed to add torrent to download"))
 			}

--- a/internal/web/torrent.go
+++ b/internal/web/torrent.go
@@ -23,12 +23,12 @@ import (
 )
 
 type AddTorrentRequest struct {
-	TorrentFile   []byte            `description:"base64 encoded torrent file content"                   json:"torrent_file"   required:"true" validate:"required"`
-	DownloadDir   string            `description:"base download dir"                                     json:"download_dir"`
+	TorrentFile   []byte            `description:"base64 encoded torrent file content"                                              json:"torrent_file"    required:"true" validate:"required"`
+	DownloadDir   string            `description:"base download dir"                                                                json:"download_dir"`
 	Tags          []string          `json:"tags"`
 	Custom        map[string]string `json:"custom"`
-	SelectedFiles []int             `description:"indices of files to download, empty means all"         json:"selected_files"` // if nil, all files are selected.
-	IsBaseDir     bool              `description:"if true, will not append torrent name to download_dir" json:"is_base_dir"`
+	SelectedFiles []int             `description:"indices of files to download, empty means all"                                    json:"selected_files"` // if nil, all files are selected.
+	IsBaseDir     bool              `description:"if true, will not append torrent name to download_dir"                            json:"is_base_dir"`
 	SkipHashCheck bool              `description:"if true, skip piece hash check and only verify file sizes match torrent metadata" json:"skip_hash_check"`
 }
 

--- a/sdk/python/src/neptune_sdk/models.py
+++ b/sdk/python/src/neptune_sdk/models.py
@@ -91,6 +91,7 @@ class AddTorrentRequest:
     custom: dict[str, str] | None = None
     selected_files: list[int] | None = None
     is_base_dir: bool = False
+    skip_hash_check: bool = False
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)


### PR DESCRIPTION
Add option to skip SHA-1 piece verification on torrent add and only verify that selected files exist with correct sizes. When enabled, all pieces are marked complete immediately (Seeding state) if file sizes match.

Resume also uses file-size verification unconditionally to detect missing or tampered files after restart.

Changes:
- Add `skip_hash_check` param to `torrent.add` JSON-RPC method
- Add `verifyFileSizes()` that checks file existence and sizes without modifying the bitmap
- Add `check()` as unified init entry point handling new-add and resume paths
- `Init()` now takes `skipHashCheck` parameter, no state stored on `Download`
- Resume always calls `Init(true, true)` for file-size verification