### PR TITLE
feat: expose tracker errors in JSON-RPC API and python SDK

### DIFF
--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -48,6 +48,7 @@ type MainDataTorrent struct {
 	Comment         string            `json:"comment"`
 	DirectoryBase   string            `json:"directory_base"`
 	Message         string            `json:"message"`
+	TrackerErrors   map[string]string `json:"tracker_errors"`
 	Tags            []string          `json:"tags"`
 	DownloadRate    int64             `json:"download_rate"`
 	DownloadTotal   int64             `json:"download_total"`
@@ -105,6 +106,7 @@ func (c *Client) GetTorrentList(keys []string) TorrentList {
 			Custom:          custom,
 			ConnectionCount: d.peers.Size(),
 			Message:         msg,
+			TrackerErrors:   d.trackerErrors(),
 		}
 
 		d.m.RUnlock()
@@ -284,8 +286,9 @@ func (c *Client) GetTorrentPeers(h metainfo.Hash) []APIPeers {
 }
 
 type APITrackers struct {
-	URL  string `json:"url"`
-	Tier int    `json:"tier"`
+	URL     string `json:"url"`
+	Message string `json:"message"`
+	Tier    int    `json:"tier"`
 }
 
 func (c *Client) GetTorrentTrackers(h metainfo.Hash) []APITrackers {
@@ -305,8 +308,9 @@ func (c *Client) GetTorrentTrackers(h metainfo.Hash) []APITrackers {
 	for iterIndex, tier := range d.trackers {
 		for _, tracker := range tier.trackers {
 			results = append(results, APITrackers{
-				Tier: iterIndex,
-				URL:  tracker.url,
+				Tier:    iterIndex,
+				URL:     tracker.url,
+				Message: tracker.errorMessage(),
 			})
 		}
 	}
@@ -370,6 +374,7 @@ func (c *Client) RemoveTracker(h metainfo.Hash, trackerURL string) error {
 		for j, tr := range tier.trackers {
 			if tr.url == trackerURL {
 				d.trackers[i].trackers = slices.Delete(tier.trackers, j, j+1)
+				d.trackerErrorsMap.Delete(trackerURL)
 				// remove empty tiers
 				if len(d.trackers[i].trackers) == 0 {
 					d.trackers = slices.Delete(d.trackers, i, i+1)
@@ -396,6 +401,7 @@ func (c *Client) ReplaceTrackers(h metainfo.Hash, replacements map[string]string
 	for _, tier := range d.trackers {
 		for _, tr := range tier.trackers {
 			if newURL, ok := replacements[tr.url]; ok {
+				d.trackerErrorsMap.Delete(tr.url)
 				tr.url = newURL
 				tr.nextAnnounce = time.Now()
 			}

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -81,6 +81,7 @@ type Download struct {
 	pieceInfo              []pieceFileChunks
 	trackers               []TrackerTier
 	pieceAvailability      []int32
+	trackerErrorsMap       *xsync.Map[string, string]
 	info                   meta.Info
 	completed              atomic.Int64
 	selectedSize           atomic.Int64
@@ -200,6 +201,7 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 			done: make(bitmap.Bitmap, int64(info.NumPieces)*((info.PieceLength+defaultBlockSize-1)/defaultBlockSize)),
 		},
 		endgameRequested: xsync.NewMap[proto.ChunkRequest, empty.Empty](),
+		trackerErrorsMap: xsync.NewMap[string, string](),
 
 		pendingPeers: heap.New[peerWithPriority](),
 

--- a/internal/core/d_tracker.go
+++ b/internal/core/d_tracker.go
@@ -46,6 +46,23 @@ func (d *Download) setAnnounceList(trackers metainfo.AnnounceList) {
 	}
 }
 
+func (d *Download) trackerErrors() map[string]string {
+	errs := make(map[string]string)
+	d.trackerErrorsMap.Range(func(url string, msg string) bool {
+		errs[url] = msg
+		return true
+	})
+	return errs
+}
+
+func (d *Download) updateTrackerError(t *Tracker) {
+	if msg := t.errorMessage(); msg != "" {
+		d.trackerErrorsMap.Store(t.url, msg)
+	} else {
+		d.trackerErrorsMap.Delete(t.url)
+	}
+}
+
 func (d *Download) backgroundTrackerHandler() {
 	timer := time.NewTimer(time.Second * 10)
 	defer timer.Stop()
@@ -126,12 +143,16 @@ func (tier TrackerTier) Announce(d *Download, event AnnounceEvent) (AnnounceResu
 
 		t.lastAnnounceTime = now
 		t.nextAnnounce = now.Add(r.Interval)
+		t.failureMessage = r.FailedReason
 
 		if r.Err != nil {
 			t.err = r.Err
+			d.updateTrackerError(t)
 			continue
 		}
 
+		t.err = nil
+		d.updateTrackerError(t)
 		t.peerCount = len(r.Peers)
 
 		r.Peers = lo.Uniq(r.Peers)
@@ -198,6 +219,16 @@ type Tracker struct {
 	peerCount        int
 	seeders          int
 	leechers         int
+}
+
+func (t *Tracker) errorMessage() string {
+	if t.failureMessage != "" {
+		return t.failureMessage
+	}
+	if t.err != nil {
+		return t.err.Error()
+	}
+	return ""
 }
 
 func (t *Tracker) req(d *Download) *resty.Request {

--- a/sdk/python/src/neptune_sdk/models.py
+++ b/sdk/python/src/neptune_sdk/models.py
@@ -15,6 +15,7 @@ class MainDataTorrent:
     comment: str
     directory_base: str
     message: str
+    tracker_errors: dict[str, str]
     tags: list[str]
     custom: dict[str, str]
     download_rate: int
@@ -67,6 +68,7 @@ class Tracker:
 
     url: str
     tier: int
+    message: str
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -39,6 +39,7 @@ TORRENT_JSON = {
     "comment": "",
     "directory_base": "/downloads/test",
     "message": "",
+    "tracker_errors": {},
     "tags": [],
     "custom": {},
     "download_rate": 0,
@@ -159,7 +160,11 @@ def test_torrent_peers(mock_api, client):
 def test_torrent_trackers(mock_api, client):
     mock_api.post("/json_rpc").mock(
         return_value=_ok(
-            {"trackers": [{"url": "http://t.example.com/announce", "tier": 0}]}
+            {
+                "trackers": [
+                    {"url": "http://t.example.com/announce", "tier": 0, "message": ""}
+                ]
+            }
         )
     )
     result = client.torrent_trackers("aabb")


### PR DESCRIPTION
## Summary

- Add `TrackerErrors map[string]string` to `MainDataTorrent` so `torrent.list` surfacing tracker-level errors
- Add `Message` field to `APITrackers` so `torrent.trackers` returns per-tracker error text
- Fix `TrackerTier.Announce()` to properly persist `failureMessage` from tracker responses and clear stale errors on recovery
- Add `trackerErrors()` on `Download` and `errorMessage()` on `Tracker`
- Update Python SDK models and test fixtures to match the new fields

`d.message` remains unchanged; continues to only carry hard I/O errors as before.