### PR TITLE
feat: add torrent.recheck API and centralized state machine

### DIFF
--- a/internal/core/c_check_queue.go
+++ b/internal/core/c_check_queue.go
@@ -2,3 +2,21 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 package core
+
+import (
+	"fmt"
+
+	"neptune/internal/metainfo"
+)
+
+func (c *Client) RecheckTorrent(h metainfo.Hash) error {
+	c.m.RLock()
+	d, ok := c.downloadMap[h]
+	c.m.RUnlock()
+
+	if !ok {
+		return fmt.Errorf("torrent %s not exists", h)
+	}
+
+	return d.AsyncCheck()
+}

--- a/internal/core/c_file_priority.go
+++ b/internal/core/c_file_priority.go
@@ -117,7 +117,9 @@ func (c *Client) SetFilePriority(h metainfo.Hash, fileIDs []int, priority int) e
 
 	// Transition to Seeding if all pieces are complete.
 	if d.bm.Count() == d.info.NumPieces {
-		d.state.Store(uint32(Seeding))
+		if err := d.transition(Seeding); err != nil {
+			d.log.Error().Err(err).Msg("failed to transition state in SetFilePriority")
+		}
 	}
 
 	d.m.Unlock()

--- a/internal/core/c_resume.go
+++ b/internal/core/c_resume.go
@@ -22,7 +22,5 @@ func (c *Client) ResumeTorrent(h metainfo.Hash) error {
 		return fmt.Errorf("torrent %s is not stopped", h)
 	}
 
-	d.Start()
-
-	return nil
+	return d.Start()
 }

--- a/internal/core/c_start_torrent.go
+++ b/internal/core/c_start_torrent.go
@@ -22,7 +22,5 @@ func (c *Client) StartTorrent(h metainfo.Hash) error {
 		return fmt.Errorf("torrent %s is not stopped", h)
 	}
 
-	d.Start()
-
-	return nil
+	return d.Start()
 }

--- a/internal/core/c_stop_torrent.go
+++ b/internal/core/c_stop_torrent.go
@@ -22,7 +22,5 @@ func (c *Client) StopTorrent(h metainfo.Hash) error {
 		return fmt.Errorf("torrent %s is already stopped", h)
 	}
 
-	d.Stop()
-
-	return nil
+	return d.Stop()
 }

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -6,6 +6,7 @@ package core
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/netip"
 	"sync"
@@ -42,6 +43,65 @@ const (
 	Moving      State = 1 << 4
 	Error       State = 1 << 5
 )
+
+type TransitionError struct {
+	From State
+	To   State
+}
+
+func (e *TransitionError) Error() string {
+	if msg := e.userMessage(); msg != "" {
+		return msg
+	}
+	return fmt.Sprintf("invalid state transition from %s to %s", e.From, e.To)
+}
+
+func (e *TransitionError) userMessage() string {
+	switch {
+	case e.From == Moving && e.To == Moving:
+		return "torrent is already being moved"
+	case e.From == Moving && e.To == Checking:
+		return "torrent is being moved, cannot recheck"
+	case e.From == Checking && e.To == Moving:
+		return "torrent is being rechecked, cannot move"
+	case e.From == Checking && e.To == Checking:
+		return "torrent is already being rechecked"
+	}
+	return ""
+}
+
+func (d *Download) transition(to State) error {
+	for {
+		old := State(d.state.Load())
+		if old == to {
+			return nil
+		}
+		if !validTransition(old, to) {
+			return &TransitionError{From: old, To: to}
+		}
+		if d.state.CompareAndSwap(uint32(old), uint32(to)) {
+			return nil
+		}
+	}
+}
+
+func validTransition(from, to State) bool {
+	switch from {
+	case Stopped:
+		return to == Downloading || to == Seeding || to == Checking || to == Moving
+	case Downloading:
+		return to == Stopped || to == Seeding || to == Error || to == Checking || to == Moving
+	case Seeding:
+		return to == Stopped || to == Error || to == Checking || to == Moving
+	case Checking:
+		return to == Downloading || to == Seeding || to == Error
+	case Moving:
+		return to == Downloading || to == Seeding || to == Stopped || to == Error
+	case Error:
+		return to == Checking
+	}
+	return false
+}
 
 // Download manage a download task
 // ctx should be canceled when torrent is removed, not stopped.
@@ -257,7 +317,9 @@ func (d *Download) setError(err error) {
 	}
 
 	d.err.Store(&err)
-	d.state.Store(uint32(Error))
+	if err := d.transition(Error); err != nil {
+		d.log.Warn().Err(err).Msg("failed to transition state in setError")
+	}
 }
 
 func (d *Download) isFileSelected(fileIndex int) bool {

--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -405,7 +405,10 @@ func (d *Download) checkDone() {
 		return
 	}
 
-	d.state.Store(uint32(Seeding))
+	if err := d.transition(Seeding); err != nil {
+		d.log.Error().Err(err).Msg("failed to transition state in checkDone")
+		return
+	}
 	d.ioDown.Reset()
 
 	d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {

--- a/internal/core/d_init.go
+++ b/internal/core/d_init.go
@@ -232,9 +232,13 @@ func (d *Download) check(resumed bool, skipHashCheck bool) {
 		d.log.Debug().Msgf("done size %s", humanize.IBytes(uint64(d.bm.Count())*uint64(d.info.PieceLength)))
 
 		if d.bm.Count() == d.info.NumPieces {
-			d.state.Store(uint32(Seeding))
+			if err := d.transition(Seeding); err != nil {
+				d.log.Error().Err(err).Msg("failed to transition state after init check")
+			}
 		} else {
-			d.state.Store(uint32(Downloading))
+			if err := d.transition(Downloading); err != nil {
+				d.log.Error().Err(err).Msg("failed to transition state after init check")
+			}
 		}
 	}
 }

--- a/internal/core/d_loop.go
+++ b/internal/core/d_loop.go
@@ -17,29 +17,73 @@ import (
 
 const defaultBlockSize = units.KiB * 16
 
-func (d *Download) Start() {
+func (d *Download) Start() error {
 	if d.bm.Count() == d.info.NumPieces {
-		d.state.Store(uint32(Seeding))
+		if err := d.transition(Seeding); err != nil {
+			d.log.Error().Err(err).Msg("failed to transition state in Start")
+			return err
+		}
 	} else {
-		d.state.Store(uint32(Downloading))
+		if err := d.transition(Downloading); err != nil {
+			d.log.Error().Err(err).Msg("failed to transition state in Start")
+			return err
+		}
 	}
 
 	d.stateCond.Broadcast()
+	return nil
 }
 
-func (d *Download) Stop() {
-	d.state.Store(uint32(Stopped))
+func (d *Download) Stop() error {
+	if err := d.transition(Stopped); err != nil {
+		d.log.Error().Err(err).Msg("failed to transition state in Stop")
+		return err
+	}
 
 	d.stateCond.Broadcast()
 
 	d.announce(EventStopped)
+	return nil
 }
 
-func (d *Download) Check() {
-	d.state.Store(uint32(Checking))
-	d.bm.Clear()
+func (d *Download) AsyncCheck() error {
+	if err := d.transition(Checking); err != nil {
+		return err
+	}
 
+	d.bm.Clear()
+	d.completed.Store(0)
 	d.stateCond.Broadcast()
+
+	go func() {
+		if err := d.initCheck(); err != nil {
+			if d.ctx.Err() != nil {
+				return
+			}
+			d.setError(err)
+			d.log.Err(err).Msg("failed to recheck torrent data")
+			return
+		}
+
+		d.markUnselectedPiecesDoneUnsafe()
+		d.completed.Store(d.computeCompletedUnsafe())
+		d.ioDown.Reset()
+
+		if d.bm.Count() == d.info.NumPieces {
+			if err := d.transition(Seeding); err != nil {
+				d.log.Error().Err(err).Msg("failed to transition state after recheck")
+				return
+			}
+		} else {
+			if err := d.transition(Downloading); err != nil {
+				d.log.Error().Err(err).Msg("failed to transition state after recheck")
+				return
+			}
+		}
+		d.stateCond.Broadcast()
+	}()
+
+	return nil
 }
 
 // Init check existing files.

--- a/internal/core/d_move.go
+++ b/internal/core/d_move.go
@@ -19,11 +19,9 @@ func (d *Download) Move(target string) error {
 
 	originalState := State(d.state.Load())
 
-	if originalState == Moving || originalState == Checking {
-		return nil
+	if err := d.transition(Moving); err != nil {
+		return err
 	}
-
-	d.state.Store(uint32(Moving))
 
 	d.m.Lock()
 	originalBasePath := d.basePath
@@ -47,7 +45,9 @@ func (d *Download) Move(target string) error {
 	d.basePath = target
 	d.m.Unlock()
 
-	d.state.Store(uint32(originalState))
+	if err := d.transition(originalState); err != nil {
+		d.log.Error().Err(err).Msg("failed to restore state after move")
+	}
 
 	return nil
 }

--- a/internal/web/torrent_recheck.go
+++ b/internal/web/torrent_recheck.go
@@ -1,0 +1,41 @@
+// Copyright 2026 trim21 <trim21.me@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package web
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+
+	"github.com/swaggest/usecase"
+
+	"neptune/internal/core"
+	"neptune/internal/metainfo"
+	"neptune/internal/web/jsonrpc"
+)
+
+type recheckTorrentRequest struct {
+	InfoHash string `description:"torrent file hash" json:"info_hash" required:"true"`
+}
+
+type recheckTorrentResponse struct{}
+
+func recheckTorrent(h *jsonrpc.Handler, c *core.Client) {
+	u := usecase.NewInteractor(
+		func(ctx context.Context, req *recheckTorrentRequest, res *recheckTorrentResponse) error {
+			if len(req.InfoHash) != sha1.Size*2 {
+				return errInvalidInfoHash
+			}
+
+			raw, err := hex.DecodeString(req.InfoHash)
+			if err != nil {
+				return errInvalidInfoHash
+			}
+
+			return c.RecheckTorrent(metainfo.Hash(raw))
+		},
+	)
+	u.SetName("torrent.recheck")
+	h.Add(u)
+}

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -117,6 +117,7 @@ func New(c *core.Client, token string, enableDebug bool) http.Handler {
 	resumeTorrent(h, c)
 	startTorrent(h, c)
 	stopTorrent(h, c)
+	recheckTorrent(h, c)
 	setFilePriority(h, c)
 	setDownloadLimit(h, c)
 	setUploadLimit(h, c)


### PR DESCRIPTION
## Summary

- Add `torrent.recheck` JSON-RPC method to trigger full SHA-1 hash re-verification of torrent data
- Add `AsyncCheck()` on Download — CAS-guarded transition to Checking state, runs `initCheck()` in a goroutine, then restores Downloading/Seeding
- Add centralized `transition(to State) error` with legal state transition table, replacing raw `state.Store()` across all state-changers
- Remove dead `d.Check()` stub

## State machine

```
Stopped     → Downloading, Seeding, Checking, Moving
Downloading → Stopped, Seeding, Error, Checking, Moving
Seeding     → Stopped, Error, Checking, Moving
Checking    → Downloading, Seeding, Error
Moving      → Downloading, Seeding, Stopped, Error
Error       → Checking
```

All state mutations (Start, Stop, AsyncCheck, setError, Move, checkDone, SetFilePriority) now go through `transition()` which uses CAS loop + table validation.