### PR TITLE
fix: open files read-only for seeding and hash checking

### DIFF
--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -345,7 +345,7 @@ func (d *Download) checkPiece(pieceIndex uint32) error {
 	piece := d.pieceInfo[pieceIndex]
 
 	for _, chunk := range piece.fileChunks {
-		f, err := d.openFile(chunk.fileIndex)
+		f, err := d.openFileReadOnly(chunk.fileIndex)
 		if err != nil {
 			return errgo.Wrap(err, "failed to open file for hashing")
 		}

--- a/internal/core/d_init.go
+++ b/internal/core/d_init.go
@@ -71,7 +71,7 @@ func (d *Download) initCheck() error {
 
 		piece := d.pieceInfo[pieceIndex]
 		for _, chunk := range piece.fileChunks {
-			f, err := d.openFile(chunk.fileIndex)
+			f, err := d.openFileReadOnly(chunk.fileIndex)
 			if err != nil {
 				return errgo.Wrap(err, fmt.Sprintf("failed to open file %q", filepath.Join(d.basePath, d.info.Files[chunk.fileIndex].Path)))
 			}

--- a/internal/core/d_loop.go
+++ b/internal/core/d_loop.go
@@ -303,3 +303,11 @@ func (d *Download) openFile(fileIndex int) (*filepool.File, error) {
 
 	return d.c.filePool.Open(p, os.O_RDWR|os.O_CREATE, os.ModePerm, time.Hour)
 }
+
+func (d *Download) openFileReadOnly(fileIndex int) (*filepool.File, error) {
+	d.m.RLock()
+	p := filepath.Join(d.basePath, d.info.Files[fileIndex].Path)
+	d.m.RUnlock()
+
+	return d.c.filePool.Open(p, os.O_RDONLY, 0, time.Hour)
+}

--- a/internal/core/d_upload.go
+++ b/internal/core/d_upload.go
@@ -289,7 +289,7 @@ func (d *Download) readPiece(index uint32, buf []byte) error {
 	pieces := d.pieceInfo[index]
 	var offset int64 = 0
 	for _, chunk := range pieces.fileChunks {
-		f, err := d.openFile(chunk.fileIndex)
+		f, err := d.openFileReadOnly(chunk.fileIndex)
 		if err != nil {
 			return err
 		}
@@ -335,7 +335,7 @@ func (d *Download) readPieceRangeCtx(ctx context.Context, req proto.ChunkRequest
 			return errUploadPaused
 		}
 
-		f, err := d.openFile(chunk.fileIndex)
+		f, err := d.openFileReadOnly(chunk.fileIndex)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Problem

When seeding, Neptune opens data files with `os.O_RDWR|os.O_CREATE` even though it only needs to read. This causes failures on read-only filesystems:

```
open /srv/hdd-22t-1/qb/...mkv: read-only file system
```

## Changes

- Add `openFileReadOnly()` method that opens files with `os.O_RDONLY`
- Update all read-only callers to use the new method:
  - `readPiece` / `readPieceRangeCtx` (seeding uploads)
  - `checkPiece` (hash verification)
  - Init-time piece verification
- Only `writeChunkToDist` retains `O_RDWR` since it actually writes data