### PR TITLE
fix(tracker): improve timeout error message and stagger initial announce

### DIFF
--- a/internal/core/d_resume.go
+++ b/internal/core/d_resume.go
@@ -6,9 +6,11 @@ package core
 import (
 	"encoding"
 	"fmt"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"slices"
+	"time"
 
 	"github.com/rs/zerolog/log"
 	"github.com/samber/lo"
@@ -151,6 +153,15 @@ func (c *Client) UnmarshalResume(data []byte) error {
 
 	d.downloadLimiter.Update(r.DownloadSpeedLimit)
 	d.uploadLimiter.Update(r.UploadSpeedLimit)
+
+	// stagger initial announce time to spread announces over 30 minutes
+	d.trackerMutex.Lock()
+	for _, tier := range d.trackers {
+		for _, t := range tier.trackers {
+			t.nextAnnounce = t.nextAnnounce.Add(time.Duration(rand.IntN(30*60)) * time.Second)
+		}
+	}
+	d.trackerMutex.Unlock()
 
 	c.m.Lock()
 	defer c.m.Unlock()

--- a/internal/core/d_tracker.go
+++ b/internal/core/d_tracker.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"net/netip"
 	"net/url"
@@ -270,7 +271,10 @@ func (t *Tracker) announce(d *Download, event AnnounceEvent) AnnounceResult {
 
 	res, err := req.Get(t.url)
 	if err != nil {
-		return AnnounceResult{Err: errgo.Wrap(err, "failed to connect to tracker")}
+		if errors.Is(err, context.DeadlineExceeded) {
+			return AnnounceResult{Err: errors.New("http request timeout")}
+		}
+		return AnnounceResult{Err: err}
 	}
 
 	var r trackerAnnounceResponse


### PR DESCRIPTION
## Summary

两个 tracker announce 相关的优化：

### 1. 超时错误不暴露 URL
`context deadline exceeded` 时返回 `"http request timeout"`，不暴露包含 passkey 的完整 URL。

### 2. 启动时错开首次 announce
进程重启后加载 resume 时，给每个种子 tracker 的 `nextAnnounce` 添加 0-30 分钟随机 jitter，避免所有种子同时发起 announce 导致超时风暴。