### PR TITLE
feat(tracker): add Pause/Resume, async announce, and fix concurrency issues

### DIFF
--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -390,7 +390,6 @@ func (c *Client) RemoveTorrent(h metainfo.Hash, removeData bool) error {
 
 	d.cancel()
 
-	d.Trk.Stop()
 	d.backgroundWg.Wait()
 
 	d.peers.Range(func(key netip.AddrPort, p *Peer) bool {

--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -26,6 +26,7 @@ import (
 	"github.com/trim21/errgo"
 	"go.uber.org/multierr"
 
+	"neptune/internal/core/tracker"
 	"neptune/internal/meta"
 	"neptune/internal/metainfo"
 	"neptune/internal/pkg/as"
@@ -312,21 +313,15 @@ func (c *Client) GetTorrentTrackers(h metainfo.Hash) []APITrackers {
 	}
 	c.m.RUnlock()
 
-	var results = make([]APITrackers, 0, 10)
-
-	d.trackerMutex.RLock()
-	defer d.trackerMutex.RUnlock()
-
-	for iterIndex, tier := range d.trackers {
-		for _, tracker := range tier.trackers {
-			results = append(results, APITrackers{
-				Tier:    iterIndex,
-				URL:     tracker.url,
-				Message: tracker.errorMessage(),
-			})
+	infos := d.Trk.List()
+	results := make([]APITrackers, len(infos))
+	for i, info := range infos {
+		results[i] = APITrackers{
+			Tier:    info.Tier,
+			URL:     info.URL,
+			Message: info.Err,
 		}
 	}
-
 	return results
 }
 
@@ -349,25 +344,7 @@ func (c *Client) AddTracker(h metainfo.Hash, trackerURL string, tier int) error 
 		return errTrackerURLMissingHost
 	}
 
-	d.trackerMutex.Lock()
-	defer d.trackerMutex.Unlock()
-
-	// check for duplicate
-	for _, t := range d.trackers {
-		for _, tr := range t.trackers {
-			if tr.url == trackerURL {
-				return nil // already exists
-			}
-		}
-	}
-
-	tracker := &Tracker{url: trackerURL, nextAnnounce: time.Now()}
-	if tier >= 0 && tier < len(d.trackers) {
-		d.trackers[tier].trackers = append(d.trackers[tier].trackers, tracker)
-	} else {
-		d.trackers = append(d.trackers, TrackerTier{trackers: []*Tracker{tracker}})
-	}
-
+	d.Trk.Add(trackerURL, tier)
 	return nil
 }
 
@@ -379,25 +356,7 @@ func (c *Client) RemoveTracker(h metainfo.Hash, trackerURL string) error {
 		return fmt.Errorf("torrent %s not exists", h)
 	}
 
-	d.trackerMutex.Lock()
-	defer d.trackerMutex.Unlock()
-
-	for i, tier := range d.trackers {
-		for j, tr := range tier.trackers {
-			if tr.url == trackerURL {
-				d.trackers[i].trackers = slices.Delete(tier.trackers, j, j+1)
-				d.trackerErrorsMap.Delete(trackerURL)
-				d.trackerSeeds.Delete(trackerURL)
-				d.trackerLeechers.Delete(trackerURL)
-				// remove empty tiers
-				if len(d.trackers[i].trackers) == 0 {
-					d.trackers = slices.Delete(d.trackers, i, i+1)
-				}
-				return nil
-			}
-		}
-	}
-
+	d.Trk.Remove(trackerURL)
 	return nil
 }
 
@@ -409,25 +368,7 @@ func (c *Client) ReplaceTrackers(h metainfo.Hash, replacements map[string]string
 		return fmt.Errorf("torrent %s not exists", h)
 	}
 
-	d.trackerMutex.Lock()
-	defer d.trackerMutex.Unlock()
-
-	for _, tier := range d.trackers {
-		for _, tr := range tier.trackers {
-			if newURL, ok := replacements[tr.url]; ok {
-				d.trackerErrorsMap.Delete(tr.url)
-				if s, loaded := d.trackerSeeds.LoadAndDelete(tr.url); loaded {
-					d.trackerSeeds.Store(newURL, s)
-				}
-				if l, loaded := d.trackerLeechers.LoadAndDelete(tr.url); loaded {
-					d.trackerLeechers.Store(newURL, l)
-				}
-				tr.url = newURL
-				tr.nextAnnounce = time.Now()
-			}
-		}
-	}
-
+	d.Trk.Replace(replacements)
 	return nil
 }
 
@@ -449,6 +390,7 @@ func (c *Client) RemoveTorrent(h metainfo.Hash, removeData bool) error {
 
 	d.cancel()
 
+	d.Trk.Stop()
 	d.backgroundWg.Wait()
 
 	d.peers.Range(func(key netip.AddrPort, p *Peer) bool {
@@ -534,9 +476,6 @@ func (c *Client) DebugHandlers() http.Handler {
 }
 
 func debugPrintTrackers(w io.Writer, d *Download) {
-	d.trackerMutex.RLock()
-	defer d.trackerMutex.RUnlock()
-
 	t := table.NewWriter()
 
 	t.AppendHeader(table.Row{"tier", "url", "seeders", "leechers", "last announce", "next announce",
@@ -544,23 +483,21 @@ func debugPrintTrackers(w io.Writer, d *Download) {
 
 	t.SortBy([]table.SortBy{{Name: "tier"}, {Name: "url"}})
 
-	for iterIndex, tier := range d.trackers {
-		for _, tracker := range tier.trackers {
-			trackerSeed, _ := d.trackerSeeds.Load(tracker.url)
-			trackerLeecher, _ := d.trackerLeechers.Load(tracker.url)
-			t.AppendRow(table.Row{
-				iterIndex,
-				lo.Ellipsis(tracker.url, 40),
-				trackerSeed,
-				trackerLeecher,
-				tracker.lastAnnounceTime.Format(time.RFC3339),
-				tracker.nextAnnounce.Format(time.RFC3339),
-				tracker.peerCount,
-				tracker.failureMessage,
-				tracker.err,
-			})
-		}
-	}
+	d.Trk.Each(func(tierIdx int, tr *tracker.Tracker) {
+		trackerSeed, _ := d.Trk.Seeds.Load(tr.URL)
+		trackerLeecher, _ := d.Trk.Leechers.Load(tr.URL)
+		t.AppendRow(table.Row{
+			tierIdx,
+			lo.Ellipsis(tr.URL, 40),
+			trackerSeed,
+			trackerLeecher,
+			tr.LastAnnounceTime.Format(time.RFC3339),
+			tr.NextAnnounce.Format(time.RFC3339),
+			tr.PeerCount,
+			tr.FailureMessage,
+			tr.Err,
+		})
+	})
 
 	_, _ = io.WriteString(w, t.Render())
 	_, _ = fmt.Fprintln(w)

--- a/internal/core/c_scrape.go
+++ b/internal/core/c_scrape.go
@@ -10,6 +10,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/trim21/go-bencode"
 
+	"neptune/internal/core/tracker"
 	"neptune/internal/metainfo"
 	"neptune/internal/pkg/null"
 )
@@ -28,7 +29,7 @@ type scrapeResponseFile struct {
 // trackerRef references a specific tracker within a download.
 type trackerRef struct {
 	download *Download
-	tracker  *Tracker
+	tracker  *tracker.Tracker
 }
 
 func (c *Client) scrape() {
@@ -45,16 +46,12 @@ func (c *Client) scrape() {
 			continue
 		}
 
-		d.m.RLock()
-		for _, tier := range d.trackers {
-			for _, t := range tier.trackers {
-				if scrapeURL, ok := announceToScrape(t.url); ok {
-					m[scrapeURL] = append(m[scrapeURL], trackerRef{download: d, tracker: t})
-					hashes[scrapeURL] = append(hashes[scrapeURL], d.info.Hash)
-				}
+		d.Trk.Each(func(_ int, t *tracker.Tracker) {
+			if scrapeURL, ok := tracker.AnnounceToScrape(t.URL); ok {
+				m[scrapeURL] = append(m[scrapeURL], trackerRef{download: d, tracker: t})
+				hashes[scrapeURL] = append(hashes[scrapeURL], d.info.Hash)
 			}
-		}
-		d.m.RUnlock()
+		})
 	}
 
 	for scrapeURL, refs := range m {
@@ -77,8 +74,8 @@ func (c *Client) scrape() {
 
 		for _, ref := range refs {
 			if file, ok := resp.Files[ref.download.info.Hash]; ok {
-				ref.download.trackerSeeds.Store(ref.tracker.url, file.Complete)
-				ref.download.trackerLeechers.Store(ref.tracker.url, file.Incomplete)
+				ref.download.Trk.Seeds.Store(ref.tracker.URL, file.Complete)
+				ref.download.Trk.Leechers.Store(ref.tracker.URL, file.Incomplete)
 			}
 		}
 	}

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -20,6 +20,7 @@ import (
 	"github.com/samber/lo"
 	"go.uber.org/atomic"
 
+	"neptune/internal/core/tracker"
 	"neptune/internal/meta"
 	"neptune/internal/metainfo"
 	"neptune/internal/pkg/as"
@@ -135,16 +136,12 @@ type Download struct {
 	selectedFilesSet       map[int]struct{}
 	basePath               string
 	downloadDir            string
-	trackerKey             string
 	chunk                  chunkState
 	tags                   []string
 	custom                 map[string]string
 	pieceInfo              pieceInfo
-	trackers               []TrackerTier
+	Trk                    *tracker.Trackers
 	pieceAvailability      []int32
-	trackerErrorsMap       *xsync.Map[string, string]
-	trackerSeeds           *xsync.Map[string, int]
-	trackerLeechers        *xsync.Map[string, int]
 	info                   meta.Info
 	completed              atomic.Int64
 	selectedSize           atomic.Int64
@@ -157,11 +154,9 @@ type Download struct {
 	downloadAtStart        int64
 	endGameMode            atomic.Bool
 	seq                    atomic.Bool
-	announcePending        atomic.Bool
 	peerSeeds              atomic.Int64
 	peerLeechers           atomic.Int64
 	state                  atomic.Uint32
-	trackerMutex           sync.RWMutex
 	m                      sync.RWMutex
 	backgroundWg           sync.WaitGroup
 	ratePieceMutex         sync.Mutex
@@ -267,9 +262,7 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 			done: make(bitmap.Bitmap, (int64(info.NumPieces)*((info.PieceLength+defaultBlockSize-1)/defaultBlockSize)+63)/64),
 		},
 		endgameRequested: xsync.NewMap[proto.ChunkRequest, empty.Empty](),
-		trackerErrorsMap: xsync.NewMap[string, string](),
-
-		pendingPeers: heap.New[peerWithPriority](),
+		pendingPeers:     heap.New[peerWithPriority](),
 
 		// will use about 1mb per torrent, can be optimized later
 		pieceInfo: buildPieceInfos(info),
@@ -290,11 +283,6 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 
 		downloadDir: basePath,
 
-		trackerKey: random.URLSafeStr(16),
-
-		trackerSeeds:    xsync.NewMap[string, int](),
-		trackerLeechers: xsync.NewMap[string, int](),
-
 		downloadLimiter: ratelimit.New(0),
 		uploadLimiter:   ratelimit.New(0),
 	}
@@ -311,6 +299,30 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 	}
 	d.selectedSize.Store(d.computeSelectedSizeUnsafe())
 	d.buildSelectedPiecesBmUnsafe()
+
+	d.Trk = tracker.New(tracker.Config{
+		Key:             random.URLSafeStr(16),
+		HTTP:            c.http,
+		InfoHash:        info.Hash.AsString(),
+		PeerID:          d.peerID.AsString(),
+		Port:            c.Config.App.P2PPort,
+		Uploaded:        &d.uploaded,
+		UploadedStart:   d.uploadAtStart,
+		Downloaded:      &d.downloaded,
+		DownloadedStart: d.downloadAtStart,
+		Completed:       &d.completed,
+		SelectedSize:    &d.selectedSize,
+		OnPeers: func(peers []netip.AddrPort) {
+			d.pendingPeersMutex.Lock()
+			for _, p := range peers {
+				d.pendingPeers.Push(peerWithPriority{
+					addrPort: p,
+					priority: c.PeerPriority(p),
+				})
+			}
+			d.pendingPeersMutex.Unlock()
+		},
+	})
 
 	d.stateCond = gsync.NewCond(&gsync.EmptyLock{})
 

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -300,7 +300,7 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 	d.selectedSize.Store(d.computeSelectedSizeUnsafe())
 	d.buildSelectedPiecesBmUnsafe()
 
-	d.Trk = tracker.New(tracker.Config{
+	d.Trk = tracker.New(d.ctx, tracker.Config{
 		Key:             random.URLSafeStr(16),
 		HTTP:            c.http,
 		InfoHash:        info.Hash.AsString(),

--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/go-units"
 	"github.com/trim21/errgo"
 
+	"neptune/internal/core/tracker"
 	"neptune/internal/meta"
 	"neptune/internal/pkg/as"
 	"neptune/internal/pkg/bm"
@@ -419,7 +420,7 @@ func (d *Download) checkDone() {
 		return true
 	})
 
-	d.announce(EventCompleted)
+	d.Trk.Announce(tracker.EventCompleted)
 }
 
 // piecePriority computes a priority score for a piece, inspired by libtorrent:

--- a/internal/core/d_loop.go
+++ b/internal/core/d_loop.go
@@ -93,7 +93,7 @@ func (d *Download) AsyncCheck() error {
 func (d *Download) Init(resumed bool, skipHashCheck bool) {
 	d.check(resumed, skipHashCheck)
 
-	d.Trk.Start(d.ctx)
+	d.goBackground(d.Trk.Run)
 	d.Trk.Announce(tracker.EventStarted)
 	go d.startBackground()
 

--- a/internal/core/d_loop.go
+++ b/internal/core/d_loop.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/go-units"
 
+	"neptune/internal/core/tracker"
 	"neptune/internal/pkg/empty"
 	"neptune/internal/pkg/fadvise"
 	"neptune/internal/pkg/filepool"
@@ -32,6 +33,7 @@ func (d *Download) Start() error {
 	}
 
 	d.stateCond.Broadcast()
+	d.Trk.Resume()
 	return nil
 }
 
@@ -43,7 +45,7 @@ func (d *Download) Stop() error {
 
 	d.stateCond.Broadcast()
 
-	d.announce(EventStopped)
+	d.Trk.Pause()
 	return nil
 }
 
@@ -91,7 +93,8 @@ func (d *Download) AsyncCheck() error {
 func (d *Download) Init(resumed bool, skipHashCheck bool) {
 	d.check(resumed, skipHashCheck)
 
-	d.announce(EventStarted)
+	d.Trk.Start(d.ctx)
+	d.Trk.Announce(tracker.EventStarted)
 	go d.startBackground()
 
 	d.saveResume()
@@ -118,7 +121,6 @@ func (d *Download) startBackground() {
 	d.goBackground(d.backgroundResHandler)
 	d.goBackground(d.backgroundReqScheduler)
 	d.goBackground(d.backgroundReqHandler)
-	d.goBackground(d.backgroundTrackerHandler)
 
 	d.goBackground(func() {
 		for {

--- a/internal/core/d_resume.go
+++ b/internal/core/d_resume.go
@@ -6,11 +6,9 @@ package core
 import (
 	"encoding"
 	"fmt"
-	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"slices"
-	"time"
 
 	"github.com/rs/zerolog/log"
 	"github.com/samber/lo"
@@ -98,11 +96,7 @@ func (d *Download) MarshalBinary() (data []byte, err error) {
 		SelectedFiles:      selectedFiles,
 		DownloadSpeedLimit: d.downloadLimiter.Rate(),
 		UploadSpeedLimit:   d.uploadLimiter.Rate(),
-		Trackers: lo.Map(d.trackers, func(tier TrackerTier, index int) []string {
-			return lo.Map(tier.trackers, func(tracker *Tracker, index int) string {
-				return tracker.url
-			})
-		}),
+		Trackers:           d.Trk.URLs(),
 	})
 }
 
@@ -155,13 +149,7 @@ func (c *Client) UnmarshalResume(data []byte) error {
 	d.uploadLimiter.Update(r.UploadSpeedLimit)
 
 	// stagger initial announce time to spread announces over 30 minutes
-	d.trackerMutex.Lock()
-	for _, tier := range d.trackers {
-		for _, t := range tier.trackers {
-			t.nextAnnounce = t.nextAnnounce.Add(time.Duration(rand.IntN(30*60)) * time.Second)
-		}
-	}
-	d.trackerMutex.Unlock()
+	d.Trk.Stagger()
 
 	c.m.Lock()
 	defer c.m.Unlock()

--- a/internal/core/d_tracker.go
+++ b/internal/core/d_tracker.go
@@ -4,391 +4,40 @@
 package core
 
 import (
-	"bytes"
-	"context"
-	"encoding/binary"
-	"errors"
-	"fmt"
 	"net/netip"
-	"net/url"
-	"slices"
-	"strconv"
-	"strings"
 	"time"
 
-	"github.com/go-resty/resty/v2"
-	"github.com/rs/zerolog/log"
 	"github.com/samber/lo"
 	"github.com/samber/lo/mutable"
-	"github.com/trim21/errgo"
-	"github.com/trim21/go-bencode"
-	"github.com/valyala/bytebufferpool"
 
+	"neptune/internal/core/tracker"
 	"neptune/internal/metainfo"
-	"neptune/internal/pkg/empty"
 )
 
-type AnnounceEvent string
-
-const (
-	EventStarted   AnnounceEvent = "started"
-	EventCompleted AnnounceEvent = "Completed"
-	EventStopped   AnnounceEvent = "stopped"
-)
-
-func (d *Download) setAnnounceList(trackers metainfo.AnnounceList) {
-	for _, tier := range trackers {
+func (d *Download) setAnnounceList(list metainfo.AnnounceList) {
+	tiers := make([]tracker.TrackerTier, 0, len(list))
+	for _, tier := range list {
 		mutable.Shuffle(tier)
-		t := TrackerTier{trackers: lo.Map(tier, func(item string, index int) *Tracker {
-			return &Tracker{url: item, nextAnnounce: time.Now()}
-		})}
-
-		d.trackers = append(d.trackers, t)
+		tiers = append(tiers, tracker.TrackerTier{
+			Trackers: lo.Map(tier, func(item string, _ int) *tracker.Tracker {
+				return &tracker.Tracker{URL: item, NextAnnounce: time.Now()}
+			}),
+		})
 	}
+	d.Trk.SetTiers(tiers)
+}
+
+func (d *Download) trackerTotals() (seeders, leechers int) {
+	return d.Trk.Totals()
 }
 
 func (d *Download) trackerErrors() map[string]string {
-	errs := make(map[string]string)
-	d.trackerErrorsMap.Range(func(url string, msg string) bool {
-		errs[url] = msg
+	m := make(map[string]string)
+	d.Trk.Errors.Range(func(url string, msg string) bool {
+		m[url] = msg
 		return true
 	})
-	return errs
-}
-
-func (d *Download) updateTrackerError(t *Tracker) {
-	if msg := t.errorMessage(); msg != "" {
-		d.trackerErrorsMap.Store(t.url, msg)
-	} else {
-		d.trackerErrorsMap.Delete(t.url)
-	}
-}
-
-func (d *Download) backgroundTrackerHandler() {
-	ticker := time.NewTicker(time.Minute)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-d.ctx.Done():
-			return
-		case <-ticker.C:
-			d.TryAnnounce()
-		}
-	}
-}
-
-func (d *Download) TryAnnounce() {
-	if d.announcePending.CompareAndSwap(false, true) {
-		defer d.announcePending.Store(false)
-		d.announce("")
-		select {
-		case d.pendingPeersSignal <- empty.Empty{}:
-		case <-d.ctx.Done():
-		}
-	}
-}
-
-func (d *Download) announce(event AnnounceEvent) {
-	d.trackerMutex.Lock()
-	defer d.trackerMutex.Unlock()
-
-	for _, tier := range d.trackers {
-		r, announced, err := tier.Announce(d, event)
-		if err != nil {
-			continue
-		}
-
-		if !announced {
-			return
-		}
-
-		if len(r.Peers) != 0 {
-			d.pendingPeersMutex.Lock()
-			for _, peer := range r.Peers {
-				d.pendingPeers.Push(peerWithPriority{
-					addrPort: peer,
-					priority: d.c.PeerPriority(peer),
-				})
-			}
-			d.pendingPeersMutex.Unlock()
-			select {
-			case d.pendingPeersSignal <- empty.Empty{}:
-			case <-d.ctx.Done():
-			}
-		}
-		return
-	}
-}
-
-type TrackerTier struct {
-	trackers []*Tracker
-}
-
-func (tier TrackerTier) Announce(d *Download, event AnnounceEvent) (AnnounceResult, bool, error) {
-	if event == EventStopped {
-		tier.announceStop(d)
-		return AnnounceResult{}, false, nil
-	}
-
-	for _, t := range tier.trackers {
-		now := time.Now()
-		if t.nextAnnounce.After(now) {
-			return AnnounceResult{}, false, nil
-		}
-
-		r := t.announce(d, event)
-		if r.Interval == 0 {
-			r.Interval = defaultTrackerInterval
-		}
-
-		t.lastAnnounceTime = now
-		t.nextAnnounce = now.Add(r.Interval)
-		t.failureMessage = r.FailedReason
-
-		if r.Err != nil {
-			t.err = r.Err
-			d.updateTrackerError(t)
-			continue
-		}
-
-		t.err = nil
-		d.updateTrackerError(t)
-		t.peerCount = len(r.Peers)
-
-		r.Peers = lo.Uniq(r.Peers)
-
-		return r, true, nil
-	}
-
-	return AnnounceResult{}, false, nil
-}
-
-func (tier TrackerTier) announceStop(d *Download) {
-	for _, t := range tier.trackers {
-		if !t.lastAnnounceTime.IsZero() {
-			_ = t.announceStop(d)
-		}
-	}
-}
-
-type nonCompactAnnounceResponse struct {
-	IP   string `bencode:"ip"`
-	Port uint16 `bencode:"port"`
-}
-
-func parseNonCompatResponse(data []byte) []netip.AddrPort {
-	var s []nonCompactAnnounceResponse
-	if err := bencode.Unmarshal(data, &s); err != nil {
-		return nil
-	}
-
-	var results = make([]netip.AddrPort, 0, len(s))
-	for _, item := range s {
-		a, err := netip.ParseAddr(item.IP)
-		if err != nil {
-			continue
-		}
-		results = append(results, netip.AddrPortFrom(a, item.Port))
-	}
-
-	return results
-}
-
-type AnnounceResult struct {
-	Err          error
-	FailedReason string
-	Peers        []netip.AddrPort
-	Interval     time.Duration
-}
-
-type trackerAnnounceResponse struct {
-	FailureReason string           `bencode:"failure reason"`
-	Peers         bencode.RawBytes `bencode:"peers"`
-	Peers6        bencode.RawBytes `bencode:"peers6"`
-	Interval      int64            `bencode:"interval"`
-	Complete      int              `bencode:"complete"`
-	Incomplete    int              `bencode:"incomplete"`
-}
-
-type Tracker struct {
-	lastAnnounceTime time.Time
-	nextAnnounce     time.Time
-	err              error
-	failureMessage   string
-	url              string
-	peerCount        int
-}
-
-func (t *Tracker) errorMessage() string {
-	if t.failureMessage != "" {
-		return t.failureMessage
-	}
-	if t.err != nil {
-		return t.err.Error()
-	}
-	return ""
-}
-
-func (t *Tracker) req(d *Download) *resty.Request {
-	req := d.c.http.R().
-		SetContext(d.ctx).
-		SetQueryParam("info_hash", d.info.Hash.AsString()).
-		SetQueryParam("peer_id", d.peerID.AsString()).
-		SetQueryParam("port", strconv.FormatUint(uint64(d.c.Config.App.P2PPort), 10)).
-		SetQueryParam("compat", "1").
-		SetQueryParam("key", d.trackerKey).
-		SetQueryParam("uploaded", strconv.FormatInt(d.uploaded.Load()-d.uploadAtStart, 10)).
-		SetQueryParam("downloaded", strconv.FormatInt(d.downloaded.Load()-d.downloadAtStart, 10)).
-		SetQueryParam("left", strconv.FormatInt(d.SelectedSize()-d.completed.Load(), 10))
-
-	if v4 := d.c.ipv4.Load(); v4 != nil {
-		req.SetQueryParam("ipv4", v4.String())
-	}
-
-	if v6 := d.c.ipv4.Load(); v6 != nil {
-		req.SetQueryParam("ipv6", v6.String())
-	}
-
-	return req
-}
-
-const defaultTrackerInterval = time.Minute * 30
-
-func (t *Tracker) announce(d *Download, event AnnounceEvent) AnnounceResult {
-	d.log.Debug().Str("url", t.url).Msg("announce to tracker")
-
-	ctx, cancel := context.WithTimeout(d.ctx, 15*time.Second)
-	defer cancel()
-
-	req := t.req(d).SetContext(ctx)
-
-	if event != "" {
-		req = req.SetQueryParam("event", string(event))
-	}
-
-	res, err := req.Get(t.url)
-	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			return AnnounceResult{Err: errors.New("http request timeout")}
-		}
-		return AnnounceResult{Err: err}
-	}
-
-	var r trackerAnnounceResponse
-	err = bencode.Unmarshal(res.Body(), &r)
-	if err != nil {
-		log.Debug().Err(err).Str("res", res.String()).Msg("failed to decode tracker response")
-		return AnnounceResult{Err: errgo.Wrap(err, "failed to parse torrent announce response")}
-	}
-
-	var result = AnnounceResult{
-		Interval:     defaultTrackerInterval,
-		FailedReason: r.FailureReason,
-	}
-
-	if r.Interval != 0 {
-		result.Interval = time.Second * time.Duration(r.Interval)
-	}
-
-	// BEP says we must support both format
-	if len(r.Peers) != 0 {
-		if r.Peers[0] == 'l' && r.Peers[len(r.Peers)-1] == 'e' {
-			result.Peers = parseNonCompatResponse(r.Peers)
-			// non compact response
-		} else {
-			// compact response
-			var b = bytebufferpool.Get()
-			defer bytebufferpool.Put(b)
-			err = bencode.Unmarshal(r.Peers, &b.B)
-			if err != nil {
-				result.Err = errgo.Wrap(err, "failed to parse binary format 'peers'")
-				return result
-			}
-
-			if b.Len()%6 != 0 {
-				result.Err = fmt.Errorf("invalid binary peers6 length %d", b.Len())
-				return result
-			}
-
-			result.Peers = make([]netip.AddrPort, 0, len(b.B)/6)
-			for i := 0; i < len(b.B); i += 6 {
-				result.Peers = append(result.Peers, parseCompact4(b.B[i:i+6]))
-			}
-		}
-
-		slices.SortFunc(result.Peers, func(a, b netip.AddrPort) int {
-			return bytes.Compare(a.Addr().AsSlice(), b.Addr().AsSlice())
-		})
-	}
-
-	if len(r.Peers6) != 0 {
-		if r.Peers6[0] == 'l' && r.Peers6[len(r.Peers6)-1] == 'e' {
-			// non compact response
-			result.Peers = append(result.Peers, parseNonCompatResponse(r.Peers6)...)
-		} else {
-			// compact response
-			var b = bytebufferpool.Get()
-			defer bytebufferpool.Put(b)
-
-			err = bencode.Unmarshal(r.Peers6, &b.B)
-			if err != nil {
-				result.Err = errgo.Wrap(err, "failed to parse binary format 'peers6'")
-				return result
-			}
-
-			if b.Len()%18 != 0 {
-				result.Err = fmt.Errorf("invalid binary peers6 length %d", b.Len())
-				return result
-			}
-
-			for i := 0; i < b.Len(); i += 18 {
-				result.Peers = append(result.Peers, parseCompact6(b.B[i:i+18]))
-			}
-		}
-	}
-
-	result.Peers = lo.Uniq(result.Peers)
-
-	return result
-}
-
-func (t *Tracker) announceStop(d *Download) error {
-	d.log.Trace().Str("url", t.url).Msg("announce to tracker")
-
-	ctx, cancel := context.WithTimeout(d.ctx, 15*time.Second)
-	defer cancel()
-
-	_, err := t.req(d).SetContext(ctx).
-		SetQueryParam("event", string(EventStopped)).
-		Get(t.url)
-	if err != nil {
-		return errgo.Wrap(err, "failed to parse torrent announce response")
-	}
-
-	return nil
-}
-
-// announceToScrape converts an announce URL to a scrape URL per BEP 48.
-// BEP 48 only applies to HTTP trackers.
-func announceToScrape(announceURL string) (string, bool) {
-	u, err := url.Parse(announceURL)
-	if err != nil {
-		return "", false
-	}
-
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return "", false
-	}
-
-	lastSlash := strings.LastIndex(u.Path, "/")
-	lastPart := u.Path[lastSlash+1:]
-	if !strings.HasPrefix(lastPart, "announce") {
-		return "", false
-	}
-
-	u.Path = u.Path[:lastSlash+1] + "scrape" + lastPart[len("announce"):]
-	return u.String(), true
+	return m
 }
 
 type peerWithPriority struct {
@@ -397,30 +46,5 @@ type peerWithPriority struct {
 }
 
 func (p peerWithPriority) Less(o peerWithPriority) bool {
-	// reversed order, so higher priority get handled first
 	return p.priority > o.priority
-}
-
-func (d *Download) trackerTotals() (seeders, leechers int) {
-	d.trackerSeeds.Range(func(url string, s int) bool {
-		if s > seeders {
-			seeders = s
-		}
-		return true
-	})
-	d.trackerLeechers.Range(func(url string, l int) bool {
-		if l > leechers {
-			leechers = l
-		}
-		return true
-	})
-	return
-}
-
-func parseCompact4(b []byte) netip.AddrPort {
-	return netip.AddrPortFrom(netip.AddrFrom4([4]byte(b[:4])), binary.BigEndian.Uint16(b[4:6]))
-}
-
-func parseCompact6(b []byte) netip.AddrPort {
-	return netip.AddrPortFrom(netip.AddrFrom16([16]byte(b[:16])), binary.BigEndian.Uint16(b[16:18]))
 }

--- a/internal/core/d_tracker_test.go
+++ b/internal/core/d_tracker_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"neptune/internal/core/tracker"
 )
 
 func TestAnnounceToScrape(t *testing.T) {
@@ -74,7 +76,7 @@ func TestAnnounceToScrape(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotURL, gotOK := announceToScrape(tt.announce)
+			gotURL, gotOK := tracker.AnnounceToScrape(tt.announce)
 			assert.Equal(t, tt.wantOK, gotOK)
 			assert.Equal(t, tt.wantURL, gotURL)
 		})

--- a/internal/core/p.go
+++ b/internal/core/p.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rs/zerolog"
 	"go.uber.org/atomic"
 
+	"neptune/internal/core/tracker"
 	"neptune/internal/pkg/as"
 	"neptune/internal/pkg/bm"
 	"neptune/internal/pkg/empty"
@@ -776,7 +777,7 @@ func parsePex(msg proto.ExtPex) ([]pexPeer, []netip.AddrPort, error) {
 
 	for i, flag := range msg.AddedFlag {
 		r = append(r, pexPeer{
-			addrPort:         parseCompact4(msg.Added[i*6 : i*6+6]),
+			addrPort:         tracker.ParseCompact4(msg.Added[i*6 : i*6+6]),
 			preferEnc:        flag&proto.PexFlagPreferEnc != 0,
 			seedOnly:         flag&proto.PexFlagSeedOnly != 0,
 			supportUTP:       flag&proto.PexFlagSupportUTP != 0,
@@ -787,7 +788,7 @@ func parsePex(msg proto.ExtPex) ([]pexPeer, []netip.AddrPort, error) {
 
 	for i, flag := range msg.Added6Flag {
 		r = append(r, pexPeer{
-			addrPort:         parseCompact6(msg.Added6[i*18 : i*18+18]),
+			addrPort:         tracker.ParseCompact6(msg.Added6[i*18 : i*18+18]),
 			preferEnc:        flag&proto.PexFlagPreferEnc != 0,
 			seedOnly:         flag&proto.PexFlagSeedOnly != 0,
 			supportUTP:       flag&proto.PexFlagSupportUTP != 0,
@@ -799,11 +800,11 @@ func parsePex(msg proto.ExtPex) ([]pexPeer, []netip.AddrPort, error) {
 	var dropped = make([]netip.AddrPort, 0, len(msg.Dropped)/6+len(msg.Dropped6)/18)
 
 	for i := 0; i < len(msg.Dropped); i += 6 {
-		dropped = append(dropped, parseCompact4(msg.Dropped[i:i+6]))
+		dropped = append(dropped, tracker.ParseCompact4(msg.Dropped[i:i+6]))
 	}
 
 	for i := 0; i < len(msg.Dropped6); i += 18 {
-		dropped = append(dropped, parseCompact6(msg.Dropped6[i:i+18]))
+		dropped = append(dropped, tracker.ParseCompact6(msg.Dropped6[i:i+18]))
 	}
 
 	return r, dropped, nil

--- a/internal/core/tracker/tracker.go
+++ b/internal/core/tracker/tracker.go
@@ -1,0 +1,661 @@
+// Copyright 2024 trim21 <trim21.me@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+// Package tracker manages BitTorrent tracker announce loops.
+package tracker
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"net/netip"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/puzpuzpuz/xsync/v4"
+	"github.com/samber/lo"
+	"github.com/trim21/errgo"
+	"github.com/trim21/go-bencode"
+	"github.com/valyala/bytebufferpool"
+	"go.uber.org/atomic"
+)
+
+type AnnounceEvent string
+
+const (
+	EventStarted   AnnounceEvent = "started"
+	EventCompleted AnnounceEvent = "Completed"
+	EventStopped   AnnounceEvent = "stopped"
+)
+
+// AnnounceResponse is the parsed result from a tracker announce.
+type AnnounceResponse struct {
+	Err          error
+	FailedReason string
+	Peers        []netip.AddrPort
+	Interval     time.Duration
+	Seeders      int
+	Leechers     int
+}
+
+// Tracker is a single announce URL with its state.
+type Tracker struct {
+	URL              string
+	LastAnnounceTime time.Time
+	NextAnnounce     time.Time
+	Err              error
+	FailureMessage   string
+	PeerCount        int
+	inFlight         atomic.Bool
+}
+
+// ErrorMessage returns the current error state description.
+func (t *Tracker) ErrorMessage() string {
+	if t.FailureMessage != "" {
+		return t.FailureMessage
+	}
+	if t.Err != nil {
+		return t.Err.Error()
+	}
+	return ""
+}
+
+// TrackerTier is a group of trackers at the same priority tier.
+type TrackerTier struct {
+	Trackers []*Tracker
+}
+
+// Config holds the static configuration for Trackers.
+type Config struct {
+	HTTP            *resty.Client
+	Uploaded        *atomic.Int64
+	Downloaded      *atomic.Int64
+	Completed       *atomic.Int64
+	SelectedSize    *atomic.Int64
+	OnPeers         func([]netip.AddrPort)
+	Key             string
+	InfoHash        string
+	PeerID          string
+	UploadedStart   int64
+	DownloadedStart int64
+	Port            uint16
+}
+
+// Trackers manages announce trackers and the background announce loop.
+type Trackers struct {
+	ctx             context.Context
+	selectedSize    *atomic.Int64
+	Seeds           *xsync.Map[string, int]
+	Leechers        *xsync.Map[string, int]
+	cancel          context.CancelFunc
+	Errors          *xsync.Map[string, string]
+	http            *resty.Client
+	onPeers         func([]netip.AddrPort)
+	queue           chan AnnounceEvent
+	uploaded        *atomic.Int64
+	completed       *atomic.Int64
+	downloaded      *atomic.Int64
+	peerID          string
+	infoHash        string
+	Key             string
+	tiers           []TrackerTier
+	wg              sync.WaitGroup
+	startOnce       sync.Once
+	paused          atomic.Bool
+	resumeCh        chan struct{}
+	downloadedStart int64
+	uploadedStart   int64
+	mu              sync.RWMutex
+	port            uint16
+}
+
+// New creates a Trackers instance.
+func New(cfg Config) *Trackers {
+	return &Trackers{
+		Errors:   xsync.NewMap[string, string](),
+		Seeds:    xsync.NewMap[string, int](),
+		Leechers: xsync.NewMap[string, int](),
+		Key:      cfg.Key,
+
+		http:     cfg.HTTP,
+		infoHash: cfg.InfoHash,
+		peerID:   cfg.PeerID,
+		port:     cfg.Port,
+
+		uploaded:        cfg.Uploaded,
+		uploadedStart:   cfg.UploadedStart,
+		downloaded:      cfg.Downloaded,
+		downloadedStart: cfg.DownloadedStart,
+		completed:       cfg.Completed,
+		selectedSize:    cfg.SelectedSize,
+
+		resumeCh: make(chan struct{}, 1),
+		queue:    make(chan AnnounceEvent, 1),
+		onPeers:  cfg.OnPeers,
+	}
+}
+
+// Start begins the background announce loop. The loop runs until ctx is cancelled.
+func (t *Trackers) Start(ctx context.Context) {
+	t.startOnce.Do(func() {
+		t.ctx, t.cancel = context.WithCancel(ctx)
+		t.wg.Add(1)
+		go t.loop()
+	})
+}
+
+// Stop cancels the background loop and waits for it to finish.
+func (t *Trackers) Stop() {
+	if t.cancel != nil {
+		t.cancel()
+	}
+	t.wg.Wait()
+}
+
+// Announce enqueues an announce event. Non-blocking.
+func (t *Trackers) Announce(event AnnounceEvent) {
+	select {
+	case t.queue <- event:
+	default:
+	}
+}
+
+// Totals returns the max seeders and leechers across all trackers.
+func (t *Trackers) Totals() (seeders, leechers int) {
+	t.Seeds.Range(func(_ string, s int) bool {
+		if s > seeders {
+			seeders = s
+		}
+		return true
+	})
+	t.Leechers.Range(func(_ string, l int) bool {
+		if l > leechers {
+			leechers = l
+		}
+		return true
+	})
+	return
+}
+
+// SetError updates the error message for a tracker URL.
+
+// Info holds tracker metadata for API responses.
+type Info struct {
+	URL  string
+	Err  string
+	Tier int
+}
+
+// SetTiers replaces the tracker tier list.
+func (t *Trackers) SetTiers(tiers []TrackerTier) {
+	t.mu.Lock()
+	t.tiers = tiers
+	t.mu.Unlock()
+}
+
+// Add adds a tracker URL at the given tier.
+func (t *Trackers) Add(url string, tier int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	for _, t := range t.tiers {
+		for _, tr := range t.Trackers {
+			if tr.URL == url {
+				return
+			}
+		}
+	}
+
+	tr := &Tracker{URL: url, NextAnnounce: time.Now()}
+	if tier >= 0 && tier < len(t.tiers) {
+		t.tiers[tier].Trackers = append(t.tiers[tier].Trackers, tr)
+	} else {
+		t.tiers = append(t.tiers, TrackerTier{Trackers: []*Tracker{tr}})
+	}
+}
+
+// Remove deletes a tracker by URL.
+func (t *Trackers) Remove(url string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	for i, tier := range t.tiers {
+		for j, tr := range tier.Trackers {
+			if tr.URL == url {
+				t.tiers[i].Trackers = slices.Delete(tier.Trackers, j, j+1)
+				t.Errors.Delete(url)
+				t.Seeds.Delete(url)
+				t.Leechers.Delete(url)
+				if len(t.tiers[i].Trackers) == 0 {
+					t.tiers = slices.Delete(t.tiers, i, i+1)
+				}
+				return
+			}
+		}
+	}
+}
+
+// Replace renames tracker URLs.
+func (t *Trackers) Replace(replacements map[string]string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	for _, tier := range t.tiers {
+		for _, tr := range tier.Trackers {
+			if newURL, ok := replacements[tr.URL]; ok {
+				t.Errors.Delete(tr.URL)
+				if s, loaded := t.Seeds.LoadAndDelete(tr.URL); loaded {
+					t.Seeds.Store(newURL, s)
+				}
+				if l, loaded := t.Leechers.LoadAndDelete(tr.URL); loaded {
+					t.Leechers.Store(newURL, l)
+				}
+				tr.URL = newURL
+				tr.NextAnnounce = time.Now()
+			}
+		}
+	}
+}
+
+// List returns all tracker info for API responses.
+func (t *Trackers) List() []Info {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	var infos []Info
+	for i, tier := range t.tiers {
+		for _, tr := range tier.Trackers {
+			errMsg, _ := t.Errors.Load(tr.URL)
+			infos = append(infos, Info{Tier: i, URL: tr.URL, Err: errMsg})
+		}
+	}
+	return infos
+}
+
+// Each calls fn for every tracker under read lock.
+// The callback must not call any Trackers method that acquires the write lock
+// (Add, Remove, SetTiers, Pause, Resume, etc.) — this would deadlock.
+func (t *Trackers) Each(fn func(tierIdx int, tr *Tracker)) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	for i, tier := range t.tiers {
+		for _, tr := range tier.Trackers {
+			fn(i, tr)
+		}
+	}
+}
+
+// URLs returns tracker URLs grouped by tier (for resume serialization).
+func (t *Trackers) URLs() [][]string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	urls := make([][]string, len(t.tiers))
+	for i, tier := range t.tiers {
+		urls[i] = make([]string, len(tier.Trackers))
+		for j, tr := range tier.Trackers {
+			urls[i][j] = tr.URL
+		}
+	}
+	return urls
+}
+
+// Stagger adds a random delay to all NextAnnounce times.
+func (t *Trackers) Stagger() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, tier := range t.tiers {
+		for _, tr := range tier.Trackers {
+			tr.NextAnnounce = tr.NextAnnounce.Add(time.Duration(rand.IntN(30*60)) * time.Second)
+		}
+	}
+}
+
+func (t *Trackers) SetError(tr *Tracker) {
+	if msg := tr.ErrorMessage(); msg != "" {
+		t.Errors.Store(tr.URL, msg)
+	} else {
+		t.Errors.Delete(tr.URL)
+	}
+}
+
+// Pause stops the periodic announce loop and sends EventStopped to all trackers.
+// Safe to call multiple times; only the first call takes effect.
+func (t *Trackers) Pause() {
+	if !t.paused.CompareAndSwap(false, true) {
+		return
+	}
+	go t.announceToAll(EventStopped)
+}
+
+// Resume restarts the periodic announce loop, resets NextAnnounce for all
+// trackers so the next tick announces immediately, and signals the loop to wake up.
+// Safe to call multiple times; only the first call after a Pause takes effect.
+func (t *Trackers) Resume() {
+	if !t.paused.CompareAndSwap(true, false) {
+		return
+	}
+
+	t.mu.Lock()
+	for _, tier := range t.tiers {
+		for _, tr := range tier.Trackers {
+			tr.NextAnnounce = time.Now()
+		}
+	}
+	t.mu.Unlock()
+
+	select {
+	case t.resumeCh <- struct{}{}:
+	default:
+	}
+}
+
+// announceToAll sends an announce event to every tracker (best-effort, 5s timeout per request).
+// Stops early if context is cancelled or Trackers is resumed.
+func (t *Trackers) announceToAll(event AnnounceEvent) {
+	t.mu.RLock()
+	trackers := make([]*Tracker, 0)
+	for _, tier := range t.tiers {
+		trackers = append(trackers, tier.Trackers...)
+	}
+	t.mu.RUnlock()
+
+	for _, tr := range trackers {
+		if t.ctx.Err() != nil || !t.paused.Load() {
+			return
+		}
+		if !tr.inFlight.CompareAndSwap(false, true) {
+			continue
+		}
+
+		ctx, cancel := context.WithTimeout(t.ctx, 5*time.Second)
+		_, err := t.announceReq(ctx, event).Get(tr.URL)
+		cancel()
+
+		if err != nil {
+			t.mu.Lock()
+			tr.Err = err
+			t.SetError(tr)
+			t.mu.Unlock()
+		}
+
+		tr.inFlight.Store(false)
+	}
+}
+
+func (t *Trackers) loop() {
+	defer t.wg.Done()
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-t.ctx.Done():
+			return
+		case event := <-t.queue:
+			t.doAnnounce(event)
+		case <-t.resumeCh:
+			if !t.paused.Load() {
+				t.doAnnounce(EventStarted)
+			}
+		case <-ticker.C:
+			if !t.paused.Load() {
+				t.doAnnounce("")
+			}
+		}
+	}
+}
+
+// doAnnounce finds all due trackers that are not currently in-flight and launches
+// goroutines to perform the HTTP announce. The loop runs until no more due
+// trackers remain, then returns without blocking.
+func (t *Trackers) doAnnounce(event AnnounceEvent) {
+	for {
+		t.mu.Lock()
+		var target *Tracker
+		for _, tier := range t.tiers {
+			for _, tr := range tier.Trackers {
+				if !tr.inFlight.Load() && !tr.NextAnnounce.After(time.Now()) {
+					target = tr
+					tr.inFlight.Store(true)
+					break
+				}
+			}
+			if target != nil {
+				break
+			}
+		}
+		t.mu.Unlock()
+
+		if target == nil {
+			return
+		}
+
+		if event == EventStopped {
+			go t.finishStop(target)
+		} else {
+			go t.finishAnnounce(target, event)
+		}
+	}
+}
+
+// finishAnnounce performs the HTTP announce for a single tracker and updates its state.
+// Called from a goroutine spawned by doAnnounce.
+func (t *Trackers) finishAnnounce(tr *Tracker, event AnnounceEvent) {
+	defer tr.inFlight.Store(false)
+
+	r := t.announceHTTP(tr, event)
+
+	now := time.Now()
+	if r.Interval == 0 {
+		r.Interval = 30 * time.Minute
+	}
+
+	t.mu.Lock()
+	tr.LastAnnounceTime = now
+	tr.NextAnnounce = now.Add(r.Interval)
+	tr.FailureMessage = r.FailedReason
+	if r.Err != nil {
+		tr.Err = r.Err
+	} else {
+		tr.Err = nil
+		tr.PeerCount = len(r.Peers)
+	}
+	t.SetError(tr)
+	t.mu.Unlock()
+
+	if r.Err != nil {
+		return
+	}
+
+	if r.Seeders > 0 {
+		t.Seeds.Store(tr.URL, r.Seeders)
+	}
+	if r.Leechers > 0 {
+		t.Leechers.Store(tr.URL, r.Leechers)
+	}
+
+	r.Peers = lo.Uniq(r.Peers)
+	if len(r.Peers) > 0 && t.onPeers != nil {
+		t.onPeers(r.Peers)
+	}
+}
+
+// finishStop completes the stopped announce for a single tracker.
+func (t *Trackers) finishStop(tr *Tracker) {
+	defer tr.inFlight.Store(false)
+	t.announceStop(tr)
+}
+
+func (t *Trackers) announceStop(tr *Tracker) {
+	ctx, cancel := context.WithTimeout(t.ctx, 15*time.Second)
+	defer cancel()
+
+	_, err := t.announceReq(ctx, EventStopped).Get(tr.URL)
+	if err != nil {
+		t.mu.Lock()
+		tr.Err = err
+		t.SetError(tr)
+		t.mu.Unlock()
+	}
+}
+
+func (t *Trackers) announceHTTP(tr *Tracker, event AnnounceEvent) AnnounceResponse {
+	ctx, cancel := context.WithTimeout(t.ctx, 15*time.Second)
+	defer cancel()
+
+	resp, err := t.announceReq(ctx, event).Get(tr.URL)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return AnnounceResponse{Err: errors.New("http request timeout")}
+		}
+		return AnnounceResponse{Err: err}
+	}
+
+	var r trackerAnnounceResponse
+	if err := bencode.Unmarshal(resp.Body(), &r); err != nil {
+		return AnnounceResponse{Err: errgo.Wrap(err, "failed to parse tracker announce response")}
+	}
+
+	result := AnnounceResponse{
+		Interval:     30 * time.Minute,
+		FailedReason: r.FailureReason,
+		Seeders:      r.Complete,
+		Leechers:     r.Incomplete,
+	}
+
+	if r.Interval != 0 {
+		result.Interval = time.Second * time.Duration(r.Interval)
+	}
+
+	if len(r.Peers) != 0 {
+		if r.Peers[0] == 'l' && r.Peers[len(r.Peers)-1] == 'e' {
+			result.Peers = parseNonCompact(r.Peers)
+		} else {
+			var b = bytebufferpool.Get()
+			defer bytebufferpool.Put(b)
+			if err := bencode.Unmarshal(r.Peers, &b.B); err != nil {
+				result.Err = errgo.Wrap(err, "failed to parse binary 'peers'")
+				return result
+			}
+			if b.Len()%6 != 0 {
+				result.Err = fmt.Errorf("invalid binary peers length %d", b.Len())
+				return result
+			}
+			result.Peers = make([]netip.AddrPort, 0, b.Len()/6)
+			for i := 0; i < b.Len(); i += 6 {
+				result.Peers = append(result.Peers, ParseCompact4(b.B[i:i+6]))
+			}
+		}
+	}
+
+	if len(r.Peers6) != 0 {
+		if r.Peers6[0] == 'l' && r.Peers6[len(r.Peers6)-1] == 'e' {
+			result.Peers = append(result.Peers, parseNonCompact(r.Peers6)...)
+		} else {
+			var b = bytebufferpool.Get()
+			defer bytebufferpool.Put(b)
+			if err := bencode.Unmarshal(r.Peers6, &b.B); err != nil {
+				result.Err = errgo.Wrap(err, "failed to parse binary 'peers6'")
+				return result
+			}
+			if b.Len()%18 != 0 {
+				result.Err = fmt.Errorf("invalid binary peers6 length %d", b.Len())
+				return result
+			}
+			for i := 0; i < b.Len(); i += 18 {
+				result.Peers = append(result.Peers, ParseCompact6(b.B[i:i+18]))
+			}
+		}
+	}
+
+	slices.SortFunc(result.Peers, func(a, b netip.AddrPort) int {
+		return bytes.Compare(a.Addr().AsSlice(), b.Addr().AsSlice())
+	})
+
+	return result
+}
+
+func (t *Trackers) announceReq(ctx context.Context, event AnnounceEvent) *resty.Request {
+	req := t.http.R().
+		SetContext(ctx).
+		SetQueryParam("info_hash", t.infoHash).
+		SetQueryParam("peer_id", t.peerID).
+		SetQueryParam("port", strconv.Itoa(int(t.port))).
+		SetQueryParam("compact", "1").
+		SetQueryParam("key", t.Key).
+		SetQueryParam("uploaded", strconv.FormatInt(t.uploaded.Load()-t.uploadedStart, 10)).
+		SetQueryParam("downloaded", strconv.FormatInt(t.downloaded.Load()-t.downloadedStart, 10)).
+		SetQueryParam("left", strconv.FormatInt(t.selectedSize.Load()-t.completed.Load(), 10))
+	if event != "" {
+		req.SetQueryParam("event", string(event))
+	}
+	return req
+}
+
+// ---- internal types and helpers ----
+
+type trackerAnnounceResponse struct {
+	FailureReason string           `bencode:"failure reason"`
+	Peers         bencode.RawBytes `bencode:"peers"`
+	Peers6        bencode.RawBytes `bencode:"peers6"`
+	Interval      int64            `bencode:"interval"`
+	Complete      int              `bencode:"complete"`
+	Incomplete    int              `bencode:"incomplete"`
+}
+
+type nonCompactPeer struct {
+	IP   string `bencode:"ip"`
+	Port uint16 `bencode:"port"`
+}
+
+func parseNonCompact(data []byte) []netip.AddrPort {
+	var s []nonCompactPeer
+	if err := bencode.Unmarshal(data, &s); err != nil {
+		return nil
+	}
+	r := make([]netip.AddrPort, 0, len(s))
+	for _, item := range s {
+		a, err := netip.ParseAddr(item.IP)
+		if err != nil {
+			continue
+		}
+		r = append(r, netip.AddrPortFrom(a, item.Port))
+	}
+	return r
+}
+
+// ParseCompact4 parses a 6-byte compact IPv4 peer address.
+func ParseCompact4(b []byte) netip.AddrPort {
+	return netip.AddrPortFrom(netip.AddrFrom4([4]byte(b[:4])), binary.BigEndian.Uint16(b[4:6]))
+}
+
+// ParseCompact6 parses an 18-byte compact IPv6 peer address.
+func ParseCompact6(b []byte) netip.AddrPort {
+	return netip.AddrPortFrom(netip.AddrFrom16([16]byte(b[:16])), binary.BigEndian.Uint16(b[16:18]))
+}
+
+// AnnounceToScrape converts an announce URL to a scrape URL per BEP 48.
+func AnnounceToScrape(announceURL string) (string, bool) {
+	u, err := url.Parse(announceURL)
+	if err != nil {
+		return "", false
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", false
+	}
+	lastSlash := strings.LastIndex(u.Path, "/")
+	lastPart := u.Path[lastSlash+1:]
+	if !strings.HasPrefix(lastPart, "announce") {
+		return "", false
+	}
+	u.Path = u.Path[:lastSlash+1] + "scrape" + lastPart[len("announce"):]
+	return u.String(), true
+}

--- a/internal/core/tracker/tracker.go
+++ b/internal/core/tracker/tracker.go
@@ -92,28 +92,28 @@ type Config struct {
 // Trackers manages announce trackers and the background announce loop.
 type Trackers struct {
 	ctx             context.Context
-	selectedSize    *atomic.Int64
+	http            *resty.Client
 	Seeds           *xsync.Map[string, int]
 	Leechers        *xsync.Map[string, int]
 	cancel          context.CancelFunc
 	Errors          *xsync.Map[string, string]
-	http            *resty.Client
+	resumeCh        chan struct{}
 	onPeers         func([]netip.AddrPort)
 	queue           chan AnnounceEvent
 	uploaded        *atomic.Int64
 	completed       *atomic.Int64
 	downloaded      *atomic.Int64
+	selectedSize    *atomic.Int64
 	peerID          string
-	infoHash        string
 	Key             string
+	infoHash        string
 	tiers           []TrackerTier
 	wg              sync.WaitGroup
-	startOnce       sync.Once
 	paused          atomic.Bool
-	resumeCh        chan struct{}
 	downloadedStart int64
 	uploadedStart   int64
 	mu              sync.RWMutex
+	startOnce       sync.Once
 	port            uint16
 }
 

--- a/internal/core/tracker/tracker.go
+++ b/internal/core/tracker/tracker.go
@@ -95,7 +95,6 @@ type Trackers struct {
 	http            *resty.Client
 	Seeds           *xsync.Map[string, int]
 	Leechers        *xsync.Map[string, int]
-	cancel          context.CancelFunc
 	Errors          *xsync.Map[string, string]
 	resumeCh        chan struct{}
 	onPeers         func([]netip.AddrPort)
@@ -108,18 +107,17 @@ type Trackers struct {
 	Key             string
 	infoHash        string
 	tiers           []TrackerTier
-	wg              sync.WaitGroup
 	paused          atomic.Bool
 	downloadedStart int64
 	uploadedStart   int64
 	mu              sync.RWMutex
-	startOnce       sync.Once
 	port            uint16
 }
 
-// New creates a Trackers instance.
-func New(cfg Config) *Trackers {
+// New creates a Trackers instance. ctx controls the announce loop lifetime.
+func New(ctx context.Context, cfg Config) *Trackers {
 	return &Trackers{
+		ctx:      ctx,
 		Errors:   xsync.NewMap[string, string](),
 		Seeds:    xsync.NewMap[string, int](),
 		Leechers: xsync.NewMap[string, int](),
@@ -143,21 +141,10 @@ func New(cfg Config) *Trackers {
 	}
 }
 
-// Start begins the background announce loop. The loop runs until ctx is cancelled.
-func (t *Trackers) Start(ctx context.Context) {
-	t.startOnce.Do(func() {
-		t.ctx, t.cancel = context.WithCancel(ctx)
-		t.wg.Add(1)
-		go t.loop()
-	})
-}
-
-// Stop cancels the background loop and waits for it to finish.
-func (t *Trackers) Stop() {
-	if t.cancel != nil {
-		t.cancel()
-	}
-	t.wg.Wait()
+// Run starts the announce loop and blocks until the context is cancelled.
+// Callers must invoke this in a goroutine.
+func (t *Trackers) Run() {
+	t.loop()
 }
 
 // Announce enqueues an announce event. Non-blocking.
@@ -391,7 +378,6 @@ func (t *Trackers) announceToAll(event AnnounceEvent) {
 }
 
 func (t *Trackers) loop() {
-	defer t.wg.Done()
 	ticker := time.NewTicker(time.Minute)
 	defer ticker.Stop()
 


### PR DESCRIPTION
## Summary

Refactor the Trackers lifecycle to fix concurrency safety issues and remove blocking from the announce loop.

## Changes

### Pause/Resume support

- **`Pause()`**: sets an atomic paused flag and sends `EventStopped` to **all** trackers via `announceToAll()`, instead of the previous single-tracker behavior.
- **`Resume()`**: clears the flag, resets all `NextAnnounce` timestamps, wakes the loop and fires `EventStarted`.
- **Loop guard**: ticker arm checks `!paused.Load()` so the loop doesn't spin every minute when the download is stopped.
- Idempotent via `CAS` — multiple calls are safe.

### Async announce (eliminates loop blocking)

- `doAnnounce()` no longer performs synchronous HTTP (up to 15s). Instead it spawns goroutines for each due tracker, gated by the new `Tracker.inFlight` atomic to prevent concurrent requests to the same tracker.
- The internal loop iterates until all due, non-busy trackers are dispatched, then returns immediately.
- Both the HTTP request and the `onPeers` callback now run in a separate goroutine — the main loop is never blocked.

### Concurrency fixes

| Fix | Detail |
|-----|--------|
| `announceStop` data race | `tr.Err` write moved inside `mu.Lock()` |
| `Start()` init race | Initialization of `t.ctx`/`t.cancel` protected by `sync.Once` |
| `announceToAll` inFlight guard | Prevents `Pause` stopped requests racing with in-progress periodic announces |
| `Each()` deadlock doc | Adds comment warning callbacks must not acquire the write lock |

### Caller updates

| File | Change |
|------|--------|
| `d_loop.go` | `Stop()` → `Trk.Pause()`, `Start()` → `Trk.Resume()` |
| `api.go` | `RemoveTorrent()` → `d.Trk.Stop()` waits for tracker loop before tearing down peers |