### PR TITLE
feat(sdk): add TypeScript SDK and CI workflow

### DIFF
--- a/.github/workflows/neptune-sdk.yml
+++ b/.github/workflows/neptune-sdk.yml
@@ -1,0 +1,40 @@
+name: neptune-sdk
+
+on:
+  push:
+    paths:
+      - "sdk/typescript/**"
+  pull_request:
+    paths:
+      - "sdk/typescript/**"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: sdk/typescript
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: sdk/typescript/pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm format:check
+
+      - run: pnpm check
+
+      - run: pnpm build

--- a/.github/workflows/neptune-sdk.yml
+++ b/.github/workflows/neptune-sdk.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: actions/checkout@v7
 
       - uses: pnpm/action-setup@v4
+        with:
+          version: 11
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/neptune-sdk.yml
+++ b/.github/workflows/neptune-sdk.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 11
+          package_json_file: sdk/typescript/package.json
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/neptune-sdk.yml
+++ b/.github/workflows/neptune-sdk.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6.0.9
         with:
           package_json_file: sdk/typescript/package.json
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: 22
           cache: pnpm

--- a/dprint.json
+++ b/dprint.json
@@ -5,7 +5,8 @@
   "excludes": [
     "**/node_modules",
     "**/*-lock.json",
-    "dprint/**"
+    "dprint/**",
+    "sdk/typescript/**"
   ],
   "plugins": [
     "https://plugins.dprint.dev/json-0.20.0.wasm",

--- a/sdk/typescript/.prettierignore
+++ b/sdk/typescript/.prettierignore
@@ -1,0 +1,12 @@
+# neptune-sdk
+
+# pnpm
+pnpm-lock.yaml
+.pnpm-store/
+
+# build output
+dist/
+
+# IDE
+.vscode/
+.idea/

--- a/sdk/typescript/.prettierrc
+++ b/sdk/typescript/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "bracketSpacing": false,
+  "printWidth": 120,
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -29,6 +29,7 @@
     "format": "prettier -w .",
     "format:check": "prettier -c ."
   },
+  "packageManager": "pnpm@11.9.0",
   "engines": {
     "node": ">=22.0.0"
   },

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@neptune/sdk",
+  "version": "0.1.0",
+  "description": "TypeScript SDK for Neptune BitTorrent client JSON-RPC API",
+  "keywords": [
+    "neptune",
+    "bittorrent",
+    "json-rpc",
+    "client"
+  ],
+  "license": "GPL-3.0-only",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./src/*": "./src/*"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit",
+    "format": "prettier -w .",
+    "format:check": "prettier -c ."
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "devDependencies": {
+    "prettier": "^3.7.4",
+    "typescript": "~6.0.3"
+  }
+}

--- a/sdk/typescript/pnpm-lock.yaml
+++ b/sdk/typescript/pnpm-lock.yaml
@@ -1,0 +1,34 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      prettier:
+        specifier: ^3.7.4
+        version: 3.9.4
+      typescript:
+        specifier: ~6.0.3
+        version: 6.0.3
+
+packages:
+
+  prettier@3.9.4:
+    resolution: {integrity: sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  prettier@3.9.4: {}
+
+  typescript@6.0.3: {}

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1,0 +1,189 @@
+import {NeptuneHTTPError, NeptuneRPCError} from './errors.js';
+import type {
+  AddTorrentParams,
+  AddTorrentResult,
+  AddTrackerParams,
+  DelCustomParams,
+  GlobalSpeedLimitParams,
+  InfoHashParams,
+  ListTorrentParams,
+  MoveTorrentParams,
+  RemoveTorrentParams,
+  RemoveTrackerParams,
+  ReplaceTrackersParams,
+  SetCustomParams,
+  SetFilePriorityParams,
+  SpeedLimitParams,
+  TagsParams,
+  TorrentFiles,
+  TorrentInfo,
+  TorrentList,
+  TorrentPeers,
+  TorrentTrackers,
+  TransferSummary,
+  UpdateCustomParams,
+} from './types.js';
+
+// ── JSON-RPC wire types ─────────────────────────────────────────────
+
+interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  method: string;
+  params: unknown;
+  id: number;
+}
+
+interface JsonRpcResponse<T = unknown> {
+  jsonrpc: '2.0';
+  result?: T;
+  error?: {code: number; message: string; data?: string};
+  id: number;
+}
+
+// ── Method map ───────────────────────────────────────────────────────
+
+/**
+ * Maps every Neptune JSON-RPC method name to its parameter and result types.
+ * Used to provide fully type-safe `.call()` invocations.
+ */
+export interface NeptuneMethodMap {
+  'system.ping': {params: Record<string, never>; result: void};
+  transfer_summary: {params: Record<string, never>; result: TransferSummary};
+  'torrent.list': {params: ListTorrentParams; result: TorrentList};
+  'torrent.get': {params: InfoHashParams; result: TorrentInfo};
+  'torrent.files': {params: InfoHashParams; result: TorrentFiles};
+  'torrent.peers': {params: InfoHashParams; result: TorrentPeers};
+  'torrent.trackers': {params: InfoHashParams; result: TorrentTrackers};
+  'torrent.add': {params: AddTorrentParams; result: AddTorrentResult};
+  'torrent.remove': {params: RemoveTorrentParams; result: void};
+  'torrent.start': {params: InfoHashParams; result: void};
+  'torrent.stop': {params: InfoHashParams; result: void};
+  'torrent.recheck': {params: InfoHashParams; result: void};
+  'torrent.move': {params: MoveTorrentParams; result: void};
+  'torrent.add_tags': {params: TagsParams; result: void};
+  'torrent.remove_tags': {params: TagsParams; result: void};
+  'torrent.add_tracker': {params: AddTrackerParams; result: void};
+  'torrent.remove_tracker': {params: RemoveTrackerParams; result: void};
+  'torrent.replace_trackers': {params: ReplaceTrackersParams; result: void};
+  'torrent.set_file_priority': {params: SetFilePriorityParams; result: void};
+  'torrent.set_download_limit': {params: SpeedLimitParams; result: void};
+  'torrent.set_upload_limit': {params: SpeedLimitParams; result: void};
+  'torrent.custom.set': {params: SetCustomParams; result: void};
+  'torrent.custom.update': {params: UpdateCustomParams; result: void};
+  'torrent.custom.del': {params: DelCustomParams; result: void};
+  'client.set_download_limit': {params: GlobalSpeedLimitParams; result: void};
+  'client.set_upload_limit': {params: GlobalSpeedLimitParams; result: void};
+}
+
+/** Union of all method name strings. */
+export type NeptuneMethod = keyof NeptuneMethodMap;
+
+// ── Client options ───────────────────────────────────────────────────
+
+export interface NeptuneClientOptions {
+  /** Base URL of the Neptune HTTP server (e.g. `http://127.0.0.1:8002`). */
+  baseUrl: string;
+  /** Secret token for the `Authorization` header. */
+  token: string;
+  /**
+   * Custom `fetch` implementation (useful for testing or proxy support).
+   * Defaults to the global `fetch`.
+   */
+  fetch?: typeof fetch;
+}
+
+// ── Client ───────────────────────────────────────────────────────────
+
+/**
+ * Type-safe JSON-RPC 2.0 client for the Neptune headless BitTorrent client.
+ *
+ * @example
+ * ```ts
+ * import { NeptuneClient } from '@neptune/sdk';
+ *
+ * const client = new NeptuneClient({
+ *   baseUrl: 'http://127.0.0.1:8002',
+ *   token: 'your-secret-token',
+ * });
+ *
+ * // Ping the server
+ * await client.call('system.ping');
+ *
+ * // List all torrents
+ * const { torrents } = await client.call('torrent.list');
+ *
+ * // Add a torrent (base64-encoded .torrent file)
+ * const { info_hash } = await client.call('torrent.add', {
+ *   torrent_file: base64Content,
+ *   tags: ['linux-iso'],
+ * });
+ *
+ * // Set global download limit to 10 MiB/s
+ * await client.call('client.set_download_limit', { limit: 10 * 1024 * 1024 });
+ * ```
+ */
+export class NeptuneClient {
+  readonly #baseUrl: string;
+  readonly #token: string;
+  readonly #fetch: typeof fetch;
+  #id = 0;
+
+  constructor(options: NeptuneClientOptions) {
+    // Strip trailing slash for consistent URL joining.
+    this.#baseUrl = options.baseUrl.replace(/\/+$/, '');
+    this.#token = options.token;
+    this.#fetch = options.fetch ?? globalThis.fetch;
+  }
+
+  /**
+   * Invoke a typed Neptune JSON-RPC method.
+   *
+   * @param method  – the method name (e.g. `'torrent.list'`).
+   * @param params  – method parameters (optional when the method takes none).
+   * @returns The parsed result.
+   * @throws {NeptuneRPCError} when the server returns a JSON-RPC error.
+   * @throws {NeptuneHTTPError} when the HTTP request fails.
+   */
+  async call<M extends NeptuneMethod>(
+    method: M,
+    ...args: {} extends NeptuneMethodMap[M]['params']
+      ? [params?: NeptuneMethodMap[M]['params']]
+      : [params: NeptuneMethodMap[M]['params']]
+  ): Promise<NeptuneMethodMap[M]['result']> {
+    const params = args[0] ?? {};
+
+    const request: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      method,
+      params,
+      id: ++this.#id,
+    };
+
+    let response: Response;
+    try {
+      response = await this.#fetch(`${this.#baseUrl}/json_rpc`, {
+        method: 'POST',
+        headers: {
+          Authorization: this.#token,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(request),
+      });
+    } catch (err) {
+      throw new NeptuneHTTPError(`Failed to reach Neptune at ${this.#baseUrl}: ${String(err)}`);
+    }
+
+    if (!response.ok) {
+      throw new NeptuneHTTPError(`Neptune returned HTTP ${response.status} ${response.statusText}`, response.status);
+    }
+
+    const body = (await response.json()) as JsonRpcResponse<NeptuneMethodMap[M]['result']>;
+
+    if (body.error) {
+      throw new NeptuneRPCError(body.error.code, body.error.message, body.error.data);
+    }
+
+    // "result" is absent for void-returning methods (or null on the wire).
+    return body.result as NeptuneMethodMap[M]['result'];
+  }
+}

--- a/sdk/typescript/src/errors.ts
+++ b/sdk/typescript/src/errors.ts
@@ -1,0 +1,40 @@
+/**
+ * Error thrown when the Neptune JSON-RPC server returns an error response.
+ *
+ * Standard JSON-RPC 2.0 error codes:
+ * - `-32700` Parse error
+ * - `-32600` Invalid Request
+ * - `-32601` Method not found
+ * - `-32602` Invalid params
+ * - `-32603` Internal error
+ *
+ * Application-level codes (positive integers) indicate specific Neptune errors.
+ */
+export class NeptuneRPCError extends Error {
+  /** JSON-RPC error code. */
+  code: number;
+  /** Optional additional error data. */
+  data?: string;
+
+  constructor(code: number, message: string, data?: string) {
+    super(message);
+    this.name = 'NeptuneRPCError';
+    this.code = code;
+    this.data = data;
+  }
+}
+
+/**
+ * Error thrown when the HTTP request itself fails (network error,
+ * non-2xx status, etc.).
+ */
+export class NeptuneHTTPError extends Error {
+  /** HTTP status code, if available. */
+  status?: number;
+
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = 'NeptuneHTTPError';
+    this.status = status;
+  }
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,0 +1,34 @@
+export {NeptuneClient} from './client.js';
+export type {NeptuneClientOptions, NeptuneMethod, NeptuneMethodMap} from './client.js';
+
+export {NeptuneHTTPError, NeptuneRPCError} from './errors.js';
+
+export type {
+  AddTorrentParams,
+  AddTorrentResult,
+  AddTrackerParams,
+  DelCustomParams,
+  GlobalSpeedLimitParams,
+  InfoHashParams,
+  ListTorrentParams,
+  MoveTorrentParams,
+  Peer,
+  RemoveTorrentParams,
+  RemoveTrackerParams,
+  ReplaceTrackersParams,
+  SetCustomParams,
+  SetFilePriorityParams,
+  SpeedLimitParams,
+  TagsParams,
+  Torrent,
+  TorrentFile,
+  TorrentFiles,
+  TorrentInfo,
+  TorrentList,
+  TorrentPeers,
+  TorrentState,
+  TorrentTrackers,
+  Tracker,
+  TransferSummary,
+  UpdateCustomParams,
+} from './types.js';

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -1,0 +1,191 @@
+// ── Torrent state ────────────────────────────────────────────────────
+
+/**
+ * BitTorrent state as reported by Neptune.
+ *
+ * - `Stopped`      – torrent is paused.
+ * - `Downloading`  – actively downloading pieces.
+ * - `Seeding`      – download complete, uploading to peers.
+ * - `Checking`     – verifying local data against piece hashes.
+ * - `Moving`       – relocating data files.
+ * - `Error`        – fatal error, torrent is stopped.
+ */
+export type TorrentState = 'Stopped' | 'Downloading' | 'Seeding' | 'Checking' | 'Moving' | 'Error';
+
+// ── Domain types ─────────────────────────────────────────────────────
+
+/** Summary of a single torrent returned by `torrent.list`. */
+export interface Torrent {
+  hash: string;
+  name: string;
+  state: TorrentState;
+  comment: string;
+  directory_base: string;
+  message: string;
+  tracker_errors: Record<string, string>;
+  tags: string[];
+  custom: Record<string, string>;
+  download_rate: number;
+  download_total: number;
+  upload_rate: number;
+  upload_total: number;
+  connection_count: number;
+  completed: number;
+  total_length: number;
+  selected_size: number;
+  add_at: number;
+  private: boolean;
+  total_seeding: number;
+  total_downloading: number;
+  connected_seeding: number;
+  connected_downloading: number;
+}
+
+/** Global transfer rates and totals. */
+export interface TransferSummary {
+  download_rate: number;
+  download_total: number;
+  upload_rate: number;
+  upload_total: number;
+}
+
+/** A single file inside a torrent. */
+export interface TorrentFile {
+  path: string[];
+  index: number;
+  progress: number;
+  size: number;
+}
+
+/** A connected peer. */
+export interface Peer {
+  address: string;
+  client: string;
+  progress: number;
+  download_rate: number;
+  upload_rate: number;
+  is_incoming: boolean;
+}
+
+/** A tracker entry. */
+export interface Tracker {
+  url: string;
+  message: string;
+  tier: number;
+}
+
+/** Basic torrent metadata from `torrent.get`. */
+export interface TorrentInfo {
+  name: string;
+  tags: string[];
+  custom: Record<string, string>;
+}
+
+// ── Response wrappers ────────────────────────────────────────────────
+
+export interface TorrentList {
+  torrents: Torrent[];
+}
+
+export interface TorrentFiles {
+  files: TorrentFile[];
+}
+
+export interface TorrentPeers {
+  peers: Peer[];
+}
+
+export interface TorrentTrackers {
+  trackers: Tracker[];
+}
+
+export interface AddTorrentResult {
+  info_hash: string;
+}
+
+// ── Request types ────────────────────────────────────────────────────
+
+export interface AddTorrentParams {
+  /** Base64-encoded torrent file content. */
+  torrent_file: string;
+  /** Base download directory. If omitted the global default is used. */
+  download_dir?: string;
+  /** Tags to attach to the torrent. */
+  tags?: string[];
+  /** Custom key-value metadata. */
+  custom?: Record<string, string>;
+  /** Indices of files to download. Omit or empty to download all. */
+  selected_files?: number[];
+  /** When true, the torrent name is not appended to `download_dir`. */
+  is_base_dir?: boolean;
+  /** When true, skip piece hash check and only verify file sizes. */
+  skip_hash_check?: boolean;
+}
+
+export interface InfoHashParams {
+  /** 40-character lowercase hex-encoded SHA-1 info hash. */
+  info_hash: string;
+}
+
+export interface RemoveTorrentParams extends InfoHashParams {
+  /** When true, also delete downloaded data files from disk. */
+  delete_data?: boolean;
+}
+
+export interface MoveTorrentParams extends InfoHashParams {
+  /** New base directory for the torrent data. */
+  target_base_path: string;
+}
+
+export interface TagsParams extends InfoHashParams {
+  tags: string[];
+}
+
+export interface SetFilePriorityParams extends InfoHashParams {
+  file_ids: number[];
+  /** 0 = skip (do not download), 1 = normal (download). */
+  priority: number;
+}
+
+export interface SpeedLimitParams extends InfoHashParams {
+  /** Speed limit in bytes/s. 0 or negative = unlimited. */
+  limit: number;
+}
+
+export interface GlobalSpeedLimitParams {
+  /** Speed limit in bytes/s. 0 or negative = unlimited. */
+  limit: number;
+}
+
+export interface ListTorrentParams {
+  /** Custom keys to include in the response. Omit for all keys. */
+  keys?: string[];
+}
+
+export interface AddTrackerParams extends InfoHashParams {
+  url: string;
+  /** Tier index. Appends to a new tier if out of range. Default 0. */
+  tier?: number;
+}
+
+export interface RemoveTrackerParams extends InfoHashParams {
+  url: string;
+}
+
+export interface ReplaceTrackersParams extends InfoHashParams {
+  /** Map of old tracker URL → new tracker URL. */
+  replacements: Record<string, string>;
+}
+
+export interface SetCustomParams extends InfoHashParams {
+  key: string;
+  value: string;
+}
+
+export interface UpdateCustomParams extends InfoHashParams {
+  custom: Record<string, string>;
+}
+
+export interface DelCustomParams extends InfoHashParams {
+  key: string;
+}

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Add a TypeScript SDK (`@neptune/sdk`) for Neptune, providing a type-safe JSON-RPC 2.0 client.

## Changes

### `sdk/typescript/` — TypeScript SDK
- **`NeptuneClient`** — type-safe JSON-RPC 2.0 client covering all 26 Neptune RPC methods
- **`NeptuneMethodMap`** — complete method signature map enabling compile-time type checking
- **Types** — full request/response type definitions (`Torrent`, `Peer`, `Tracker`, `TorrentFile`, etc.)
- **Errors** — `NeptuneRPCError` (JSON-RPC error codes) and `NeptuneHTTPError` (network/HTTP errors)
- **Build** — TypeScript strict mode, Node16 module resolution, target ES2022, Node.js >= 22
- **Formatting** — Prettier configuration

### `.github/workflows/neptune-sdk.yml` — CI
- pnpm install with frozen lockfile
- Prettier format check
- TypeScript type check (`tsc --noEmit`)
- Production build (`tsc`)
- Triggered on changes to `sdk/typescript/**`, with manual `workflow_dispatch` support

### Usage

```ts
import { NeptuneClient } from "@neptune/sdk";

const client = new NeptuneClient({
  baseUrl: "http://127.0.0.1:8002",
  token: "your-secret-token",
});

// List all torrents
const { torrents } = await client.call("torrent.list");

// Add a torrent
const { info_hash } = await client.call("torrent.add", {
  torrent_file: base64Content,
  tags: ["linux-iso"],
});

// Set global download limit to 10 MiB/s
await client.call("client.set_download_limit", {
  limit: 10 * 1024 * 1024,
});
```