### PR TITLE
feat(config): add Lua script config support

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+  "runtime.version": "Lua 5.1",
+  "workspace.library": ["library"]
+}

--- a/docs/config-lua.md
+++ b/docs/config-lua.md
@@ -1,0 +1,165 @@
+# Config Script (config.lua)
+
+Neptune 支持可选的 Lua 配置脚本，与 TOML 配置二选一。
+
+## 加载机制
+
+`config.toml` 和 `config.lua` **二选一**，通过 `--config` 指定（或自动检测）：
+
+```bash
+# 使用 TOML
+neptune --config config.toml
+
+# 使用 Lua
+neptune --config config.lua
+```
+
+不指定 `--config` 时的自动检测逻辑：
+
+- 如果 `{session}/config.lua` 存在 → 使用 Lua
+- 否则 → 使用 `{session}/config.toml`
+
+## 编辑器支持
+
+项目仓库的 [`library/neptune.lua`](../library/neptune.lua) 提供了 [LuaCATS](https://luals.github.io/wiki/annotations/) 类型声明。
+
+在项目根目录有 `.luarc.json` 配置，用 VS Code + [lua-language-server](https://github.com/LuaLS/lua-language-server) 打开仓库即可获得自动补全和类型检查。
+
+对于自己的 `~/.neptune/config.lua`，在该目录创建 `.luarc.json`：
+
+```json
+{
+  "runtime.version": "Lua 5.1",
+  "workspace.library": ["/path/to/neptune/library"]
+}
+```
+
+## 全局 API
+
+### neptune.set(key, value)
+
+设置配置项。重复调用后面的值覆盖前面的值。`key` 必须在白名单内，否则报错。
+
+### neptune.get(key)
+
+读取当前配置值（默认值或被 `neptune.set()` 覆盖后的值）。
+
+### os.getenv(name)
+
+读取环境变量，等价于 `os.Getenv`。变量不存在时返回空字符串 `""`。
+
+### os.hostname()
+
+返回主机名。
+
+### os.cpus()
+
+返回逻辑 CPU 核心数。
+
+### console.log(...) / console.warn(...) / console.error(...)
+
+输出日志到 stderr，格式: `[config] <message>`。
+
+### 标准 Lua 库
+
+`math`、`string`、`table`、`os.date()`、`os.time()` 等标准库可用。
+
+## 配置键列表
+
+| key | 类型 | 说明 | 默认值 |
+|---|---|---|---|
+| `application.download-dir` | string | 下载目录 | `~/downloads` |
+| `application.p2p-port` | number | P2P 监听端口 | `50047` |
+| `application.max-http-parallel` | number | 最大 HTTP 并发连接数 | `100` |
+| `application.num-want` | number | 每次向 peer 请求的 piece 数 | `0` (auto) |
+| `application.global-connections-limit` | number | 全局连接数上限 | `50` |
+| `application.global-upload-slots` | number | 全局上传 slot 上限 | `0` (auto: `connections-limit*4`) |
+| `application.global-download-speed-limit` | number | 全局下载限速 (bytes/sec)，`0` 不限制 | `0` |
+| `application.global-upload-speed-limit` | number | 全局上传限速 (bytes/sec)，`0` 不限制 | `0` |
+| `application.fallocate` | boolean | 是否预分配磁盘空间 | `false` |
+
+Key 使用 kebab-case，与 TOML 完全一致。
+
+## 示例
+
+### 基础：根据主机名切换配置
+
+```lua
+local node = os.getenv("NODE_NAME") or ""
+
+if node == "seedbox" then
+    neptune.set("application.download-dir", "/mnt/big/downloads")
+    neptune.set("application.global-connections-limit", 500)
+    neptune.set("application.global-upload-slots", 200)
+    neptune.set("application.global-upload-speed-limit", 0)  -- 不限速做种
+end
+```
+
+### 时间段限速
+
+```lua
+local hour = tonumber(os.date("%H"))
+
+if hour >= 1 and hour < 8 then
+    -- 夜间不限速
+    neptune.set("application.global-upload-speed-limit", 0)
+    neptune.set("application.global-download-speed-limit", 0)
+else
+    -- 白天限速
+    neptune.set("application.global-upload-speed-limit", 30 * 1024 * 1024)   -- 30 MB/s
+    neptune.set("application.global-download-speed-limit", 100 * 1024 * 1024) -- 100 MB/s
+end
+```
+
+### 根据 CPU 核心数调整并发
+
+```lua
+local conns = neptune.get("application.global-connections-limit")
+neptune.set("application.global-connections-limit", math.max(conns, os.cpus() * 20))
+
+local http = neptune.get("application.max-http-parallel")
+neptune.set("application.max-http-parallel", math.max(http, os.cpus() * 50))
+```
+
+### 多条件组合
+
+```lua
+local node = os.getenv("NODE_NAME") or ""
+local hour = tonumber(os.date("%H"))
+
+-- 默认上传限速 200 MB/s
+neptune.set("application.global-upload-speed-limit", 200 * 1024 * 1024)
+
+if node == "n5" then
+    neptune.set("application.global-upload-speed-limit", 10 * 1024 * 1024)
+    neptune.set("application.global-download-speed-limit", 15 * 1024 * 1024)
+    neptune.set("application.fallocate", false)
+elseif node == "n5-slow" then
+    neptune.set("application.global-download-speed-limit", 5 * 1024 * 1024)
+    neptune.set("application.global-upload-speed-limit", 0)
+end
+
+-- 无论什么节点，深夜都不限速
+if hour >= 2 and hour < 6 then
+    neptune.set("application.global-upload-speed-limit", 0)
+    neptune.set("application.global-download-speed-limit", 0)
+end
+
+console.log("node=" .. node .. " host=" .. os.hostname() .. " cpus=" .. os.cpus())
+```
+
+## 错误处理
+
+- **语法错误**：启动失败，打印 Lua 错误信息
+- **未知 key**：`neptune.set("typoKey", 123)` → 启动失败，列出所有合法 key
+- **类型错误**：`neptune.set("application.p2p-port", "abc")` → 启动失败
+- 未通过 validator 校验的配置值也会导致启动失败
+
+## 注意事项
+
+- `config.toml` 和 `config.lua` 二选一，Lua 脚本存在时 TOML 被忽略
+- 脚本启动时执行一次，不支持热重载
+- 不要写死循环（Lua 默认不带超时中断）
+- `os.getenv()` 返回空字符串表示环境变量不存在
+- `application.download-dir` 未在脚本中设置时默认为 `~/downloads`
+- 配置可信，没有沙箱限制

--- a/etc/example/config.lua
+++ b/etc/example/config.lua
@@ -1,0 +1,37 @@
+-- Neptune configuration script.
+-- If this file exists at {session}/config.lua, it replaces config.toml entirely.
+--
+-- For editor autocompletion, place the library/neptune.lua stub in your
+-- lua-language-server workspace.library path (see .luarc.json).
+--
+--@type neptune Neptune
+--@type console NeptuneConsole
+
+local node = os.getenv("NODE_NAME") or ""
+
+-- Default: 200 MB/s upload, no download limit
+neptune.set("application.global-upload-speed-limit", 200 * 1024 * 1024)
+
+if node == "n5" then
+    neptune.set("application.global-upload-speed-limit", 10 * 1024 * 1024)
+    neptune.set("application.global-download-speed-limit", 15 * 1024 * 1024)
+    neptune.set("application.fallocate", false)
+
+elseif node == "n5-slow" then
+    neptune.set("application.global-download-speed-limit", 5 * 1024 * 1024)
+    neptune.set("application.global-upload-speed-limit", 0)
+
+elseif node == "seedbox" then
+    neptune.set("application.global-upload-speed-limit", 0)
+    neptune.set("application.global-connections-limit", 500)
+    neptune.set("application.global-upload-slots", 200)
+    neptune.set("application.download-dir", "/mnt/big/downloads")
+
+else
+    -- Adjust based on CPU cores (reads default value first, then bumps if needed)
+    local conns = neptune.get("application.global-connections-limit")
+    neptune.set("application.global-connections-limit", math.max(conns, os.cpus() * 20))
+    neptune.set("application.max-http-parallel", math.max(neptune.get("application.max-http-parallel"), os.cpus() * 50))
+end
+
+print("node=" .. node .. " host=" .. os.hostname())

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/trim21/errgo v0.0.6
 	github.com/trim21/go-bencode v0.0.16
 	github.com/valyala/bytebufferpool v1.0.0
+	github.com/yuin/gopher-lua v1.1.2
 	go.uber.org/atomic v1.11.0
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/multierr v1.11.0
@@ -76,7 +77,6 @@ require (
 	github.com/swaggest/jsonschema-go v0.3.79 // indirect
 	github.com/swaggest/refl v1.4.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
-	github.com/yuin/gopher-lua v1.1.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect
 	golang.org/x/crypto v0.53.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	github.com/swaggest/jsonschema-go v0.3.79 // indirect
 	github.com/swaggest/refl v1.4.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
+	github.com/yuin/gopher-lua v1.1.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect
 	golang.org/x/crypto v0.53.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,8 @@ github.com/yudai/gojsondiff v1.0.0 h1:27cbfqXLVEJ1o8I6v3y9lg8Ydm53EKqHXAOMxEGlCO
 github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 h1:BHyfKlQyqbsFN5p3IfnEUduWvb9is428/nNb5L3U01M=
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=
+github.com/yuin/gopher-lua v1.1.2 h1:yF/FjE3hD65tBbt0VXLE13HWS9h34fdzJmrWRXwobGA=
+github.com/yuin/gopher-lua v1.1.2/go.mod h1:7aRmXIWl37SqRf0koeyylBEzJ+aPt8A+mmkQ4f1ntR8=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,14 +3,6 @@
 
 package config
 
-import (
-	"os"
-	"path/filepath"
-
-	"github.com/pelletier/go-toml/v2"
-	"github.com/trim21/errgo"
-)
-
 type Application struct {
 	DownloadDir     string `toml:"download-dir"`
 	MaxHTTPParallel int    `toml:"max-http-parallel"`
@@ -30,43 +22,4 @@ type Application struct {
 
 type Config struct {
 	App Application `toml:"application"`
-}
-
-func LoadFromFile(path string) (Config, error) {
-	var cfg = Config{
-		App: Application{MaxHTTPParallel: 100, GlobalConnectionLimit: 50},
-	}
-
-	f, err := os.Open(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return cfg, nil
-		}
-
-		return Config{}, errgo.Wrap(err, "failed to read config file")
-	}
-	defer f.Close()
-
-	if err := toml.NewDecoder(f).DisallowUnknownFields().Decode(&cfg); err != nil {
-		return cfg, errgo.Wrap(err, "failed to parse config file")
-	}
-
-	if cfg.App.DownloadDir == "" {
-		hd, err := os.UserHomeDir()
-		if err != nil {
-			panic(errgo.Wrap(err, "failed to get user homedir"))
-		}
-
-		cfg.App.DownloadDir = filepath.Join(hd, "downloads")
-	}
-
-	if cfg.App.GlobalUploadSlots == 0 {
-		// Default to a small multiple of connection limit to allow pipelining,
-		// while still providing a hard cap across all torrents.
-		// Min 64 to avoid being too restrictive on small setups.
-		slots := max(cfg.App.GlobalConnectionLimit*4, 64)
-		cfg.App.GlobalUploadSlots = slots
-	}
-
-	return cfg, nil
 }

--- a/internal/config/script.go
+++ b/internal/config/script.go
@@ -1,0 +1,361 @@
+// Copyright 2025 trim21 <trim21.me@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/pelletier/go-toml/v2"
+	"github.com/trim21/errgo"
+	lua "github.com/yuin/gopher-lua"
+)
+
+// LoadFromTOML loads the base config from a TOML file.
+// Moved from config.go to keep the public API clean.
+func LoadFromTOML(path string) (Config, error) {
+	var cfg = Config{
+		App: Application{MaxHTTPParallel: 100, GlobalConnectionLimit: 50},
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cfg, nil
+		}
+
+		return Config{}, errgo.Wrap(err, "failed to read config file")
+	}
+	defer f.Close()
+
+	if err := toml.NewDecoder(f).DisallowUnknownFields().Decode(&cfg); err != nil {
+		return cfg, errgo.Wrap(err, "failed to parse config file")
+	}
+
+	applyDefaults(&cfg.App)
+
+	return cfg, nil
+}
+
+// LoadFromLua loads config entirely from a Lua script, starting with defaults.
+// TOML and Lua are mutually exclusive: if config.lua exists, config.toml is ignored.
+func LoadFromLua(path string) (Config, error) {
+	base := Config{
+		App: Application{
+			MaxHTTPParallel:       100,
+			GlobalConnectionLimit: 50,
+		},
+	}
+
+	cfg, err := loadFromLua(path, base)
+	if err != nil {
+		return Config{}, err
+	}
+
+	applyDefaults(&cfg.App)
+	return cfg, nil
+}
+
+func applyDefaults(app *Application) {
+	if app.DownloadDir == "" {
+		hd, err := os.UserHomeDir()
+		if err != nil {
+			panic(errgo.Wrap(err, "failed to get user homedir"))
+		}
+		app.DownloadDir = filepath.Join(hd, "downloads")
+	}
+
+	if app.GlobalUploadSlots == 0 {
+		slots := max(app.GlobalConnectionLimit*4, 64)
+		app.GlobalUploadSlots = slots
+	}
+}
+
+// loadFromLua executes a Lua config script that receives a base config (from TOML + CLI)
+// and may adjust values via neptune.set() / neptune.get().
+func loadFromLua(path string, base Config) (Config, error) {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, errgo.Wrap(err, "read config script")
+	}
+
+	L := lua.NewState()
+	defer L.Close()
+
+	// Open base libraries: os, math, string, table (no io for safety).
+	// We skip the package library to keep it simple.
+	lua.OpenBase(L)
+	lua.OpenMath(L)
+	lua.OpenString(L)
+	lua.OpenTable(L)
+
+	// Open the standard os module, then extend it.
+	lua.OpenOs(L)
+	extendOS(L)
+
+	// Register neptune module with set/get.
+	registerNeptune(L, &base.App)
+
+	// Register console.
+	registerConsole(L)
+
+	// Execute.
+	if err := L.DoString(string(src)); err != nil {
+		return Config{}, errgo.Wrap(err, "execute config script")
+	}
+
+	// Validate final config.
+	validate := validator.New()
+	if err := validate.Struct(base.App); err != nil {
+		return Config{}, errgo.Wrap(err, "validate config after script")
+	}
+
+	return Config{App: base.App}, nil
+}
+
+// --- os module extensions ---
+
+func extendOS(L *lua.LState) {
+	t := L.GetGlobal("os").(*lua.LTable)
+
+	t.RawSetString("getenv", L.NewFunction(luaOSGetenv))
+	t.RawSetString("hostname", L.NewFunction(luaOSHostname))
+	t.RawSetString("cpus", L.NewFunction(luaOSCpus))
+}
+
+func luaOSGetenv(L *lua.LState) int {
+	name := L.CheckString(1)
+	L.Push(lua.LString(os.Getenv(name)))
+	return 1
+}
+
+func luaOSHostname(L *lua.LState) int {
+	h, _ := os.Hostname()
+	L.Push(lua.LString(h))
+	return 1
+}
+
+func luaOSCpus(L *lua.LState) int {
+	L.Push(lua.LNumber(runtime.NumCPU()))
+	return 1
+}
+
+// --- neptune module ---
+
+type configField struct {
+	setter func(app *Application, v lua.LValue) error
+	getter func(app *Application) lua.LValue
+}
+
+var configFields = map[string]configField{
+	"application.download-dir": {
+		setter: func(a *Application, v lua.LValue) error { a.DownloadDir = lua.LVAsString(v); return nil },
+		getter: func(a *Application) lua.LValue { return lua.LString(a.DownloadDir) },
+	},
+	"application.max-http-parallel": {
+		setter: func(a *Application, v lua.LValue) error {
+			n, err := toGoInt(v)
+			if err != nil {
+				return err
+			}
+			a.MaxHTTPParallel = n
+			return nil
+		},
+		getter: func(a *Application) lua.LValue { return lua.LNumber(a.MaxHTTPParallel) },
+	},
+	"application.p2p-port": {
+		setter: func(a *Application, v lua.LValue) error {
+			n, err := toGoUint16(v)
+			if err != nil {
+				return err
+			}
+			a.P2PPort = n
+			return nil
+		},
+		getter: func(a *Application) lua.LValue { return lua.LNumber(a.P2PPort) },
+	},
+	"application.num-want": {
+		setter: func(a *Application, v lua.LValue) error {
+			n, err := toGoUint16(v)
+			if err != nil {
+				return err
+			}
+			a.NumWant = n
+			return nil
+		},
+		getter: func(a *Application) lua.LValue { return lua.LNumber(a.NumWant) },
+	},
+	"application.global-connections-limit": {
+		setter: func(a *Application, v lua.LValue) error {
+			n, err := toGoUint16(v)
+			if err != nil {
+				return err
+			}
+			a.GlobalConnectionLimit = n
+			return nil
+		},
+		getter: func(a *Application) lua.LValue { return lua.LNumber(a.GlobalConnectionLimit) },
+	},
+	"application.global-upload-slots": {
+		setter: func(a *Application, v lua.LValue) error {
+			n, err := toGoUint16(v)
+			if err != nil {
+				return err
+			}
+			a.GlobalUploadSlots = n
+			return nil
+		},
+		getter: func(a *Application) lua.LValue { return lua.LNumber(a.GlobalUploadSlots) },
+	},
+	"application.global-download-speed-limit": {
+		setter: func(a *Application, v lua.LValue) error {
+			n, err := toGoInt64(v)
+			if err != nil {
+				return err
+			}
+			a.GlobalDownloadSpeedLimit = n
+			return nil
+		},
+		getter: func(a *Application) lua.LValue { return lua.LNumber(a.GlobalDownloadSpeedLimit) },
+	},
+	"application.global-upload-speed-limit": {
+		setter: func(a *Application, v lua.LValue) error {
+			n, err := toGoInt64(v)
+			if err != nil {
+				return err
+			}
+			a.GlobalUploadSpeedLimit = n
+			return nil
+		},
+		getter: func(a *Application) lua.LValue { return lua.LNumber(a.GlobalUploadSpeedLimit) },
+	},
+	"application.fallocate": {
+		setter: func(a *Application, v lua.LValue) error { a.Fallocate = lua.LVAsBool(v); return nil },
+		getter: func(a *Application) lua.LValue { return lua.LBool(a.Fallocate) },
+	},
+}
+
+func registerNeptune(L *lua.LState, app *Application) {
+	neptune := L.NewTable()
+
+	neptune.RawSetString("set", L.NewFunction(func(L *lua.LState) int {
+		key := L.CheckString(1)
+		field, ok := configFields[key]
+		if !ok {
+			validKeys := make([]string, 0, len(configFields))
+			for k := range configFields {
+				validKeys = append(validKeys, k)
+			}
+			L.RaiseError("unknown config key %q, valid keys: %s", key, strings.Join(validKeys, ", "))
+			return 0
+		}
+		val := L.Get(2)
+		if err := field.setter(app, val); err != nil {
+			L.RaiseError("invalid value for %q: %v", key, err)
+		}
+		return 0
+	}))
+
+	neptune.RawSetString("get", L.NewFunction(func(L *lua.LState) int {
+		key := L.CheckString(1)
+		field, ok := configFields[key]
+		if !ok {
+			validKeys := make([]string, 0, len(configFields))
+			for k := range configFields {
+				validKeys = append(validKeys, k)
+			}
+			L.RaiseError("unknown config key %q, valid keys: %s", key, strings.Join(validKeys, ", "))
+			return 0
+		}
+		L.Push(field.getter(app))
+		return 1
+	}))
+
+	L.SetGlobal("neptune", neptune)
+}
+
+// --- console module ---
+
+func registerConsole(L *lua.LState) {
+	console := L.NewTable()
+
+	console.RawSetString("log", L.NewFunction(func(L *lua.LState) int {
+		top := L.GetTop()
+		parts := make([]string, 0, top)
+		for i := 1; i <= top; i++ {
+			parts = append(parts, L.CheckAny(i).String())
+		}
+		_, _ = fmt.Fprintln(os.Stderr, "[config] "+strings.Join(parts, " "))
+		return 0
+	}))
+
+	console.RawSetString("warn", L.NewFunction(func(L *lua.LState) int {
+		top := L.GetTop()
+		parts := make([]string, 0, top)
+		for i := 1; i <= top; i++ {
+			parts = append(parts, L.CheckAny(i).String())
+		}
+		_, _ = fmt.Fprintln(os.Stderr, "[config] WARN: "+strings.Join(parts, " "))
+		return 0
+	}))
+
+	console.RawSetString("error", L.NewFunction(func(L *lua.LState) int {
+		top := L.GetTop()
+		parts := make([]string, 0, top)
+		for i := 1; i <= top; i++ {
+			parts = append(parts, L.CheckAny(i).String())
+		}
+		_, _ = fmt.Fprintln(os.Stderr, "[config] ERROR: "+strings.Join(parts, " "))
+		return 0
+	}))
+
+	L.SetGlobal("console", console)
+}
+
+// --- helpers ---
+
+func toGoInt(v lua.LValue) (int, error) {
+	switch v.Type() {
+	case lua.LTNumber:
+		return int(lua.LVAsNumber(v)), nil
+	case lua.LTString:
+		var n int
+		if _, err := fmt.Sscanf(lua.LVAsString(v), "%d", &n); err != nil {
+			return 0, fmt.Errorf("cannot convert %q to integer", v.String())
+		}
+		return n, nil
+	default:
+		return 0, fmt.Errorf("expected number, got %s", v.Type())
+	}
+}
+
+func toGoUint16(v lua.LValue) (uint16, error) {
+	n, err := toGoInt(v)
+	if err != nil {
+		return 0, err
+	}
+	if n < 0 || n > 65535 {
+		return 0, fmt.Errorf("value %d out of range for uint16", n)
+	}
+	return uint16(n), nil
+}
+
+func toGoInt64(v lua.LValue) (int64, error) {
+	switch v.Type() {
+	case lua.LTNumber:
+		return int64(lua.LVAsNumber(v)), nil
+	case lua.LTString:
+		var n int64
+		if _, err := fmt.Sscanf(lua.LVAsString(v), "%d", &n); err != nil {
+			return 0, fmt.Errorf("cannot convert %q to integer", v.String())
+		}
+		return n, nil
+	default:
+		return 0, fmt.Errorf("expected number, got %s", v.Type())
+	}
+}

--- a/internal/config/script_test.go
+++ b/internal/config/script_test.go
@@ -1,0 +1,163 @@
+// Copyright 2025 trim21 <trim21.me@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadFromLua_SimpleSet(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "config.lua")
+	require.NoError(t, os.WriteFile(script, []byte(`
+		neptune.set("application.p2p-port", 12345)
+		neptune.set("application.fallocate", true)
+		neptune.set("application.download-dir", "/custom/downloads")
+	`), 0644))
+
+	cfg, err := LoadFromLua(script)
+	require.NoError(t, err)
+	assert.Equal(t, uint16(12345), cfg.App.P2PPort)
+	assert.True(t, cfg.App.Fallocate)
+	assert.Equal(t, "/custom/downloads", cfg.App.DownloadDir)
+}
+
+func TestLoadFromLua_Defaults(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "config.lua")
+	require.NoError(t, os.WriteFile(script, []byte(`
+		print("hello")
+	`), 0644))
+
+	cfg, err := LoadFromLua(script)
+	require.NoError(t, err)
+	assert.Equal(t, 100, cfg.App.MaxHTTPParallel)
+	assert.Equal(t, uint16(50), cfg.App.GlobalConnectionLimit)
+	assert.False(t, cfg.App.Fallocate)
+}
+
+func TestLoadFromLua_GetAndSet(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "config.lua")
+	require.NoError(t, os.WriteFile(script, []byte(`
+		local conns = neptune.get("application.global-connections-limit")
+		neptune.set("application.global-connections-limit", math.max(conns, 100))
+	`), 0644))
+
+	cfg, err := LoadFromLua(script)
+	require.NoError(t, err)
+	assert.Equal(t, uint16(100), cfg.App.GlobalConnectionLimit)
+}
+
+func TestLoadFromLua_LastSetWins(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "config.lua")
+	require.NoError(t, os.WriteFile(script, []byte(`
+		neptune.set("application.global-upload-speed-limit", 200 * 1024 * 1024)
+		neptune.set("application.global-upload-speed-limit", 10 * 1024 * 1024)
+	`), 0644))
+
+	cfg, err := LoadFromLua(script)
+	require.NoError(t, err)
+	assert.Equal(t, int64(10*1024*1024), cfg.App.GlobalUploadSpeedLimit)
+}
+
+func TestLoadFromLua_OsEnv(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "config.lua")
+	require.NoError(t, os.WriteFile(script, []byte(`
+		if os.getenv("NODE_NAME") == "testnode" then
+			neptune.set("application.download-dir", "/mnt/test/downloads")
+			neptune.set("application.global-connections-limit", 200)
+		else
+			neptune.set("application.global-connections-limit", 50)
+		end
+	`), 0644))
+
+	t.Setenv("NODE_NAME", "testnode")
+
+	cfg, err := LoadFromLua(script)
+	require.NoError(t, err)
+	assert.Equal(t, "/mnt/test/downloads", cfg.App.DownloadDir)
+	assert.Equal(t, uint16(200), cfg.App.GlobalConnectionLimit)
+}
+
+func TestLoadFromLua_OsEnvNotSet(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "config.lua")
+	require.NoError(t, os.WriteFile(script, []byte(`
+		local node = os.getenv("NONEXISTENT")
+		neptune.set("application.download-dir", "/data/" .. tostring(node))
+	`), 0644))
+
+	cfg, err := LoadFromLua(script)
+	require.NoError(t, err)
+	assert.Equal(t, "/data/", cfg.App.DownloadDir)
+}
+
+func TestLoadFromLua_OsHostname(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "config.lua")
+	require.NoError(t, os.WriteFile(script, []byte(`
+		local host = os.hostname()
+		neptune.set("application.download-dir", "/data/" .. host)
+	`), 0644))
+
+	cfg, err := LoadFromLua(script)
+	require.NoError(t, err)
+
+	expectedHost, _ := os.Hostname()
+	assert.Equal(t, "/data/"+expectedHost, cfg.App.DownloadDir)
+}
+
+func TestLoadFromLua_OsCpus(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "config.lua")
+	require.NoError(t, os.WriteFile(script, []byte(`
+		neptune.set("application.global-connections-limit", os.cpus() * 20)
+	`), 0644))
+
+	cfg, err := LoadFromLua(script)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, cfg.App.GlobalConnectionLimit, uint16(20))
+}
+
+func TestLoadFromLua_InvalidKey(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "config.lua")
+	require.NoError(t, os.WriteFile(script, []byte(`
+		neptune.set("nonexistentKey", 123)
+	`), 0644))
+
+	_, err := LoadFromLua(script)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown config key")
+}
+
+func TestLoadFromLua_InvalidValueType(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "config.lua")
+	require.NoError(t, os.WriteFile(script, []byte(`
+		neptune.set("application.p2p-port", "not a number")
+	`), 0644))
+
+	_, err := LoadFromLua(script)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid value")
+}
+
+func TestLoadFromLua_SyntaxError(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "config.lua")
+	require.NoError(t, os.WriteFile(script, []byte(`invalid lua syntax {{{`), 0644))
+
+	_, err := LoadFromLua(script)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "execute config script")
+}

--- a/library/neptune.lua
+++ b/library/neptune.lua
@@ -1,0 +1,30 @@
+---@meta
+--- Neptune config script API type stubs.
+--- For editor autocompletion, add this file's directory to lua-language-server's
+--- workspace.library path (see .luarc.json).
+
+---@class Neptune
+---@field set fun(key: string, value: any)
+---@field get fun(key: string): any
+neptune = {}
+
+---@class NeptuneConsole
+---@field log fun(...: any)
+---@field warn fun(...: any)
+---@field error fun(...: any)
+console = {}
+
+--- Extensions to the standard os library.
+
+--- Returns the value of the environment variable `name`, or empty string if not set.
+---@param name string
+---@return string
+function os.getenv(name) end
+
+--- Returns the hostname of the current machine.
+---@return string
+function os.hostname() end
+
+--- Returns the number of logical CPU cores.
+---@return integer
+function os.cpus() end

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -23,7 +22,6 @@ import (
 
 	"github.com/KimMachineGun/automemlimit/memlimit"
 	"github.com/gofrs/flock"
-	"github.com/pelletier/go-toml/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/rs/zerolog"
@@ -194,7 +192,7 @@ func setupFlagsAndEnvParser() {
 	}
 
 	pflag.String("session-path", "", "client session path (default ~/.neptune/)")
-	pflag.String("config-file", "", "path to config file (default {session-path}/config.toml)")
+	pflag.String("config", "", "path to config file (.toml or .lua, default {session-path}/config.toml)")
 
 	pflag.String("web", "127.0.0.1:8002", "web interface address")
 	pflag.String("web-secret-token", "", "web interface address secret token")
@@ -351,21 +349,31 @@ func setupLogger(sessionPath string) {
 }
 
 func mustParseConfig(sessionPath string) config.Config {
-	configFilePath := viper.GetString("config-file")
-	if configFilePath == "" {
-		configFilePath = filepath.Join(sessionPath, "config.toml")
+	configPath := viper.GetString("config")
+
+	// Auto-detect: prefer config.lua, fallback to config.toml
+	if configPath == "" {
+		luaPath := filepath.Join(sessionPath, "config.lua")
+		if _, err := os.Stat(luaPath); err == nil {
+			configPath = luaPath
+		} else {
+			configPath = filepath.Join(sessionPath, "config.toml")
+		}
 	}
 
-	cfg, err := config.LoadFromFile(configFilePath)
-	if err != nil {
-		var derr *toml.DecodeError
-		if errors.As(err, &derr) {
-			_, _ = fmt.Fprintln(os.Stderr, derr.String())
-			row, col := derr.Position()
-			_, _ = fmt.Fprintln(os.Stderr, "error occurred at row", row, "column", col)
-			os.Exit(2)
-		}
+	var cfg config.Config
+	var err error
 
+	switch filepath.Ext(configPath) {
+	case ".lua":
+		cfg, err = config.LoadFromLua(configPath)
+	case ".toml":
+		cfg, err = config.LoadFromTOML(configPath)
+	default:
+		errExit(fmt.Sprintf("unknown config format %q, expected .toml or .lua", configPath))
+	}
+
+	if err != nil {
 		errExit("failed to load config", err)
 	}
 


### PR DESCRIPTION
## Summary

Add optional Lua config script as an alternative to TOML, using [gopher-lua](https://github.com/yuin/gopher-lua).

### How it works

- `config.toml` and `config.lua` are **mutually exclusive** — single `--config` flag auto-detects format by extension
- Lua script receives `neptune.set(key, value)` / `neptune.get(key)` API with kebab-case keys matching TOML exactly
- Extended standard `os` table with `os.getenv()`, `os.hostname()`, `os.cpus()`
- LuaCATS type stubs for editor autocompletion

### Example

```lua
-- {session}/config.lua
local node = os.getenv("NODE_NAME") or ""

neptune.set("application.global-upload-speed-limit", 200 * 1024 * 1024)

if node == "n5" then
    neptune.set("application.global-upload-speed-limit", 10 * 1024 * 1024)
    neptune.set("application.global-download-speed-limit", 15 * 1024 * 1024)
else
    neptune.set("application.global-connections-limit", math.max(
        neptune.get("application.global-connections-limit"), os.cpus() * 20))
end
```

### Files

| File | Change |
|---|---|
| `internal/config/config.go` | Stripped to struct definitions only |
| `internal/config/script.go` | New: gopher-lua engine, `LoadFromTOML`, `LoadFromLua` |
| `internal/config/script_test.go` | 11 tests |
| `main.go` | Single `--config` flag, auto-dispatch by extension |
| `library/neptune.lua` | LuaCATS type stubs |
| `.luarc.json` | lua-language-server config |
| `docs/config-lua.md` | Full documentation |