### PR TITLE
feat: record torrent download completion time

### DIFF
--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -60,6 +60,7 @@ type MainDataTorrent struct {
 	TotalLength          int64             `json:"total_length"`
 	SelectedSize         int64             `json:"selected_size"`
 	AddedAt              int64             `json:"add_at"`
+	CompletedAt          int64             `json:"completed_at"`
 	Private              bool              `json:"private"`
 	TotalSeeding         int               `json:"total_seeding"`
 	TotalDownloading     int               `json:"total_downloading"`
@@ -109,6 +110,7 @@ func (c *Client) GetTorrentList(keys []string) TorrentList {
 			SelectedSize:         d.SelectedSize(),
 			Comment:              d.info.Comment,
 			AddedAt:              d.AddAt,
+			CompletedAt:          d.CompletedAt.Load(),
 			DirectoryBase:        d.downloadDir,
 			Private:              d.info.Private,
 			Tags:                 d.tags,

--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -410,6 +410,7 @@ func (d *Download) checkDone() {
 		d.log.Error().Err(err).Msg("failed to transition state in checkDone")
 		return
 	}
+	d.CompletedAt.Store(time.Now().Unix())
 	d.ioDown.Reset()
 
 	d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {

--- a/internal/core/d_init.go
+++ b/internal/core/d_init.go
@@ -233,6 +233,7 @@ func (d *Download) check(resumed bool, skipHashCheck bool) {
 		d.log.Debug().Msgf("done size %s", humanize.IBytes(uint64(d.bm.Count())*uint64(d.info.PieceLength)))
 
 		if d.bm.Count() == d.info.NumPieces {
+			d.CompletedAt.Store(time.Now().Unix())
 			if err := d.transition(Seeding); err != nil {
 				d.log.Error().Err(err).Msg("failed to transition state after init check")
 			}

--- a/internal/core/d_resume.go
+++ b/internal/core/d_resume.go
@@ -137,7 +137,7 @@ func (c *Client) UnmarshalResume(data []byte, totalDownloads int) error {
 	d.completed.Store(d.computeCompletedUnsafe())
 	d.state.Store(uint32(r.State))
 	d.AddAt = r.AddAt
-	d.CompletedAt.Store(d.CompletedAt.Load())
+	d.CompletedAt.Store(r.CompletedAt)
 
 	d.downloaded.Store(r.Downloaded)
 	d.downloadAtStart = r.Downloaded

--- a/sdk/python/src/neptune_sdk/models.py
+++ b/sdk/python/src/neptune_sdk/models.py
@@ -27,6 +27,7 @@ class MainDataTorrent:
     total_length: int
     selected_size: int
     add_at: int
+    completed_at: int
     private: bool
     total_seeding: int
     total_downloading: int

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -51,6 +51,7 @@ TORRENT_JSON = {
     "total_length": 100,
     "selected_size": 100,
     "add_at": 0,
+    "completed_at": 0,
     "total_seeding": 0,
     "total_downloading": 1,
     "connected_seeding": 0,

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -34,6 +34,7 @@ export interface Torrent {
   total_length: number;
   selected_size: number;
   add_at: number;
+  completed_at: number;
   private: boolean;
   total_seeding: number;
   total_downloading: number;


### PR DESCRIPTION
## Summary

Records the Unix timestamp when a torrent download completes, exposed via the `torrent.list` API as `completed_at`.

## Changes

- **Core**: Set `CompletedAt` in `checkDone()` when all pieces are acquired during active download
- **Core**: Set `CompletedAt` in `check()` when a fresh add finds all data already on disk
- **Core**: Fix resume — correctly restore `CompletedAt` from the resume file (was a no-op before)
- **API**: Expose `completed_at` field in `torrent.list` response (`MainDataTorrent`)
- **SDK**: Add `completed_at` to TypeScript `Torrent` type and Python `MainDataTorrent` model

`completed_at` is a Unix timestamp (seconds), 0 when the torrent has never completed. Re-checking (`AsyncCheck`) does not overwrite the stored value.