### PR TITLE
fix(core): update seeder/leecher counters on HaveAll message

### DIFF
--- a/internal/core/p.go
+++ b/internal/core/p.go
@@ -604,6 +604,11 @@ func (p *Peer) start(skipHandshake bool) {
 			continue
 		case proto.HaveAll:
 			p.Bitmap.Fill()
+			if !p.isSeed.Load() {
+				p.isSeed.Store(true)
+				p.d.peerLeechers.Add(-1)
+				p.d.peerSeeds.Add(1)
+			}
 		case proto.HaveNone:
 			p.Bitmap.Clear()
 		case proto.Cancel:


### PR DESCRIPTION
## Problem

When a peer using Fast Extension sends `HaveAll` to declare it has the complete file, Neptune's `connected_seeding` counter was not updated, causing the Flood UI to always show 0 connected seeders.

## Root Cause

In `internal/core/p.go`, the `proto.HaveAll` handler only called `p.Bitmap.Fill()` but missed the seeder/leecher counter migration that exists in the `proto.Bitfield` and `proto.Have` handlers.

Peers using Fast Extension use `HaveAll` instead of `Bitfield` to announce they have the complete file. These peers were permanently counted as leechers.

## Fix

Added the counter migration logic after `p.Bitmap.Fill()` in the `HaveAll` case, consistent with `Bitfield` and `Have` handlers:

```go
if !p.isSeed.Load() {
    p.isSeed.Store(true)
    p.d.peerLeechers.Add(-1)
    p.d.peerSeeds.Add(1)
}
```

The `HaveNone` case was intentionally left unchanged since a peer with no pieces should remain as a leecher.