### PR TITLE
fix(core): replace event-driven seeder/leecher counters with periodic recalculation

### DIFF
--- a/internal/core/c_loop.go
+++ b/internal/core/c_loop.go
@@ -24,6 +24,7 @@ func (c *Client) globalUnchokeLoop() {
 			for _, d := range c.downloads {
 				if d.HasState(Downloading | Seeding) {
 					d.recalculateUnchokeSlots()
+					d.recalcPeerCounts()
 				}
 			}
 			c.m.RUnlock()

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -432,3 +432,18 @@ func (d *Download) markUnselectedPiecesDoneUnsafe() {
 func (d *Download) peerSeedLeecherCounts() (seeds, leechers int) {
 	return int(d.peerSeeds.Load()), int(d.peerLeechers.Load())
 }
+
+// recalcPeerCounts iterates all connected peers and refreshes the cached seed/leecher counters.
+func (d *Download) recalcPeerCounts() {
+	var seeds, leechers int64
+	d.peers.Range(func(_ netip.AddrPort, p *Peer) bool {
+		if p.isSeed.Load() {
+			seeds++
+		} else {
+			leechers++
+		}
+		return true
+	})
+	d.peerSeeds.Store(seeds)
+	d.peerLeechers.Store(leechers)
+}

--- a/internal/core/p.go
+++ b/internal/core/p.go
@@ -228,11 +228,6 @@ func (p *Peer) close() {
 	if p.closed.CompareAndSwap(false, true) {
 		p.log.Trace().Caller(1).Msg("close")
 		p.d.peers.Delete(p.Address)
-		if p.isSeed.Load() {
-			p.d.peerSeeds.Add(-1)
-		} else {
-			p.d.peerLeechers.Add(-1)
-		}
 		p.d.c.sem.Release(1)
 		p.d.c.connectionCount.Sub(1)
 		p.cancel()
@@ -490,8 +485,6 @@ func (p *Peer) start(skipHandshake bool) {
 		return
 	}
 
-	p.d.peerLeechers.Add(1)
-
 	go p.ourRequestHandle()
 	go p.checkRequestTimeouts()
 
@@ -517,8 +510,6 @@ func (p *Peer) start(skipHandshake bool) {
 			p.Bitmap.OR(event.Bitmap)
 			if !p.isSeed.Load() && p.Bitmap.Count() == p.d.info.NumPieces {
 				p.isSeed.Store(true)
-				p.d.peerLeechers.Add(-1)
-				p.d.peerSeeds.Add(1)
 			}
 		case proto.Have:
 			if event.Index >= p.d.info.NumPieces {
@@ -529,8 +520,6 @@ func (p *Peer) start(skipHandshake bool) {
 			p.Bitmap.Set(event.Index)
 			if !p.isSeed.Load() && p.Bitmap.Count() == p.d.info.NumPieces {
 				p.isSeed.Store(true)
-				p.d.peerLeechers.Add(-1)
-				p.d.peerSeeds.Add(1)
 			}
 		case proto.Interested:
 			p.peerInterested.Store(true)
@@ -604,11 +593,7 @@ func (p *Peer) start(skipHandshake bool) {
 			continue
 		case proto.HaveAll:
 			p.Bitmap.Fill()
-			if !p.isSeed.Load() {
-				p.isSeed.Store(true)
-				p.d.peerLeechers.Add(-1)
-				p.d.peerSeeds.Add(1)
-			}
+			p.isSeed.Store(true)
 		case proto.HaveNone:
 			p.Bitmap.Clear()
 		case proto.Cancel:


### PR DESCRIPTION
## Problem

The event-driven `peerSeeds`/`peerLeechers` atomic counters suffered from TOCTOU races and inconsistent update paths, resulting in negative `connected_downloading` counts:

| torrent | connection_count | connected_seeding | connected_downloading |
|---|---|---|---|
| Face Off | 4 | 4 | **-9** |
| Kingsman | 5 | 5 | **-3** |

## Root Cause

Manual `Add(1)`/`Add(-1)` calls scattered across peer lifecycle events (connect, disconnect, Bitfield, Have, HaveAll) were impossible to keep consistent — `HaveAll` (Fast Extension) was missing the transition entirely (fixed in #308), but even after that fix the counters went negative.

## Fix

Replace all manual counter adjustments with a `recalcPeerCounts()` method that iterates connected peers and stores results into the atomic counters. This is called from the existing `globalUnchokeLoop` (runs every 10s, already iterates all downloads), so **zero additional goroutines, zero additional overhead** on the read path (`peerSeedLeecherCounts()` remains O(1) `Load`).

### Changes

- **c_loop.go**: Add `d.recalcPeerCounts()` call in `globalUnchokeLoop`
- **d.go**: Add `recalcPeerCounts()` method; `peerSeedLeecherCounts()` unchanged
- **p.go**: Remove all 7 manual `Add(1)`/`Add(-1)` calls; `isSeed` flag still maintained by the event loop