### PR TITLE
pref(ratelimit): improve stability with debt model, larger burst, and Wait order swap

### DIFF
--- a/internal/core/c_upload_pool.go
+++ b/internal/core/c_upload_pool.go
@@ -87,12 +87,12 @@ func (c *Client) uploadWorker() {
 				}
 			}
 
-			// Rate limit: block before sending to the network.
-			if err := d.uploadLimiter.Wait(d.ctx, len(res.Data)); err != nil {
+			// Rate limit: global first, then per-torrent (same rationale as download).
+			if err := d.c.uploadLimiter.Wait(d.ctx, len(res.Data)); err != nil {
 				proto.PiecePool.Put(res)
 				continue
 			}
-			if err := d.c.uploadLimiter.Wait(d.ctx, len(res.Data)); err != nil {
+			if err := d.uploadLimiter.Wait(d.ctx, len(res.Data)); err != nil {
 				proto.PiecePool.Put(res)
 				continue
 			}

--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -99,12 +99,14 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 		Uint32("piece", res.PieceIndex).
 		Msg("res received")
 
-	// Rate limit: block until allowed, which backpressures the peer read loop
-	// and ultimately slows TCP reception via flow control.
-	if err := d.downloadLimiter.Wait(d.ctx, len(res.Data)); err != nil {
+	// Rate limit: global first, then per-torrent.
+	// Global acts as the primary clock; per-torrent is a secondary constraint.
+	// This order prevents the global limiter from accumulating burst while the
+	// per-torrent limiter blocks, avoiding boom-bust oscillation.
+	if err := d.c.downloadLimiter.Wait(d.ctx, len(res.Data)); err != nil {
 		return
 	}
-	if err := d.c.downloadLimiter.Wait(d.ctx, len(res.Data)); err != nil {
+	if err := d.downloadLimiter.Wait(d.ctx, len(res.Data)); err != nil {
 		return
 	}
 

--- a/internal/pkg/ratelimit/ratelimit.go
+++ b/internal/pkg/ratelimit/ratelimit.go
@@ -1,8 +1,8 @@
 // Copyright 2024 trim21 <trim21.me@gmail.com>
 // SPDX-License-Identifier: GPL-3.0-only
 
-// Package ratelimit provides a simple token-bucket rate limiter for byte streams.
-// A zero Limiter is a no-op (unlimited).
+// Package ratelimit provides a token-bucket rate limiter for byte streams.
+// A zero-value Limiter is a no-op (unlimited).
 package ratelimit
 
 import (
@@ -13,9 +13,15 @@ import (
 	"go.uber.org/atomic"
 )
 
+// maxSleep is the upper bound for a single Wait sleep cycle.
+// It ensures that dynamic rate changes (via Update) and context cancellations
+// are noticed within this interval, while adding negligible overhead for
+// typical rates (MB/s range) where the computed sleep is far shorter.
+const maxSleep = 250 * time.Millisecond
+
 // Limiter controls the rate of byte transfers using a token bucket algorithm.
 // Tokens represent bytes and are replenished at the configured rate.
-// A zero value Limiter imposes no limit.
+// A zero-value Limiter imposes no limit.
 type Limiter struct {
 	last   time.Time
 	rate   atomic.Int64
@@ -25,9 +31,13 @@ type Limiter struct {
 }
 
 func computeBurst(rate float64) float64 {
-	burst := rate
-	if burst < 256*1024 {
-		burst = 256 * 1024
+	// Burst of 2 seconds worth of tokens provides smooth traffic shaping
+	// while absorbing TCP window fluctuations.
+	// Minimum 512 KB ensures reasonable burst even at very low rates.
+	const minBurst = 512 * 1024
+	burst := rate * 2
+	if burst < minBurst {
+		burst = minBurst
 	}
 	return burst
 }
@@ -52,6 +62,7 @@ func New(rate int64) *Limiter {
 
 // Update dynamically changes the rate limit.
 // If rate <= 0, the limiter becomes unlimited.
+// Waiting goroutines will notice the change within maxSleep.
 func (l *Limiter) Update(rate int64) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -82,26 +93,35 @@ func (l *Limiter) Wait(ctx context.Context, n int) error {
 
 	l.mu.Lock()
 	l.refill()
+	l.tokens -= float64(n)
 
-	// Fast path: enough tokens available, consume and return.
-	if l.tokens >= float64(n) {
-		l.tokens -= float64(n)
+	// Fast path: enough tokens available (including burst), return immediately.
+	if l.tokens >= 0 {
 		l.mu.Unlock()
 		return nil
 	}
 
-	// Slow path: calculate the exact wait time once and wait.
-	// Only re-loops if the rate was changed (via Update) during the wait.
+	// Slow path: we are in token debt.
+	// By going negative early (debt model), we prevent other goroutines from
+	// consuming the same tokens, avoiding "token stealing" that causes jitter
+	// when multiple peers share a limiter.
+	// Each sleep cycle is capped at maxSleep so that dynamic rate changes via
+	// Update() are noticed promptly.
 	for {
 		r := float64(l.rate.Load())
 		if r <= 0 {
+			// Rate became unlimited — clear debt and return.
+			l.tokens = 0
 			l.mu.Unlock()
 			return nil
 		}
 
-		deficit := float64(n) - l.tokens
-		waitTime := time.Duration(deficit / r * float64(time.Second))
-		waitTime = max(waitTime, time.Microsecond)
+		debt := -l.tokens
+		waitTime := time.Duration(debt / r * float64(time.Second))
+		waitTime = max(waitTime, time.Microsecond) // prevent busy-wait
+		if waitTime > maxSleep {
+			waitTime = maxSleep
+		}
 
 		l.mu.Unlock()
 
@@ -109,6 +129,13 @@ func (l *Limiter) Wait(ctx context.Context, n int) error {
 		select {
 		case <-ctx.Done():
 			timer.Stop()
+			// Restore tokens that were reserved but never used.
+			l.mu.Lock()
+			l.tokens += float64(n)
+			if l.tokens > l.burst {
+				l.tokens = l.burst
+			}
+			l.mu.Unlock()
 			return ctx.Err()
 		case <-timer.C:
 		}
@@ -117,15 +144,17 @@ func (l *Limiter) Wait(ctx context.Context, n int) error {
 		l.refill()
 
 		if l.rate.Load() <= 0 {
+			l.tokens = 0
 			l.mu.Unlock()
 			return nil
 		}
 
-		if l.tokens >= float64(n) {
-			l.tokens -= float64(n)
+		// Debt repaid?
+		if l.tokens >= 0 {
 			l.mu.Unlock()
 			return nil
 		}
+		// Still in debt, loop to wait more.
 	}
 }
 

--- a/internal/pkg/ratelimit/ratelimit.go
+++ b/internal/pkg/ratelimit/ratelimit.go
@@ -119,9 +119,7 @@ func (l *Limiter) Wait(ctx context.Context, n int) error {
 		debt := -l.tokens
 		waitTime := time.Duration(debt / r * float64(time.Second))
 		waitTime = max(waitTime, time.Microsecond) // prevent busy-wait
-		if waitTime > maxSleep {
-			waitTime = maxSleep
-		}
+		waitTime = min(waitTime, maxSleep)
 
 		l.mu.Unlock()
 

--- a/internal/pkg/ratelimit/ratelimit_test.go
+++ b/internal/pkg/ratelimit/ratelimit_test.go
@@ -5,6 +5,7 @@ package ratelimit
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 )
@@ -65,8 +66,9 @@ func TestUpdate(t *testing.T) {
 func TestLimiterBlocks(t *testing.T) {
 	l := New(100)
 
+	// Exhaust the 512 KB min burst first.
 	start := time.Now()
-	err := l.Wait(context.Background(), 256*1024)
+	err := l.Wait(context.Background(), 512*1024)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,6 +76,7 @@ func TestLimiterBlocks(t *testing.T) {
 		t.Fatal("first call should not block significantly")
 	}
 
+	// Now tokens are empty. 100 bytes at 100 B/s → ~1s.
 	start = time.Now()
 	err = l.Wait(context.Background(), 100)
 	if err != nil {
@@ -83,14 +86,23 @@ func TestLimiterBlocks(t *testing.T) {
 	if elapsed < 500*time.Millisecond {
 		t.Fatalf("expected ~1s block, got %v", elapsed)
 	}
+	if elapsed > 1500*time.Millisecond {
+		t.Fatalf("expected ~1s block, got %v (too slow)", elapsed)
+	}
 }
 
 func TestLimiterContextCancel(t *testing.T) {
 	l := New(1)
+
+	// Exhaust burst so the next Wait enters the slow path.
+	if err := l.Wait(context.Background(), 512*1024); err != nil {
+		t.Fatal(err)
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := l.Wait(ctx, 256*1024+1)
+	err := l.Wait(ctx, 1)
 	if err != context.Canceled {
 		t.Fatalf("expected context.Canceled, got %v", err)
 	}
@@ -99,9 +111,15 @@ func TestLimiterContextCancel(t *testing.T) {
 func TestUpdateToUnlimitedWhileWaiting(t *testing.T) {
 	l := New(1)
 
+	// Exhaust burst so the next Wait enters the slow path.
+	if err := l.Wait(context.Background(), 512*1024); err != nil {
+		t.Fatal(err)
+	}
+
 	done := make(chan error, 1)
 	go func() {
-		done <- l.Wait(context.Background(), 256*1024+1)
+		// 256 KB at 1 B/s — would block for days without the Update.
+		done <- l.Wait(context.Background(), 256*1024)
 	}()
 
 	time.Sleep(50 * time.Millisecond)
@@ -112,7 +130,79 @@ func TestUpdateToUnlimitedWhileWaiting(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected nil, got %v", err)
 		}
-	case <-time.After(time.Second):
+	case <-time.After(2 * time.Second):
 		t.Fatal("Wait did not return after Update(0)")
+	}
+}
+
+func TestConcurrentWaitFairness(t *testing.T) {
+	// Two goroutines sharing one limiter: wall-clock time should be
+	// ~ total_bytes / rate, not dominated by token stealing.
+	l := New(1000) // 1 KB/s
+
+	// Exhaust burst first.
+	if err := l.Wait(context.Background(), 512*1024); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	start := time.Now()
+
+	for range 2 {
+		go func() {
+			defer wg.Done()
+			// Each needs 500 bytes at 1 KB/s → wall clock ~1s total.
+			if err := l.Wait(context.Background(), 500); err != nil {
+				t.Error(err)
+			}
+		}()
+	}
+
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	// 1000 bytes at 1000 B/s = 1s wall clock.
+	if elapsed < 700*time.Millisecond {
+		t.Fatalf("concurrent wait too fast: %v (possible token stealing)", elapsed)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("concurrent wait too slow: %v", elapsed)
+	}
+}
+
+func TestUpdateToLowerRateWhileWaiting(t *testing.T) {
+	l := New(2000) // 2 KB/s
+
+	// Exhaust burst.
+	if err := l.Wait(context.Background(), 512*1024); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		// 2 KB at 2 KB/s → ~1s initially.
+		done <- l.Wait(context.Background(), 2048)
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	// Drop rate to 1 KB/s — remaining wait should slow down.
+	l.Update(1000)
+
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	elapsed := time.Since(start)
+
+	// Started at 2 KB/s, after 200ms dropped to 1 KB/s.
+	// Approx: 0.2s at 2 KB/s = 0.4 KB done, 1.6 KB left at 1 KB/s = 1.6s.
+	// Total ≈ 1.8s. Accept 1.2s–2.5s.
+	t.Logf("elapsed: %v", elapsed)
+	if elapsed < 1200*time.Millisecond {
+		t.Fatalf("expected >1.2s after rate drop, got %v", elapsed)
+	}
+	if elapsed > 2500*time.Millisecond {
+		t.Fatalf("expected <2.5s, got %v (too slow)", elapsed)
 	}
 }


### PR DESCRIPTION
## Problem

Rate limiting was unstable due to three issues:

### 1. Token stealing between concurrent callers
Multiple goroutines (peers) sharing the same Limiter would race: G1 calculates deficit, releases lock, sleeps T seconds. During that sleep, G2 locks, refills, and consumes the tokens G1 was counting on. G1 wakes up to find tokens gone → extra sleep cycle → jitter. In high-concurrency scenarios this reduces effective throughput.

### 2. Burst too small
`computeBurst` used `max(rate, 256KB)`. At low rates (e.g. 100 KB/s) the 256 KB burst gets consumed instantly, then the limiter blocks for 2.5 seconds. This creates a pronounced sawtooth: burst → long wait → burst → long wait.

### 3. Dual limiter cascade
`handleRes` and the upload pool call per-torrent `Wait` then global `Wait` sequentially. During the per-torrent wait, the global limiter accumulates burst tokens. When per-torrent unblocks, global doesn't block at all. Then the next chunk exhausts global burst and both block — causing boom-bust oscillation.

## Changes

| File | Change |
|------|--------|
| `ratelimit.go` | **Debt model**: pre-consume tokens (allow negative) to prevent stealing. **Larger burst**: `rate * 2`, min 512 KB. **maxSleep cap**: 250 ms so `Update()` is noticed promptly. **Cancel restoration**: restore reserved tokens on ctx cancel. |
| `d_download.go` / `c_upload_pool.go` | **Swap Wait order**: global limiter first (as primary clock), per-torrent second (as secondary constraint). |
| `ratelimit_test.go` | Updated existing tests for new burst size. Added `TestConcurrentWaitFairness` and `TestUpdateToLowerRateWhileWaiting`.