### PR TITLE
fix: use `UnmarshalRelaxed` for tracker announce responses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/swaggest/usecase v1.3.1
 	github.com/trim21/conntrack v0.0.2
 	github.com/trim21/errgo v0.0.6
-	github.com/trim21/go-bencode v0.0.16
+	github.com/trim21/go-bencode v0.1.0
 	github.com/valyala/bytebufferpool v1.0.0
 	github.com/yuin/gopher-lua v1.1.2
 	go.uber.org/atomic v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
-github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
+github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
+github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
@@ -154,8 +154,8 @@ github.com/trim21/conntrack v0.0.2 h1:w3yZKwXTdGVwUCIIebWK43hWthzhbsAGcFnfjmjXSF
 github.com/trim21/conntrack v0.0.2/go.mod h1:+WnKAYkUv87gZMdJcRjN6xEK281cuZ4QM0JRJltqvgs=
 github.com/trim21/errgo v0.0.6 h1:Qz10hGY51k5u7ADRa/jqan8VaQYKx7hAqUJ6t5m42/I=
 github.com/trim21/errgo v0.0.6/go.mod h1:8uSKeZAGc+XDaPDqcgOCduVPb2Xpb1YxqxfMK1JcLlo=
-github.com/trim21/go-bencode v0.0.16 h1:aKqjBFZFUD6WtvKHvBLWwsr6XQMW/J5nZgJg1/ZBQao=
-github.com/trim21/go-bencode v0.0.16/go.mod h1:Tf+qJHY1T17MVH0zDXCWeHAnuPniMnUxGbO1epmxRw0=
+github.com/trim21/go-bencode v0.1.0 h1:/giNabql1WQeLvGbKSxOC8ZKOOacR+06G3RAnd9fx9A=
+github.com/trim21/go-bencode v0.1.0/go.mod h1:y/C7Qr4jGQ3YvS16FoE9OMfCI/TGLRLxfBd5N+vOogw=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/internal/core/tracker/tracker.go
+++ b/internal/core/tracker/tracker.go
@@ -548,7 +548,7 @@ func (t *Trackers) announceHTTP(tr *Tracker, event AnnounceEvent) AnnounceRespon
 
 	var r trackerAnnounceResponse
 	body := resp.Body()
-	if err := bencode.Unmarshal(body, &r); err != nil {
+	if err := bencode.UnmarshalRelaxed(body, &r); err != nil {
 		if t.debug {
 			return AnnounceResponse{Err: fmt.Errorf("failed to parse tracker announce response %v: %s", err, base64.StdEncoding.EncodeToString(body))}
 		}


### PR DESCRIPTION
## Summary

- Upgrade `github.com/trim21/go-bencode` from v0.0.16 to v0.1.0
- Use `bencode.UnmarshalRelaxed` instead of `bencode.Unmarshal` for parsing tracker HTTP announce responses in `internal/core/tracker/tracker.go`

## Rationale

`UnmarshalRelaxed` applies relaxed parsing rules:
- Dictionary keys are not required to be sorted lexicographically
- Duplicate dictionary keys are allowed (last value wins)

Many real-world BitTorrent trackers produce bencoded responses that don't strictly follow the bencode specification (e.g. unsorted dictionary keys). Using `UnmarshalRelaxed` improves compatibility with these trackers.