### PR TITLE
refactor(core): rename rate monitors and add corruptedBytes tracking

### DIFF
--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -101,9 +101,9 @@ func (c *Client) GetTorrentList(keys []string) TorrentList {
 			InfoHash:             d.info.Hash.Hex(),
 			Name:                 d.info.Name,
 			State:                State(d.state.Load()).String(),
-			DownloadRate:         d.ioDown.Status().CurRate,
+			DownloadRate:         d.pieceDownloadRate.Status().CurRate,
 			DownloadTotal:        d.downloaded.Load(),
-			UploadRate:           d.ioUp.Status().CurRate,
+			UploadRate:           d.pieceUploadRate.Status().CurRate,
 			UploadTotal:          d.uploaded.Load(),
 			Completed:            d.completed.Load(),
 			TotalLength:          d.info.TotalLength,
@@ -140,8 +140,8 @@ type TransferSummary struct {
 }
 
 func (c *Client) GetTransferSummary() TransferSummary {
-	down := c.ioDown.Status()
-	up := c.ioUp.Status()
+	down := c.pieceDownloadRate.Status()
+	up := c.pieceUploadRate.Status()
 
 	return TransferSummary{
 		DownloadRate:  down.CurRate,
@@ -290,8 +290,8 @@ func (c *Client) GetTorrentPeers(h metainfo.Hash) []APIPeers {
 			Address:      addr.String(),
 			Client:       lo.FromPtrOr(p.UserAgent.Load(), ""),
 			Progress:     float64(p.Bitmap.Count()) / float64(d.info.NumPieces),
-			DownloadRate: p.ioIn.Status().CurRate,
-			UploadRate:   p.ioOut.Status().CurRate,
+			DownloadRate: p.pieceDownloadRate.Status().CurRate,
+			UploadRate:   p.pieceUploadRate.Status().CurRate,
 			IsIncoming:   p.Incoming,
 		})
 		return true
@@ -451,12 +451,23 @@ func (c *Client) DebugHandlers() http.Handler {
 		w.WriteHeader(http.StatusOK)
 
 		fmt.Fprintf(w, "%q\n\n", d.info.Name)
-		fmt.Fprintf(w, "download %9s                         upload %9s\n\n",
-			humanize.IBytes(uint64(d.ioDown.Status().CurRate))+"/s",
-			humanize.IBytes(uint64(d.ioUp.Status().CurRate))+"/s",
+ 		fmt.Fprintf(w, "download %9s (net %9s)      upload %9s\n\n",
+			humanize.IBytes(uint64(d.pieceDownloadRate.Status().CurRate))+"/s",
+			humanize.IBytes(uint64(d.ioDownloadRate.Status().CurRate))+"/s",
+			humanize.IBytes(uint64(d.pieceUploadRate.Status().CurRate))+"/s",
 		)
 
 		fmt.Fprintf(w, "progress: %6.2f %%\n", float64(d.completed.Load())/float64(d.SelectedSize())*100)
+
+		fmt.Fprintf(w, "downloaded: %s  completed: %s  waste: %s\n",
+			humanize.IBytes(uint64(d.downloaded.Load())),
+			humanize.IBytes(uint64(d.completed.Load())),
+			humanize.IBytes(uint64(d.downloaded.Load()-d.completed.Load())),
+		)
+		fmt.Fprintf(w, "corrupted: %s (pieces)  corrupted_bytes: %s\n",
+			humanize.IBytes(uint64(d.corrupted.Load())),
+			humanize.IBytes(uint64(d.corruptedBytes.Load())),
+		)
 
 		debugPrintTrackers(w, d)
 		debugPrintPeers(w, d)
@@ -516,8 +527,8 @@ func debugPrintPeers(w io.Writer, d *Download) {
 	d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {
 		t.AppendRow(table.Row{
 			lo.Ellipsis(addr.String(), 20),
-			humanize.IBytes(uint64(p.ioIn.Status().CurRate)) + "/s",
-			humanize.IBytes(uint64(p.ioOut.Status().CurRate)) + "/s",
+			humanize.IBytes(uint64(p.pieceDownloadRate.Status().CurRate)) + "/s",
+			humanize.IBytes(uint64(p.pieceUploadRate.Status().CurRate)) + "/s",
 			p.myRequests.Size(),
 			len(p.ourPieceRequests),
 			*p.UserAgent.Load(),

--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -62,6 +62,7 @@ type MainDataTorrent struct {
 	AddedAt              int64             `json:"add_at"`
 	CompletedAt          int64             `json:"completed_at"`
 	Private              bool              `json:"private"`
+	Corrupted            int64             `json:"corrupted"`
 	TotalSeeding         int               `json:"total_seeding"`
 	TotalDownloading     int               `json:"total_downloading"`
 	ConnectedSeeding     int               `json:"connected_seeding"`
@@ -113,6 +114,7 @@ func (c *Client) GetTorrentList(keys []string) TorrentList {
 			CompletedAt:          d.CompletedAt.Load(),
 			DirectoryBase:        d.downloadDir,
 			Private:              d.info.Private,
+			Corrupted:            d.corrupted.Load(),
 			Tags:                 d.tags,
 			Custom:               custom,
 			ConnectionCount:      peers,
@@ -451,7 +453,7 @@ func (c *Client) DebugHandlers() http.Handler {
 		w.WriteHeader(http.StatusOK)
 
 		fmt.Fprintf(w, "%q\n\n", d.info.Name)
- 		fmt.Fprintf(w, "download %9s (net %9s)      upload %9s\n\n",
+		fmt.Fprintf(w, "download %9s (net %9s)      upload %9s\n\n",
 			humanize.IBytes(uint64(d.pieceDownloadRate.Status().CurRate))+"/s",
 			humanize.IBytes(uint64(d.ioDownloadRate.Status().CurRate))+"/s",
 			humanize.IBytes(uint64(d.pieceUploadRate.Status().CurRate))+"/s",
@@ -464,9 +466,8 @@ func (c *Client) DebugHandlers() http.Handler {
 			humanize.IBytes(uint64(d.completed.Load())),
 			humanize.IBytes(uint64(d.downloaded.Load()-d.completed.Load())),
 		)
-		fmt.Fprintf(w, "corrupted: %s (pieces)  corrupted_bytes: %s\n",
+		fmt.Fprintf(w, "corrupted: %s\n",
 			humanize.IBytes(uint64(d.corrupted.Load())),
-			humanize.IBytes(uint64(d.corruptedBytes.Load())),
 		)
 
 		debugPrintTrackers(w, d)

--- a/internal/core/c.go
+++ b/internal/core/c.go
@@ -75,8 +75,8 @@ func New(cfg config.Config, sessionPath string, debug bool) *Client {
 
 		filePool: filepool.New(),
 
-		ioUp:   flowrate.New(time.Second, time.Second),
-		ioDown: flowrate.New(time.Second, time.Second),
+		pieceUploadRate:   flowrate.New(time.Second, time.Second),
+		pieceDownloadRate: flowrate.New(time.Second, time.Second),
 
 		downloadLimiter: ratelimit.New(cfg.App.GlobalDownloadSpeedLimit),
 		uploadLimiter:   ratelimit.New(cfg.App.GlobalUploadSpeedLimit),
@@ -133,8 +133,8 @@ type Client struct {
 	uploadQ     chan uploadTask
 	fh          map[string]*os.File
 
-	ioDown *flowrate.Monitor
-	ioUp   *flowrate.Monitor
+	pieceDownloadRate *flowrate.Monitor
+	pieceUploadRate   *flowrate.Monitor
 
 	downloadLimiter *ratelimit.Limiter
 	uploadLimiter   *ratelimit.Limiter

--- a/internal/core/c_upload_pool.go
+++ b/internal/core/c_upload_pool.go
@@ -98,8 +98,8 @@ func (c *Client) uploadWorker() {
 			}
 
 			if p.Response(res) {
-				d.ioUp.Update(len(res.Data))
-				d.c.ioUp.Update(len(res.Data))
+				d.pieceUploadRate.Update(len(res.Data))
+				d.c.pieceUploadRate.Update(len(res.Data))
 				d.uploaded.Add(int64(len(res.Data)))
 			}
 			proto.PiecePool.Put(res)

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -149,7 +149,6 @@ type Download struct {
 	CompletedAt            atomic.Int64
 	downloaded             atomic.Int64
 	corrupted              atomic.Int64
-	corruptedBytes         atomic.Int64 // bytes received for pieces that failed hash check
 	uploaded               atomic.Int64
 	uploadAtStart          int64
 	downloadAtStart        int64

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -113,9 +113,9 @@ type Download struct {
 	err                    atomic.Pointer[error]
 	cancel                 context.CancelFunc
 	c                      *Client
-	ioDown                 *flowrate.Monitor
-	netDown                *flowrate.Monitor
-	ioUp                   *flowrate.Monitor
+	pieceDownloadRate      *flowrate.Monitor
+	ioDownloadRate         *flowrate.Monitor
+	pieceUploadRate        *flowrate.Monitor
 	ResChan                chan *proto.ChunkResponse
 	downloadLimiter        *ratelimit.Limiter
 	uploadLimiter          *ratelimit.Limiter
@@ -149,6 +149,7 @@ type Download struct {
 	CompletedAt            atomic.Int64
 	downloaded             atomic.Int64
 	corrupted              atomic.Int64
+	corruptedBytes         atomic.Int64 // bytes received for pieces that failed hash check
 	uploaded               atomic.Int64
 	uploadAtStart          int64
 	downloadAtStart        int64
@@ -251,9 +252,9 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 
 		ResChan: make(chan *proto.ChunkResponse, 1),
 
-		ioDown:  flowrate.New(time.Second, time.Second),
-		netDown: flowrate.New(time.Second, time.Second),
-		ioUp:    flowrate.New(time.Second, time.Second),
+		pieceDownloadRate: flowrate.New(time.Second, time.Second),
+		ioDownloadRate:    flowrate.New(time.Second, time.Second),
+		pieceUploadRate:   flowrate.New(time.Second, time.Second),
 
 		peers:             xsync.NewMap[netip.AddrPort, *Peer](),
 		connectionHistory: lo.Must(lru.New[netip.AddrPort, connHistory](256)),

--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -380,8 +380,7 @@ func (d *Download) checkPiece(pieceIndex uint32) error {
 	copy(digest[:], hasher.Sum(nil))
 
 	if digest != d.info.Pieces[pieceIndex] {
-		d.corrupted.Add(d.info.PieceLength)
-		d.corruptedBytes.Add(pieceSize)
+		d.corrupted.Add(pieceSize)
 		start := pieceIndex * d.normalChunkLen
 		end := start + uint32(pieceChunksCount(d.info, pieceIndex))
 		d.chunk.mu.Lock()

--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -110,9 +110,8 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 		return
 	}
 
-	d.ioDown.Update(len(res.Data))
-	d.netDown.Update(len(res.Data))
-	d.c.ioDown.Update(len(res.Data))
+	d.pieceDownloadRate.Update(len(res.Data))
+	d.c.pieceDownloadRate.Update(len(res.Data))
 	d.downloaded.Add(int64(len(res.Data)))
 
 	// clear endgame tracking for this chunk
@@ -382,6 +381,7 @@ func (d *Download) checkPiece(pieceIndex uint32) error {
 
 	if digest != d.info.Pieces[pieceIndex] {
 		d.corrupted.Add(d.info.PieceLength)
+		d.corruptedBytes.Add(pieceSize)
 		start := pieceIndex * d.normalChunkLen
 		end := start + uint32(pieceChunksCount(d.info, pieceIndex))
 		d.chunk.mu.Lock()
@@ -413,7 +413,7 @@ func (d *Download) checkDone() {
 		return
 	}
 	d.CompletedAt.Store(time.Now().Unix())
-	d.ioDown.Reset()
+	d.pieceDownloadRate.Reset()
 
 	d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {
 		if p.Bitmap.Count() == d.info.NumPieces {
@@ -634,7 +634,7 @@ func (d *Download) assignPiecesToPeers(nextPiece func() (uint32, bool)) {
 
 	// sort by download rate descending (fastest peer first)
 	slices.SortFunc(peers, func(a, b peerInfo) int {
-		return cmp.Compare(b.peer.ioIn.Status().CurRate, a.peer.ioIn.Status().CurRate)
+		return cmp.Compare(b.peer.pieceDownloadRate.Status().CurRate, a.peer.pieceDownloadRate.Status().CurRate)
 	})
 
 	for _, pi := range peers {

--- a/internal/core/d_init.go
+++ b/internal/core/d_init.go
@@ -79,7 +79,7 @@ func (d *Download) initCheck() error {
 			// Init check scans files sequentially; tell the kernel to prefetch.
 			_ = fadvise.Sequential(f, 0, 0)
 
-			_, err = d.ioDown.IO64(gfs.CopyReaderAt(w, f, chunk.offsetOfFile, chunk.length))
+			_, err = d.pieceDownloadRate.IO64(gfs.CopyReaderAt(w, f, chunk.offsetOfFile, chunk.length))
 			if err != nil {
 				f.Close()
 				return errgo.Wrap(err, "failed to read file "+f.Name())
@@ -228,7 +228,7 @@ func (d *Download) check(resumed bool, skipHashCheck bool) {
 		// unsafe methods are safe here because d hasn't been shared with other goroutines yet.
 		d.markUnselectedPiecesDoneUnsafe()
 		d.completed.Store(d.computeCompletedUnsafe())
-		d.ioDown.Reset()
+		d.pieceDownloadRate.Reset()
 
 		d.log.Debug().Msgf("done size %s", humanize.IBytes(uint64(d.bm.Count())*uint64(d.info.PieceLength)))
 

--- a/internal/core/d_loop.go
+++ b/internal/core/d_loop.go
@@ -70,7 +70,7 @@ func (d *Download) AsyncCheck() error {
 
 		d.markUnselectedPiecesDoneUnsafe()
 		d.completed.Store(d.computeCompletedUnsafe())
-		d.ioDown.Reset()
+		d.pieceDownloadRate.Reset()
 
 		if d.bm.Count() == d.info.NumPieces {
 			if err := d.transition(Seeding); err != nil {

--- a/internal/core/d_move.go
+++ b/internal/core/d_move.go
@@ -85,10 +85,10 @@ func (d *Download) moveFile(ctx context.Context, target string, originalBasePath
 		return err
 	}
 
-	d.ioDown.Reset()
-	defer d.ioDown.Reset()
+	d.pieceDownloadRate.Reset()
+	defer d.pieceDownloadRate.Reset()
 
-	return gfs.SmartCopy(ctx, sourcePath, targetPath, d.ioDown)
+	return gfs.SmartCopy(ctx, sourcePath, targetPath, d.pieceDownloadRate)
 }
 
 func pruneEmptyDirectories(osDirname string) error {

--- a/internal/core/d_upload.go
+++ b/internal/core/d_upload.go
@@ -47,7 +47,7 @@ func (d *Download) recalculateUnchokeSlots() {
 		if p.peerInterested.Load() {
 			candidates = append(candidates, peerRate{
 				peer: p,
-				rate: p.ioOut.Status().CurRate,
+				rate: p.pieceUploadRate.Status().CurRate,
 			})
 		}
 		if !p.peerInterested.Load() || p.snubbed.Load() {

--- a/internal/core/p.go
+++ b/internal/core/p.go
@@ -84,8 +84,8 @@ func newPeer(
 		Conn:       conn,
 		d:          d,
 		Bitmap:     bm.New(d.info.NumPieces),
-		ioOut:      flowrate.New(time.Second, time.Second),
-		ioIn:       flowrate.New(time.Second, time.Second),
+		pieceUploadRate:   flowrate.New(time.Second, time.Second),
+		pieceDownloadRate: flowrate.New(time.Second, time.Second),
 		Address:    addr,
 		QueueLimit: *atomic.NewUint32(200),
 		Incoming:   skipReadHandshake,
@@ -114,7 +114,7 @@ func newPeer(
 
 		peerRequests: xsync.NewMap[proto.ChunkRequest, empty.Empty](),
 
-		r: bufio.NewReaderSize(conn, units.KiB*18),
+		r: bufio.NewReaderSize(d.ioDownloadRate.WrapReader(conn), units.KiB*18),
 		w: bufio.NewWriterSize(conn, units.KiB*8),
 
 		allowFast: bm.New(d.info.NumPieces),
@@ -145,14 +145,14 @@ type Peer struct {
 	lastSend         atomic.Time
 	snubbedAt        atomic.Time
 	peerRequests     *xsync.Map[proto.ChunkRequest, empty.Empty]
-	ioIn             *flowrate.Monitor
+	pieceDownloadRate *flowrate.Monitor
 	Bitmap           *bm.Bitmap
 	myRequests       *xsync.Map[proto.ChunkRequest, time.Time]
 	myRequestHistory *xsync.Map[proto.ChunkRequest, empty.Empty]
 	d                *Download
 	Rejected         *xsync.Map[proto.ChunkRequest, empty.Empty]
 	allowFast        *bm.Bitmap
-	ioOut            *flowrate.Monitor
+	pieceUploadRate   *flowrate.Monitor
 	cancel           context.CancelFunc
 	UserAgent        atomic.Pointer[string]
 	ourPieceRequests chan uint32
@@ -255,7 +255,7 @@ func (p *Peer) ourRequestHandleLoop() {
 			queueSize = int(p.desiredQueueSize.Load())
 		} else {
 			// rate-based: keep 3s of pipeline
-			queueSize = int(3*p.ioIn.Status().CurRate) / int(defaultBlockSize)
+			queueSize = int(3*p.pieceDownloadRate.Status().CurRate) / int(defaultBlockSize)
 		}
 		queueSize = max(queueSize, 1)
 		queueSize = min(queueSize, 20)
@@ -319,7 +319,7 @@ func (p *Peer) handleSlowStart() {
 		return
 	}
 
-	currentRate := p.ioIn.Status().CurRate
+	currentRate := p.pieceDownloadRate.Status().CurRate
 	lastRate := p.lastRate.Load()
 	p.lastRate.Store(currentRate)
 
@@ -539,7 +539,7 @@ func (p *Peer) start(skipHandshake bool) {
 			}
 
 			p.responseCond.Signal()
-			p.ioIn.Update(len(event.Res.Data))
+			p.pieceDownloadRate.Update(len(event.Res.Data))
 			p.d.ResChan <- event.Res
 		case proto.Request:
 			if !p.validateRequest(event.Req) {

--- a/internal/core/p.go
+++ b/internal/core/p.go
@@ -80,15 +80,15 @@ func newPeer(
 		ctx:    ctx,
 		cancel: cancel,
 
-		log:        l.Logger(),
-		Conn:       conn,
-		d:          d,
-		Bitmap:     bm.New(d.info.NumPieces),
+		log:               l.Logger(),
+		Conn:              conn,
+		d:                 d,
+		Bitmap:            bm.New(d.info.NumPieces),
 		pieceUploadRate:   flowrate.New(time.Second, time.Second),
 		pieceDownloadRate: flowrate.New(time.Second, time.Second),
-		Address:    addr,
-		QueueLimit: *atomic.NewUint32(200),
-		Incoming:   skipReadHandshake,
+		Address:           addr,
+		QueueLimit:        *atomic.NewUint32(200),
+		Incoming:          skipReadHandshake,
 
 		ourChoking:     *atomic.NewBool(true),
 		ourInterested:  *atomic.NewBool(false),
@@ -139,52 +139,52 @@ func newPeer(
 var ErrPeerSendInvalidData = errors.New("addrPort send invalid data")
 
 type Peer struct {
-	log              zerolog.Logger
-	ctx              context.Context
-	Conn             net.Conn
-	lastSend         atomic.Time
-	snubbedAt        atomic.Time
-	peerRequests     *xsync.Map[proto.ChunkRequest, empty.Empty]
+	log               zerolog.Logger
+	ctx               context.Context
+	Conn              net.Conn
+	lastSend          atomic.Time
+	snubbedAt         atomic.Time
+	peerRequests      *xsync.Map[proto.ChunkRequest, empty.Empty]
 	pieceDownloadRate *flowrate.Monitor
-	Bitmap           *bm.Bitmap
-	myRequests       *xsync.Map[proto.ChunkRequest, time.Time]
-	myRequestHistory *xsync.Map[proto.ChunkRequest, empty.Empty]
-	d                *Download
-	Rejected         *xsync.Map[proto.ChunkRequest, empty.Empty]
-	allowFast        *bm.Bitmap
+	Bitmap            *bm.Bitmap
+	myRequests        *xsync.Map[proto.ChunkRequest, time.Time]
+	myRequestHistory  *xsync.Map[proto.ChunkRequest, empty.Empty]
+	d                 *Download
+	Rejected          *xsync.Map[proto.ChunkRequest, empty.Empty]
+	allowFast         *bm.Bitmap
 	pieceUploadRate   *flowrate.Monitor
-	cancel           context.CancelFunc
-	UserAgent        atomic.Pointer[string]
-	ourPieceRequests chan uint32
-	responseCond     *gsync.Cond
-	peerID           atomic.Pointer[proto.PeerID]
-	pieceDone        chan struct{}
-	w                *bufio.Writer
-	r                *bufio.Reader
-	Address          netip.AddrPort
-	Requested        bitmap.Bitmap
-	rttAverage       sizedSlice[time.Duration]
-	slowStart        atomic.Bool
-	QueueLimit       atomic.Uint32
-	lastRate         atomic.Int64
-	desiredQueueSize atomic.Int32
-	ourInterested    atomic.Bool
-	snubbed          atomic.Bool
-	closed           atomic.Bool
-	isSeed           atomic.Bool
-	peerChoking      atomic.Bool
-	peerInterested   atomic.Bool
-	ourChoking       atomic.Bool
-	rttMutex         sync.RWMutex
-	wm               sync.Mutex
-	extDontHaveID    gsync.AtomicUint[proto.ExtensionMessage]
-	extPexID         gsync.AtomicUint[proto.ExtensionMessage]
-	readBuf          [4]byte
-	writeBuf         [4]byte
-	Incoming         bool
-	fastExtension    bool
-	dhtEnabled       bool
-	subExtensions    bool
+	cancel            context.CancelFunc
+	UserAgent         atomic.Pointer[string]
+	ourPieceRequests  chan uint32
+	responseCond      *gsync.Cond
+	peerID            atomic.Pointer[proto.PeerID]
+	pieceDone         chan struct{}
+	w                 *bufio.Writer
+	r                 *bufio.Reader
+	Address           netip.AddrPort
+	Requested         bitmap.Bitmap
+	rttAverage        sizedSlice[time.Duration]
+	slowStart         atomic.Bool
+	QueueLimit        atomic.Uint32
+	lastRate          atomic.Int64
+	desiredQueueSize  atomic.Int32
+	ourInterested     atomic.Bool
+	snubbed           atomic.Bool
+	closed            atomic.Bool
+	isSeed            atomic.Bool
+	peerChoking       atomic.Bool
+	peerInterested    atomic.Bool
+	ourChoking        atomic.Bool
+	rttMutex          sync.RWMutex
+	wm                sync.Mutex
+	extDontHaveID     gsync.AtomicUint[proto.ExtensionMessage]
+	extPexID          gsync.AtomicUint[proto.ExtensionMessage]
+	readBuf           [4]byte
+	writeBuf          [4]byte
+	Incoming          bool
+	fastExtension     bool
+	dhtEnabled        bool
+	subExtensions     bool
 }
 
 func (p *Peer) Response(res *proto.ChunkResponse) bool {

--- a/internal/core/p_protocol.go
+++ b/internal/core/p_protocol.go
@@ -236,7 +236,7 @@ func (p *Peer) write(e Event) error {
 	case proto.Request:
 		return proto.SendRequest(p.w, e.Req)
 	case proto.Piece:
-		p.ioOut.Update(len(e.Res.Data))
+		p.pieceUploadRate.Update(len(e.Res.Data))
 		return proto.SendPiece(p.w, e.Res)
 	case proto.Cancel:
 		return proto.SendCancel(p.w, e.Req)

--- a/internal/core/p_test.go
+++ b/internal/core/p_test.go
@@ -36,12 +36,12 @@ func TestPeerResponseSendsOnceAndCountsOnce(t *testing.T) {
 	})
 
 	p := &Peer{
-		Conn:         c1,
-		w:            bufio.NewWriterSize(c1, 64*1024),
-		log:          zerolog.New(io.Discard),
-		lastSend:     *atomic.NewTime(time.Now()),
+		Conn:            c1,
+		w:               bufio.NewWriterSize(c1, 64*1024),
+		log:             zerolog.New(io.Discard),
+		lastSend:        *atomic.NewTime(time.Now()),
 		pieceUploadRate: flowrate.New(time.Second, time.Second),
-		peerRequests: xsync.NewMap[proto.ChunkRequest, empty.Empty](),
+		peerRequests:    xsync.NewMap[proto.ChunkRequest, empty.Empty](),
 	}
 
 	data := []byte{1, 2, 3, 4, 5, 6, 7}
@@ -64,12 +64,12 @@ func TestPeerResponseNoRequestDoesNotWrite(t *testing.T) {
 	defer c2.Close()
 
 	p := &Peer{
-		Conn:         c1,
-		w:            bufio.NewWriterSize(c1, 64*1024),
-		log:          zerolog.New(io.Discard),
-		lastSend:     *atomic.NewTime(time.Now()),
+		Conn:            c1,
+		w:               bufio.NewWriterSize(c1, 64*1024),
+		log:             zerolog.New(io.Discard),
+		lastSend:        *atomic.NewTime(time.Now()),
 		pieceUploadRate: flowrate.New(time.Second, time.Second),
-		peerRequests: xsync.NewMap[proto.ChunkRequest, empty.Empty](),
+		peerRequests:    xsync.NewMap[proto.ChunkRequest, empty.Empty](),
 	}
 
 	data := []byte{9, 9, 9, 9}

--- a/internal/core/p_test.go
+++ b/internal/core/p_test.go
@@ -40,7 +40,7 @@ func TestPeerResponseSendsOnceAndCountsOnce(t *testing.T) {
 		w:            bufio.NewWriterSize(c1, 64*1024),
 		log:          zerolog.New(io.Discard),
 		lastSend:     *atomic.NewTime(time.Now()),
-		ioOut:        flowrate.New(time.Second, time.Second),
+		pieceUploadRate: flowrate.New(time.Second, time.Second),
 		peerRequests: xsync.NewMap[proto.ChunkRequest, empty.Empty](),
 	}
 
@@ -55,7 +55,7 @@ func TestPeerResponseSendsOnceAndCountsOnce(t *testing.T) {
 	_ = c2.Close()
 	wg.Wait()
 
-	require.Equal(t, int64(len(data)), p.ioOut.Done())
+	require.Equal(t, int64(len(data)), p.pieceUploadRate.Done())
 }
 
 func TestPeerResponseNoRequestDoesNotWrite(t *testing.T) {
@@ -68,14 +68,14 @@ func TestPeerResponseNoRequestDoesNotWrite(t *testing.T) {
 		w:            bufio.NewWriterSize(c1, 64*1024),
 		log:          zerolog.New(io.Discard),
 		lastSend:     *atomic.NewTime(time.Now()),
-		ioOut:        flowrate.New(time.Second, time.Second),
+		pieceUploadRate: flowrate.New(time.Second, time.Second),
 		peerRequests: xsync.NewMap[proto.ChunkRequest, empty.Empty](),
 	}
 
 	data := []byte{9, 9, 9, 9}
 	ok := p.Response(&proto.ChunkResponse{PieceIndex: 1, Begin: 0, Data: data})
 	require.False(t, ok)
-	require.Equal(t, int64(0), p.ioOut.Done())
+	require.Equal(t, int64(0), p.pieceUploadRate.Done())
 
 	_ = c2.SetReadDeadline(time.Now().Add(30 * time.Millisecond))
 	buf := make([]byte, 1)

--- a/sdk/python/src/neptune_sdk/models.py
+++ b/sdk/python/src/neptune_sdk/models.py
@@ -28,6 +28,7 @@ class MainDataTorrent:
     selected_size: int
     add_at: int
     completed_at: int
+    corrupted: int
     private: bool
     total_seeding: int
     total_downloading: int

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -48,6 +48,7 @@ TORRENT_JSON = {
     "upload_total": 0,
     "connection_count": 0,
     "completed": 0,
+    "corrupted": 0,
     "total_length": 100,
     "selected_size": 100,
     "add_at": 0,

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -35,6 +35,7 @@ export interface Torrent {
   selected_size: number;
   add_at: number;
   completed_at: number;
+  corrupted: number;
   private: boolean;
   total_seeding: number;
   total_downloading: number;


### PR DESCRIPTION
## Summary

### Rename for clarity

| Old | New | Meaning |
|---|---|---|
| `d.ioDown` / `c.ioDown` / `p.ioIn` | `pieceDownloadRate` | piece payload download rate |
| `d.ioUp` / `c.ioUp` / `p.ioOut` | `pieceUploadRate` | piece payload upload rate |
| `d.netDown` | `ioDownloadRate` | raw TCP inbound bytes (protocol + payload) |

`ioDownloadRate` now properly tracks raw TCP reads via `flowrate.Monitor.WrapReader(conn)` instead of being manually updated with the same payload bytes as `pieceDownloadRate`.

### New tracking

- `corruptedBytes` — counts actual byte size of hash-failed pieces (previously only `corrupted` existed, which counts by piece size without accounting for last-piece truncation)
- Debug endpoint (`GET /debug/neptune/{info_hash}`) now shows `downloaded / completed / waste / corrupted_bytes` stats and both `ioDownloadRate` and `pieceDownloadRate` rates