### PR TITLE
fix(core): avoid re-requesting corrupted pieces from the same peers

### DIFF
--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -471,22 +471,28 @@ func (c *Client) DebugHandlers() http.Handler {
 		)
 
 		d.corruptedPiecesMu.Lock()
+		d.piecePeerMu.Lock()
 		if len(d.corruptedPieces) > 0 {
 			fmt.Fprintf(w, "failing pieces: %d\n", len(d.corruptedPieces))
-			// show top 10 pieces with most failures
 			type kv struct {
-				idx   uint32
-				count int
+				idx       uint32
+				count     int
+				blockedBy int
 			}
 			var top []kv
 			for idx, count := range d.corruptedPieces {
-				top = append(top, kv{idx, count})
+				blockedBy := 0
+				if peers, ok := d.piecePeerAssignments[idx]; ok {
+					blockedBy = len(peers)
+				}
+				top = append(top, kv{idx, count, blockedBy})
 			}
 			slices.SortFunc(top, func(a, b kv) int { return b.count - a.count })
 			for i := 0; i < len(top) && i < 10; i++ {
-				fmt.Fprintf(w, "  piece %d: %d failures\n", top[i].idx, top[i].count)
+				fmt.Fprintf(w, "  piece %d: %d failures, %d peers blocked\n", top[i].idx, top[i].count, top[i].blockedBy)
 			}
 		}
+		d.piecePeerMu.Unlock()
 		d.corruptedPiecesMu.Unlock()
 
 		debugPrintTrackers(w, d)

--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -470,6 +470,25 @@ func (c *Client) DebugHandlers() http.Handler {
 			humanize.IBytes(uint64(d.corrupted.Load())),
 		)
 
+		d.corruptedPiecesMu.Lock()
+		if len(d.corruptedPieces) > 0 {
+			fmt.Fprintf(w, "failing pieces: %d\n", len(d.corruptedPieces))
+			// show top 10 pieces with most failures
+			type kv struct {
+				idx   uint32
+				count int
+			}
+			var top []kv
+			for idx, count := range d.corruptedPieces {
+				top = append(top, kv{idx, count})
+			}
+			slices.SortFunc(top, func(a, b kv) int { return b.count - a.count })
+			for i := 0; i < len(top) && i < 10; i++ {
+				fmt.Fprintf(w, "  piece %d: %d failures\n", top[i].idx, top[i].count)
+			}
+		}
+		d.corruptedPiecesMu.Unlock()
+
 		debugPrintTrackers(w, d)
 		debugPrintPeers(w, d)
 

--- a/internal/core/c.go
+++ b/internal/core/c.go
@@ -147,7 +147,7 @@ type Client struct {
 	checkQueue        []metainfo.Hash
 	randKey           []byte
 	Config            config.Config
-	peerIDCounter     atomic.Uint64
+	peerIDCounter     atomic.Uint32
 	connectionCount   atomic.Uint32
 	m                 sync.RWMutex
 	debug             bool

--- a/internal/core/c.go
+++ b/internal/core/c.go
@@ -124,41 +124,33 @@ type incomingConn struct {
 }
 
 type Client struct {
-	ctx         context.Context
-	http        *resty.Client
-	cancel      context.CancelFunc
-	downloadMap map[metainfo.Hash]*Download
-	connChan    chan incomingConn
-	sem         *semaphore.Weighted
-	uploadQ     chan uploadTask
-	fh          map[string]*os.File
-
+	ctx               context.Context
+	uploadLimiter     *ratelimit.Limiter
+	ipv4              atomic.Pointer[netip.Addr]
+	downloadMap       map[metainfo.Hash]*Download
+	connChan          chan incomingConn
+	sem               *semaphore.Weighted
+	uploadQ           chan uploadTask
+	fh                map[string]*os.File
 	pieceDownloadRate *flowrate.Monitor
 	pieceUploadRate   *flowrate.Monitor
-
-	downloadLimiter *ratelimit.Limiter
-	uploadLimiter   *ratelimit.Limiter
-
-	filePool *filepool.FilePool
-
-	ipv4 atomic.Pointer[netip.Addr]
-	ipv6 atomic.Pointer[netip.Addr]
-
-	dht *dht.DHT
-
-	resumePath  string
-	torrentPath string
-
-	infoHashes []metainfo.Hash
-	downloads  []*Download
-	checkQueue []metainfo.Hash
-
-	randKey []byte
-
-	Config          config.Config
-	connectionCount atomic.Uint32
-	m               sync.RWMutex
-	debug           bool
+	dht               *dht.DHT
+	downloadLimiter   *ratelimit.Limiter
+	http              *resty.Client
+	cancel            context.CancelFunc
+	filePool          *filepool.FilePool
+	ipv6              atomic.Pointer[netip.Addr]
+	torrentPath       string
+	resumePath        string
+	downloads         []*Download
+	infoHashes        []metainfo.Hash
+	checkQueue        []metainfo.Hash
+	randKey           []byte
+	Config            config.Config
+	peerIDCounter     atomic.Uint64
+	connectionCount   atomic.Uint32
+	m                 sync.RWMutex
+	debug             bool
 }
 
 type DownloadInfo struct {

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -110,8 +110,8 @@ func validTransition(from, to State) bool {
 type Download struct {
 	log                    zerolog.Logger
 	ctx                    context.Context
-	err                    atomic.Pointer[error]
-	cancel                 context.CancelFunc
+	selectedPiecesBm       *bm.Bitmap
+	stateCond              *gsync.Cond
 	c                      *Client
 	pieceDownloadRate      *flowrate.Monitor
 	ioDownloadRate         *flowrate.Monitor
@@ -122,31 +122,31 @@ type Download struct {
 	peers                  *xsync.Map[netip.AddrPort, *Peer]
 	connectionHistory      *lru.Cache[netip.AddrPort, connHistory]
 	bm                     *bm.Bitmap
-	selectedPiecesBm       *bm.Bitmap
+	err                    atomic.Pointer[error]
 	pendingPeers           *heap.Heap[peerWithPriority]
-	rarePieceQueue         *heap.Heap[pieceRare]
-	buildNetworkPieces     chan empty.Empty
+	cancel                 context.CancelFunc
 	scheduleRequestSignal  chan empty.Empty
+	rarePieceQueue         *heap.Heap[pieceRare]
 	scheduleResponseSignal chan empty.Empty
 	pendingPeersSignal     chan empty.Empty
-	stateCond              *gsync.Cond
+	buildNetworkPieces     chan empty.Empty
 	pexAdd                 chan []pexPeer
 	pexDrop                chan []netip.AddrPort
 	endgameRequested       *xsync.Map[proto.ChunkRequest, empty.Empty]
 	selectedFilesSet       map[int]struct{}
-	basePath               string
-	downloadDir            string
-	chunk                  chunkState
-	tags                   []string
 	custom                 map[string]string
-	pieceInfo              pieceInfo
 	Trk                    *tracker.Trackers
+	corruptedPieces        map[uint32]int
+	downloadDir            string
+	basePath               string
+	pieceInfo              pieceInfo
+	tags                   []string
 	pieceAvailability      []int32
+	chunk                  chunkState
 	info                   meta.Info
-	completed              atomic.Int64
-	selectedSize           atomic.Int64
-	AddAt                  int64
-	CompletedAt            atomic.Int64
+	backgroundWg           sync.WaitGroup
+	peerSeeds              atomic.Int64
+	state                  atomic.Uint32
 	downloaded             atomic.Int64
 	corrupted              atomic.Int64
 	uploaded               atomic.Int64
@@ -154,14 +154,16 @@ type Download struct {
 	downloadAtStart        int64
 	endGameMode            atomic.Bool
 	seq                    atomic.Bool
-	peerSeeds              atomic.Int64
+	AddAt                  int64
 	peerLeechers           atomic.Int64
-	state                  atomic.Uint32
-	m                      sync.RWMutex
-	backgroundWg           sync.WaitGroup
-	ratePieceMutex         sync.Mutex
-	pendingPeersMutex      sync.Mutex
+	CompletedAt            atomic.Int64
+	completed              atomic.Int64
+	selectedSize           atomic.Int64
 	unchokeSlotIdx         int
+	m                      sync.RWMutex
+	pendingPeersMutex      sync.Mutex
+	ratePieceMutex         sync.Mutex
+	corruptedPiecesMu      sync.Mutex
 	normalChunkLen         uint32
 	bitfieldSize           uint32
 	peerID                 proto.PeerID
@@ -285,6 +287,8 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 
 		downloadLimiter: ratelimit.New(0),
 		uploadLimiter:   ratelimit.New(0),
+
+		corruptedPieces: make(map[uint32]int),
 	}
 
 	d.state.Store(uint32(Checking))

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -137,7 +137,7 @@ type Download struct {
 	custom                 map[string]string
 	Trk                    *tracker.Trackers
 	corruptedPieces        map[uint32]int
-	piecePeerAssignments   map[uint32]map[uint64]struct{}
+	piecePeerAssignments   map[uint32]map[uint32]struct{}
 	downloadDir            string
 	basePath               string
 	pieceInfo              pieceInfo
@@ -291,7 +291,7 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 		uploadLimiter:   ratelimit.New(0),
 
 		corruptedPieces:      make(map[uint32]int),
-		piecePeerAssignments: make(map[uint32]map[uint64]struct{}),
+		piecePeerAssignments: make(map[uint32]map[uint32]struct{}),
 	}
 
 	d.state.Store(uint32(Checking))

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -137,6 +137,7 @@ type Download struct {
 	custom                 map[string]string
 	Trk                    *tracker.Trackers
 	corruptedPieces        map[uint32]int
+	piecePeerAssignments   map[uint32]map[uint64]struct{}
 	downloadDir            string
 	basePath               string
 	pieceInfo              pieceInfo
@@ -164,6 +165,7 @@ type Download struct {
 	pendingPeersMutex      sync.Mutex
 	ratePieceMutex         sync.Mutex
 	corruptedPiecesMu      sync.Mutex
+	piecePeerMu            sync.Mutex
 	normalChunkLen         uint32
 	bitfieldSize           uint32
 	peerID                 proto.PeerID
@@ -288,7 +290,8 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 		downloadLimiter: ratelimit.New(0),
 		uploadLimiter:   ratelimit.New(0),
 
-		corruptedPieces: make(map[uint32]int),
+		corruptedPieces:      make(map[uint32]int),
+		piecePeerAssignments: make(map[uint32]map[uint64]struct{}),
 	}
 
 	d.state.Store(uint32(Checking))

--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -399,14 +399,11 @@ func (d *Download) checkPiece(pieceIndex uint32) error {
 	if notHave {
 		d.completed.Add(pieceSize)
 		d.corruptedPiecesMu.Lock()
-		if fc := d.corruptedPieces[pieceIndex]; fc > 0 {
-			d.log.Info().
-				Uint32("piece", pieceIndex).
-				Int("prev_failures", fc).
-				Msg("piece passed hash after previous failures")
-		}
 		delete(d.corruptedPieces, pieceIndex)
 		d.corruptedPiecesMu.Unlock()
+		d.piecePeerMu.Lock()
+		delete(d.piecePeerAssignments, pieceIndex)
+		d.piecePeerMu.Unlock()
 		d.log.Trace().Msgf("piece %d done", pieceIndex)
 		d.have(pieceIndex)
 	}
@@ -667,13 +664,20 @@ func (d *Download) assignPiecesToPeers(nextPiece func() (uint32, bool)) {
 				continue
 			}
 
-			// if this piece has failed before, don't re-request from the same peer
-			d.corruptedPiecesMu.Lock()
-			failCount := d.corruptedPieces[pieceIndex]
-			d.corruptedPiecesMu.Unlock()
-			if failCount >= 3 && pi.peer.Requested.Contains(pieceIndex) {
-				continue
+			// skip peers that previously sent corrupted data for this piece
+			d.piecePeerMu.Lock()
+			if peers, ok := d.piecePeerAssignments[pieceIndex]; ok {
+				if _, bad := peers[pi.peer.id]; bad {
+					d.piecePeerMu.Unlock()
+					continue
+				}
 			}
+			// record this assignment
+			if d.piecePeerAssignments[pieceIndex] == nil {
+				d.piecePeerAssignments[pieceIndex] = make(map[uint64]struct{})
+			}
+			d.piecePeerAssignments[pieceIndex][pi.peer.id] = struct{}{}
+			d.piecePeerMu.Unlock()
 
 			select {
 			case pi.peer.ourPieceRequests <- pieceIndex:

--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -674,7 +674,7 @@ func (d *Download) assignPiecesToPeers(nextPiece func() (uint32, bool)) {
 			}
 			// record this assignment
 			if d.piecePeerAssignments[pieceIndex] == nil {
-				d.piecePeerAssignments[pieceIndex] = make(map[uint64]struct{})
+				d.piecePeerAssignments[pieceIndex] = make(map[uint32]struct{})
 			}
 			d.piecePeerAssignments[pieceIndex][pi.peer.id] = struct{}{}
 			d.piecePeerMu.Unlock()

--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -380,6 +380,9 @@ func (d *Download) checkPiece(pieceIndex uint32) error {
 	copy(digest[:], hasher.Sum(nil))
 
 	if digest != d.info.Pieces[pieceIndex] {
+		d.corruptedPiecesMu.Lock()
+		d.corruptedPieces[pieceIndex]++
+		d.corruptedPiecesMu.Unlock()
 		d.corrupted.Add(pieceSize)
 		start := pieceIndex * d.normalChunkLen
 		end := start + uint32(pieceChunksCount(d.info, pieceIndex))
@@ -395,6 +398,15 @@ func (d *Download) checkPiece(pieceIndex uint32) error {
 
 	if notHave {
 		d.completed.Add(pieceSize)
+		d.corruptedPiecesMu.Lock()
+		if fc := d.corruptedPieces[pieceIndex]; fc > 0 {
+			d.log.Info().
+				Uint32("piece", pieceIndex).
+				Int("prev_failures", fc).
+				Msg("piece passed hash after previous failures")
+		}
+		delete(d.corruptedPieces, pieceIndex)
+		d.corruptedPiecesMu.Unlock()
 		d.log.Trace().Msgf("piece %d done", pieceIndex)
 		d.have(pieceIndex)
 	}
@@ -652,6 +664,14 @@ func (d *Download) assignPiecesToPeers(nextPiece func() (uint32, bool)) {
 					continue
 				}
 			} else if !pi.peer.Bitmap.Contains(pieceIndex) {
+				continue
+			}
+
+			// if this piece has failed before, don't re-request from the same peer
+			d.corruptedPiecesMu.Lock()
+			failCount := d.corruptedPieces[pieceIndex]
+			d.corruptedPiecesMu.Unlock()
+			if failCount >= 3 && pi.peer.Requested.Contains(pieceIndex) {
 				continue
 			}
 

--- a/internal/core/p.go
+++ b/internal/core/p.go
@@ -176,7 +176,7 @@ type Peer struct {
 	isSeed            atomic.Bool
 	peerChoking       atomic.Bool
 	peerInterested    atomic.Bool
-	id                uint64
+	id                uint32
 	rttMutex          sync.RWMutex
 	wm                sync.Mutex
 	extDontHaveID     gsync.AtomicUint[proto.ExtensionMessage]

--- a/internal/core/p.go
+++ b/internal/core/p.go
@@ -87,6 +87,7 @@ func newPeer(
 		pieceUploadRate:   flowrate.New(time.Second, time.Second),
 		pieceDownloadRate: flowrate.New(time.Second, time.Second),
 		Address:           addr,
+		id:                d.c.peerIDCounter.Add(1),
 		QueueLimit:        *atomic.NewUint32(200),
 		Incoming:          skipReadHandshake,
 
@@ -144,7 +145,8 @@ type Peer struct {
 	Conn              net.Conn
 	lastSend          atomic.Time
 	snubbedAt         atomic.Time
-	peerRequests      *xsync.Map[proto.ChunkRequest, empty.Empty]
+	r                 *bufio.Reader
+	pieceUploadRate   *flowrate.Monitor
 	pieceDownloadRate *flowrate.Monitor
 	Bitmap            *bm.Bitmap
 	myRequests        *xsync.Map[proto.ChunkRequest, time.Time]
@@ -152,7 +154,7 @@ type Peer struct {
 	d                 *Download
 	Rejected          *xsync.Map[proto.ChunkRequest, empty.Empty]
 	allowFast         *bm.Bitmap
-	pieceUploadRate   *flowrate.Monitor
+	peerRequests      *xsync.Map[proto.ChunkRequest, empty.Empty]
 	cancel            context.CancelFunc
 	UserAgent         atomic.Pointer[string]
 	ourPieceRequests  chan uint32
@@ -160,11 +162,11 @@ type Peer struct {
 	peerID            atomic.Pointer[proto.PeerID]
 	pieceDone         chan struct{}
 	w                 *bufio.Writer
-	r                 *bufio.Reader
 	Address           netip.AddrPort
 	Requested         bitmap.Bitmap
 	rttAverage        sizedSlice[time.Duration]
 	slowStart         atomic.Bool
+	ourChoking        atomic.Bool
 	QueueLimit        atomic.Uint32
 	lastRate          atomic.Int64
 	desiredQueueSize  atomic.Int32
@@ -174,7 +176,7 @@ type Peer struct {
 	isSeed            atomic.Bool
 	peerChoking       atomic.Bool
 	peerInterested    atomic.Bool
-	ourChoking        atomic.Bool
+	id                uint64
 	rttMutex          sync.RWMutex
 	wm                sync.Mutex
 	extDontHaveID     gsync.AtomicUint[proto.ExtensionMessage]


### PR DESCRIPTION
## Problem

When a piece fails SHA-1 hash check, its chunks are cleared and the piece is re-scheduled. However, `assignPiecesToPeers` did not check whether a peer had already been assigned (and failed) this piece before. The same peer with corrupt data could be re-selected repeatedly, causing the piece to fail hash over and over — explaining the `downloaded` >> `completed` discrepancy.

## Fix

Track per-piece hash failure count in `corruptedPieces`. When a piece has failed `>= 3` times, skip peers whose `Requested` bitmap already contains this piece, forcing cycling through different peers.

When a previously-failing piece eventually passes, log an info message with the failure count, and clean up the tracking entry.

## Debug endpoint

Shows top 10 pieces with most hash failures:

```
failing pieces: 5
  piece 123: 7 failures
  piece 456: 3 failures
```