### PR TITLE
debug: add Sync() after WriteAt to test cache coherency hypothesis

### DIFF
--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -323,6 +323,8 @@ func (d *Download) writeChunkToDist(begin int64, data []byte) error {
 			return errgo.Wrap(err, "failed to write chunk")
 		}
 
+		_ = f.File.Sync()
+
 		f.Release()
 		offset += chunk.length
 	}


### PR DESCRIPTION
## Hypothesis

Piece hash check failures may be caused by  data not being visible to subsequent  when using different file descriptors (O_RDWR write → pool release → O_RDONLY read).

## Change

Add  after each  to force disk flush before releasing the file handle.

⚠️ Performance impact: ~375 syncs/sec at 6 MB/s download. This is a diagnostic change only.

## Testing

Deploy and observe if  rate drops for new torrents.