### PR TITLE
fix(core): pending check used c.pi instead of loop variable i

### DIFF
--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -141,7 +141,7 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 		piecePiStart := res.Begin/defaultBlockSize + res.PieceIndex*d.normalChunkLen
 		piecePiEnd := piecePiStart + uint32(pieceChunksCount(d.info, res.PieceIndex))
 		for i := piecePiStart; i < piecePiEnd; i++ {
-			if !d.chunk.pending.Contains(c.pi) {
+			if !d.chunk.pending.Contains(i) {
 				return
 			}
 		}


### PR DESCRIPTION
`handlePieceFromHeap` was never called through the normal path because the pending check loop always tested `c.pi` (which is always in pending) instead of the loop iterator `i`. This caused all pieces to be written via the 10-chunk merge path instead of the optimized single-batch path.