### PR TITLE
fix(core): un-snub peers when they start responding again

### DIFF
--- a/internal/core/p.go
+++ b/internal/core/p.go
@@ -542,6 +542,15 @@ func (p *Peer) start(skipHandshake bool) {
 
 			p.responseCond.Signal()
 			p.pieceDownloadRate.Update(len(event.Res.Data))
+
+			if p.snubbed.Load() {
+				p.snubbed.Store(false)
+				p.slowStart.Store(true)
+				p.desiredQueueSize.Store(1)
+				p.lastRate.Store(0)
+				p.log.Info().Msg("peer un-snubbed: responding again")
+			}
+
 			p.d.ResChan <- event.Res
 		case proto.Request:
 			if !p.validateRequest(event.Req) {


### PR DESCRIPTION
Snubbed peers (30s chunk timeout) had their pipeline permanently stuck at 1 with no recovery path — they were never un-snubbed.

Now when a snubbed peer delivers a chunk response, it is un-snubbed and re-enters slow start (pipeline=1, gradually doubling on each piece completion).