### PR TITLE
fix(core): prevent request pipeline flooding and add tit-for-tat unchoking

### DIFF
--- a/internal/core/d_upload.go
+++ b/internal/core/d_upload.go
@@ -44,15 +44,19 @@ func (d *Download) recalculateUnchokeSlots() {
 		if p.closed.Load() {
 			return true
 		}
-		if p.peerInterested.Load() {
+		// A peer is eligible for unchoking if:
+		// - it is interested in us (wants our data), OR
+		// - we are interested in it AND it is unchoking us (tit-for-tat reciprocation)
+		eligible := p.peerInterested.Load() || (!p.peerChoking.Load() && p.ourInterested.Load())
+		if eligible {
 			candidates = append(candidates, peerRate{
 				peer: p,
 				rate: p.pieceUploadRate.Status().CurRate,
 			})
 		}
-		if !p.peerInterested.Load() || p.snubbed.Load() {
-			// choke peers that are not interested or snubbed
-			if !p.ourChoking.CompareAndSwap(false, true) {
+		if !eligible || p.snubbed.Load() {
+			// choke peers that are not eligible or snubbed
+			if p.ourChoking.CompareAndSwap(false, true) {
 				go p.sendEventX(Event{Event: proto.Choke})
 			}
 		}

--- a/internal/core/p.go
+++ b/internal/core/p.go
@@ -356,8 +356,15 @@ func (p *Peer) downloadPieceChunks(index uint32) {
 			p.d.endgameRequested.Store(chunk, empty.Empty{})
 		}
 
-		// wait if peer's request queue is full
-		for p.myRequests.Size() >= min(int(p.QueueLimit.Load())-10, 300) {
+		// Pace chunk requests to avoid flooding slow peers.
+		// Use a fraction of the peer's advertised queue limit,
+		// clamped between the per-piece floor and the global ceiling.
+		limit := max(int(p.QueueLimit.Load())/2, 10)
+		globalLimit := min(int(p.QueueLimit.Load())-10, 300)
+		if limit > globalLimit {
+			limit = globalLimit
+		}
+		for p.myRequests.Size() >= limit {
 			select {
 			case <-p.ctx.Done():
 				return


### PR DESCRIPTION
## Summary

Fixes three issues causing poor download performance:

### 1. Request pipeline flooding (`p.go`)
The chunk request loop in `downloadPieceChunks` previously used the peer's full queue limit (`QueueLimit - 10`, typically 190) as backpressure. For slow peers, this caused hundreds of requests to pile up, saturating the pipeline with no room to recover. Now uses `QueueLimit/2` (minimum 10) to pace requests per-piece, preventing the bomb effect while allowing fast peers to maintain good throughput.

### 2. Tit-for-tat unchoking (`d_upload.go`)
`recalculateUnchokeSlots` only unchoked peers that were interested in us (`peerInterested`). As a leecher, no seeders are interested, so all peers stayed choked (`OUR CHOKE = true`). Now includes peers that unchoke us (we're downloading from) as eligible candidates for unchoking, implementing proper tit-for-tat reciprocation.

### 3. Inverted CAS logic (`d_upload.go`)
The Choke message dispatch used `!CompareAndSwap(false, true)` which sent `Choke` only to already-choked peers. Fixed to `CompareAndSwap(false, true)` so Choke is sent when transitioning from unchoked→choked.

### Before (debug output showing the problems)
- `OUR CHOKE = true` for all peers — no reciprocation
- `QUEUE PIECE = 0` — pipeline deadlocked
- `OUR REQ` = 238/253 with QueueLimit=200 — request bomb on slow peers
- 76 MiB waste out of 324 MiB downloaded (23.5%)

### After
- Unchoke peers that unchoke us → more peers may reciprocate with data
- Request pipeline stays at healthy levels (100 for QueueLimit=200)
- Correct Choke/Unchoke protocol messages