### PR TITLE
feat: add torrent.reannounce JSON-RPC method

### DIFF
--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -376,6 +376,29 @@ func (c *Client) ReplaceTrackers(h metainfo.Hash, replacements map[string]string
 	return nil
 }
 
+func (c *Client) Reannounce(h metainfo.Hash) error {
+	c.m.RLock()
+	d, ok := c.downloadMap[h]
+	c.m.RUnlock()
+	if !ok {
+		return fmt.Errorf("torrent %s not exists", h)
+	}
+
+	var event tracker.AnnounceEvent
+	switch {
+	case d.HasState(Downloading):
+		event = tracker.EventStarted
+	case d.HasState(Seeding):
+		event = tracker.EventCompleted
+	default:
+		// Stopped, Checking, Moving, Error — send a regular update without event.
+		event = ""
+	}
+
+	d.Trk.ForceReannounce(event)
+	return nil
+}
+
 func (c *Client) RemoveTorrent(h metainfo.Hash, removeData bool) error {
 	c.m.Lock()
 

--- a/internal/core/tracker/tracker.go
+++ b/internal/core/tracker/tracker.go
@@ -159,6 +159,20 @@ func (t *Trackers) Announce(event AnnounceEvent) {
 	}
 }
 
+// ForceReannounce resets NextAnnounce for all trackers and triggers an immediate
+// announce with the given event. Useful for manual reannounce requests from the API.
+func (t *Trackers) ForceReannounce(event AnnounceEvent) {
+	now := time.Now()
+	t.mu.Lock()
+	for _, tier := range t.tiers {
+		for _, tr := range tier.Trackers {
+			tr.NextAnnounce = now
+		}
+	}
+	t.mu.Unlock()
+	t.Announce(event)
+}
+
 // Totals returns the max seeders and leechers across all trackers.
 func (t *Trackers) Totals() (seeders, leechers int) {
 	t.Seeds.Range(func(_ string, s int) bool {

--- a/internal/web/torrent_reannounce.go
+++ b/internal/web/torrent_reannounce.go
@@ -1,0 +1,41 @@
+// Copyright 2026 trim21 <trim21.me@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package web
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+
+	"github.com/swaggest/usecase"
+
+	"neptune/internal/core"
+	"neptune/internal/metainfo"
+	"neptune/internal/web/jsonrpc"
+)
+
+type reannounceRequest struct {
+	InfoHash string `description:"torrent file hash" json:"info_hash" required:"true"`
+}
+
+type reannounceResponse struct{}
+
+func reannounceTorrent(h *jsonrpc.Handler, c *core.Client) {
+	u := usecase.NewInteractor(
+		func(ctx context.Context, req *reannounceRequest, res *reannounceResponse) error {
+			if len(req.InfoHash) != sha1.Size*2 {
+				return errInvalidInfoHash
+			}
+
+			raw, err := hex.DecodeString(req.InfoHash)
+			if err != nil {
+				return errInvalidInfoHash
+			}
+
+			return c.Reannounce(metainfo.Hash(raw))
+		},
+	)
+	u.SetName("torrent.reannounce")
+	h.Add(u)
+}

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -105,6 +105,7 @@ func New(c *core.Client, token string, enableDebug bool) http.Handler {
 	addTracker(h, c)
 	removeTracker(h, c)
 	replaceTrackers(h, c)
+	reannounceTorrent(h, c)
 
 	addTorrent(h, c)
 	removeTorrent(h, c)

--- a/sdk/python/src/neptune_sdk/client.py
+++ b/sdk/python/src/neptune_sdk/client.py
@@ -235,6 +235,10 @@ class NeptuneClient:
         """Recheck torrent data integrity."""
         self._call("torrent.recheck", InfoHashRequest(info_hash=info_hash))
 
+    def torrent_reannounce(self, info_hash: str) -> None:
+        """Force immediate re-announce to all trackers."""
+        self._call("torrent.reannounce", InfoHashRequest(info_hash=info_hash))
+
     # ── torrent — custom ───────────────────────────────────────────────
 
     def torrent_custom_set(self, info_hash: str, key: str, value: str) -> None:

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -66,6 +66,7 @@ export interface NeptuneMethodMap {
   'torrent.add_tracker': {params: AddTrackerParams; result: void};
   'torrent.remove_tracker': {params: RemoveTrackerParams; result: void};
   'torrent.replace_trackers': {params: ReplaceTrackersParams; result: void};
+  'torrent.reannounce': {params: InfoHashParams; result: void};
   'torrent.set_file_priority': {params: SetFilePriorityParams; result: void};
   'torrent.set_download_limit': {params: SpeedLimitParams; result: void};
   'torrent.set_upload_limit': {params: SpeedLimitParams; result: void};


### PR DESCRIPTION
Add `torrent.reannounce` JSON-RPC method to manually trigger tracker re-announce.

## Changes

- **`tracker/tracker.go`**: Added `ForceReannounce(event)` method that resets all trackers' `NextAnnounce` and immediately triggers an announce with the given event.
- **`api.go`**: Added `Client.Reannounce()` that selects the appropriate tracker event based on download state:
  - `Downloading` → `EventStarted`
  - `Seeding` → `EventCompleted`
  - `Stopped` / `Checking` / `Moving` / `Error` → no event (regular update query)
- **`web/torrent_reannounce.go`**: New JSON-RPC handler (method `torrent.reannounce`)
- **`web/web.go`**: Registered new handler