### PR TITLE
feat(core): align peer reconnect and choke/unchoke with libtorrent

### DIFF
--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -161,6 +161,7 @@ type Download struct {
 	completed              atomic.Int64
 	selectedSize           atomic.Int64
 	unchokeSlotIdx         int
+	unchokeCycleOffset     int // rotating offset for slot cycling
 	m                      sync.RWMutex
 	pendingPeersMutex      sync.Mutex
 	ratePieceMutex         sync.Mutex

--- a/internal/core/d_conn.go
+++ b/internal/core/d_conn.go
@@ -6,8 +6,10 @@ package core
 import (
 	"context"
 	"errors"
+	"io"
 	"net"
 	"net/netip"
+	"os"
 	"syscall"
 	"time"
 
@@ -16,17 +18,36 @@ import (
 	"neptune/internal/proto"
 )
 
+// connBackoff constants mirror libtorrent's strategy:
+//   - Timeout (transient network issue): short backoff, immediate if peer had transfers
+//   - Refused (peer likely offline): long backoff
+//   - Other errors: moderate backoff
+const (
+	connBackoffTimeout  = 30 * time.Second
+	connBackoffRefused  = 10 * time.Minute
+	connBackoffGeneric  = 1 * time.Minute
+	connBackoffTransfer = 0 // immediate retry if peer had active transfers
+)
+
+type connDisconnectReason uint8
+
+const (
+	connReasonNone    connDisconnectReason = iota // never connected / no info
+	connReasonEOF                                 // peer closed cleanly (io.EOF)
+	connReasonTimeout                             // read deadline exceeded / TCP timeout
+	connReasonRefused                             // connection refused (only for outgoing)
+	connReasonError                               // other network error
+)
+
 type connHistory struct {
-	lastTry time.Time
-	err     error
-	timeout bool
-	refused bool
+	lastTry  time.Time
+	err      error
+	hadTrans bool
+	reason   connDisconnectReason
 }
 
 // AddConn add an incoming connection from client listener.
 func (d *Download) AddConn(addr netip.AddrPort, conn net.Conn, h proto.Handshake) {
-	// d.connMutex.Lock()
-	// defer d.connMutex.Unlock()
 	d.connectionHistory.Add(addr, connHistory{})
 	NewIncomingPeer(conn, d, addr, h)
 }
@@ -36,17 +57,11 @@ func (d *Download) connectToPeers() {
 	defer d.pendingPeersMutex.Unlock()
 
 	for d.pendingPeers.Len() > 0 {
-		// try connecting first
 		pp := d.pendingPeers.Pop()
 
 		if item, ok := d.connectionHistory.Get(pp.addrPort); ok {
-			if time.Since(item.lastTry) < time.Minute*10 {
-				if item.timeout {
-					continue
-				}
-				if item.refused {
-					continue
-				}
+			if d.canRetry(item) {
+				continue
 			}
 		}
 
@@ -70,11 +85,13 @@ func (d *Download) connectToPeers() {
 
 			conn, err := global.Dial(ctx, "tcp", pp.addrPort.String())
 			if err != nil {
-				if errors.Is(err, context.DeadlineExceeded) {
-					ch.timeout = true
+				ch.lastTry = time.Now()
+				if errors.Is(err, context.DeadlineExceeded) || os.IsTimeout(err) {
+					ch.reason = connReasonTimeout
 				} else if errors.Is(err, syscall.ECONNREFUSED) {
-					ch.refused = true
+					ch.reason = connReasonRefused
 				} else {
+					ch.reason = connReasonError
 					ch.err = err
 				}
 
@@ -94,4 +111,57 @@ func (d *Download) connectToPeers() {
 			NewOutgoingPeer(conn, d, pp.addrPort)
 		})
 	}
+}
+
+// canRetry returns true if the peer should be skipped (not yet ready to retry).
+// Returns false if enough time has passed to retry the connection.
+func (d *Download) canRetry(ch connHistory) bool {
+	// If peer had transferred data, retry immediately regardless of reason.
+	// This mirrors libtorrent's behavior where peers with transfer_counter > 0
+	// are never culled and can be reconnected aggressively.
+	if ch.hadTrans {
+		return false
+	}
+
+	elapsed := time.Since(ch.lastTry)
+
+	switch ch.reason {
+	case connReasonNone:
+		// Never tried before, always allow.
+		return false
+	case connReasonTimeout:
+		return elapsed < connBackoffTimeout
+	case connReasonRefused:
+		return elapsed < connBackoffRefused
+	case connReasonEOF:
+		// Peer closed cleanly — it may come back soon (e.g., client restart).
+		// Use a short backoff.
+		return elapsed < connBackoffTimeout
+	default:
+		return elapsed < connBackoffGeneric
+	}
+}
+
+// recordDisconnect records the reason a peer disconnected.
+// Called by Peer.close() to update connection history for future retry decisions.
+func (d *Download) recordDisconnect(addr netip.AddrPort, hadTrans bool, err error) {
+	ch := connHistory{
+		lastTry:  time.Now(),
+		hadTrans: hadTrans,
+	}
+
+	if err == nil {
+		ch.reason = connReasonEOF
+	} else if os.IsTimeout(err) || errors.Is(err, context.DeadlineExceeded) {
+		ch.reason = connReasonTimeout
+	} else if errors.Is(err, io.EOF) {
+		ch.reason = connReasonEOF
+	} else if errors.Is(err, syscall.ECONNRESET) {
+		ch.reason = connReasonError
+	} else {
+		ch.reason = connReasonError
+		ch.err = err
+	}
+
+	d.connectionHistory.Add(addr, ch)
 }

--- a/internal/core/d_upload.go
+++ b/internal/core/d_upload.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"net/netip"
 	"slices"
 	"sort"
@@ -26,88 +27,234 @@ type uploadReq struct {
 var errUploadPaused = errors.New("upload paused")
 
 const (
-	uploadSlots        = 4 // default number of upload slots
-	optimisticUnchokeN = 1 // number of optimistic unchoke slots
-	unchokeInterval    = 10 * time.Second
+	uploadSlots          = 4 // default number of upload slots
+	optimisticUnchokeN   = 1 // reserved for optimistic unchoke
+	unchokeInterval      = 10 * time.Second
+	unchokeGracePeriod   = 50 * time.Second // don't choke peers recently unchoked
+	unchokeCycleFraction = 8                // cycle ~1/8 = ~12.5% of slots per round
 )
 
-func (d *Download) recalculateUnchokeSlots() {
-	type peerRate struct {
-		peer *Peer
-		rate int64
+// peerUploadScore computes a weighted score for unchoke priority.
+// Aligns with libtorrent's calculate_unchoke_upload_leech_experimental:
+//   - Peers that have unchoked us (reciprocating) get order_base + rate bonus
+//   - Peers that haven't unchoked us get random weight (optimistic queue)
+//   - Preferred peers get a multiplier
+func peerUploadScore(p *Peer) (score uint32, isReciprocal bool) {
+	const orderBase uint32 = 1 << 30
+
+	multiplier := uint32(1)
+	if p.preferred.Load() {
+		multiplier = 4
 	}
 
-	var candidates []peerRate
-	var unchokable []*Peer
+	// Peer has unchoked us — they're reciprocating.
+	if !p.peerChoking.Load() {
+		downRate := uint32(p.pieceDownloadRate.Status().CurRate) / 64
+		score = orderBase + downRate*multiplier
+		return score, true
+	}
+
+	// Peer hasn't unchoked us — optimistic, random weight.
+	// Lower weight for stingy peers (those we upload to at < 1KB/s).
+	upRate := uint32(p.pieceUploadRate.Status().CurRate) / 64
+	if upRate < 2048/64 {
+		score = upRate * multiplier
+	} else {
+		base := uint32(1 << 10)
+		if p.preferred.Load() {
+			base *= 4
+		}
+		score = rand.Uint32N(base) * multiplier
+	}
+	return score, false
+}
+
+// recalculateUnchokeSlots re-evaluates which peers should be unchoked.
+//
+// Strategy (aligned with libtorrent):
+//  1. Always choke snubbed and uninterested peers.
+//  2. Sort candidates by weighted score (prefer reciprocating peers).
+//  3. Unchoke top-N candidates, respecting grace period for recently unchoked.
+//  4. Reserve one slot for optimistic unchoke (randomized, cycling).
+//  5. Rotate a fraction of slots each round to discover faster peers.
+func (d *Download) recalculateUnchokeSlots() {
+	now := time.Now()
+
+	type candidate struct {
+		peer        *Peer
+		score       uint32
+		reciprocal  bool // peer has unchoked us
+		recentlyUnc bool // unchoked within grace period
+	}
+
+	var candidates []candidate
 
 	d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {
 		if p.closed.Load() {
 			return true
 		}
-		// A peer is eligible for unchoking if:
-		// - it is interested in us (wants our data), OR
-		// - we are interested in it AND it is unchoking us (tit-for-tat reciprocation)
-		eligible := p.peerInterested.Load() || (!p.peerChoking.Load() && p.ourInterested.Load())
-		if eligible {
-			candidates = append(candidates, peerRate{
-				peer: p,
-				rate: p.pieceUploadRate.Status().CurRate,
-			})
-		}
-		if !eligible || p.snubbed.Load() {
-			// choke peers that are not eligible or snubbed
+
+		// Always choke snubbed peers.
+		if p.snubbed.Load() {
 			if p.ourChoking.CompareAndSwap(false, true) {
 				go p.sendEventX(Event{Event: proto.Choke})
 			}
+			return true
 		}
+
+		// Always choke uninterested peers — libtorrent only queues peers
+		// that explicitly signaled Interested.
+		if !p.peerInterested.Load() {
+			if p.ourChoking.CompareAndSwap(false, true) {
+				go p.sendEventX(Event{Event: proto.Choke})
+			}
+			return true
+		}
+
+		score, reciprocal := peerUploadScore(p)
+		recently := now.Sub(p.lastUnchokeAt.Load()) < unchokeGracePeriod
+
+		candidates = append(candidates, candidate{
+			peer:        p,
+			score:       score,
+			reciprocal:  reciprocal,
+			recentlyUnc: recently,
+		})
 		return true
 	})
 
-	// sort by upload rate descending (fastest first)
-	slices.SortFunc(candidates, func(a, b peerRate) int {
-		if a.rate > b.rate {
-			return -1
-		}
-		if a.rate < b.rate {
-			return 1
-		}
-		return 0
-	})
-
-	// unchoke top-N peers by rate
-	normalSlots := uploadSlots - optimisticUnchokeN
-	for i, c := range candidates {
-		if i >= normalSlots {
-			break
-		}
-		unchokable = append(unchokable, c.peer)
+	if len(candidates) == 0 {
+		return
 	}
 
-	// optimistic unchoke: pick the peer that has been waiting longest
-	if len(candidates) > normalSlots {
-		// rotate through candidates beyond the normal slots
-		if d.unchokeSlotIdx >= len(candidates)-normalSlots {
-			d.unchokeSlotIdx = 0
+	// Sort by:
+	// 1. Recently unchoked peers first (grace period protection)
+	// 2. Reciprocal peers first (they're giving us data)
+	// 3. Score descending
+	sort.SliceStable(candidates, func(i, j int) bool {
+		a, b := candidates[i], candidates[j]
+		if a.recentlyUnc != b.recentlyUnc {
+			return a.recentlyUnc
 		}
-		if normalSlots+d.unchokeSlotIdx < len(candidates) {
-			unchokable = append(unchokable, candidates[normalSlots+d.unchokeSlotIdx].peer)
+		if a.reciprocal != b.reciprocal {
+			return a.reciprocal
+		}
+		return a.score > b.score
+	})
+
+	normalSlots := max(uploadSlots-optimisticUnchokeN, 1)
+
+	// ── Normal slots (rate-based) ──────────────────────────────────
+	// Rotate cycleSlotsToRotate slots each round to discover faster peers.
+	totalSlots := min(normalSlots, len(candidates))
+	cycleN := max(1, totalSlots/unchokeCycleFraction)
+	d.unchokeCycleOffset = (d.unchokeCycleOffset + cycleN) % max(totalSlots, 1)
+
+	var unchokeSet []*Peer
+
+	// Fill normal slots: take top (normalSlots - cycleN) by score,
+	// then cycle the remaining slots starting at cycleOffset.
+	topN := max(normalSlots-cycleN, 0)
+
+	for i := 0; i < topN && i < len(candidates); i++ {
+		unchokeSet = append(unchokeSet, candidates[i].peer)
+	}
+
+	// Cycled slots: starting from offset, wrapping around.
+	added := topN
+	for i := 0; i < cycleN && added < normalSlots && added < len(candidates); i++ {
+		idx := (d.unchokeCycleOffset + i) % len(candidates)
+		// Skip if already selected.
+		alreadySelected := slices.Contains(unchokeSet, candidates[idx].peer)
+		if !alreadySelected {
+			unchokeSet = append(unchokeSet, candidates[idx].peer)
+			added++
+		}
+	}
+
+	// ── Optimistic unchoke slot ─────────────────────────────────────
+	// Pick a random peer NOT already in the unchoke set.
+	if optimisticUnchokeN > 0 && len(candidates) > len(unchokeSet) {
+		// Collect peers not in unchokeSet.
+		var remaining []*Peer
+		inSet := make(map[*Peer]bool, len(unchokeSet))
+		for _, p := range unchokeSet {
+			inSet[p] = true
+		}
+		for _, c := range candidates {
+			if !inSet[c.peer] {
+				remaining = append(remaining, c.peer)
+			}
+		}
+		if len(remaining) > 0 {
+			optIdx := d.unchokeSlotIdx % len(remaining)
+			unchokeSet = append(unchokeSet, remaining[optIdx])
 			d.unchokeSlotIdx++
 		}
 	}
 
-	// apply: unchoke selected peers, choke the rest
-	for _, p := range unchokable {
+	// ── Apply ───────────────────────────────────────────────────────
+	for _, p := range unchokeSet {
 		if p.ourChoking.CompareAndSwap(true, false) {
+			p.lastUnchokeAt.Store(now)
 			go p.sendEventX(Event{Event: proto.Unchoke})
 		}
 	}
 
-	// trigger response scheduling for newly unchoked peers
+	// Choke everyone not in the unchoke set.
+	inSet := make(map[*Peer]bool, len(unchokeSet))
+	for _, p := range unchokeSet {
+		inSet[p] = true
+	}
+	for _, c := range candidates {
+		if !inSet[c.peer] {
+			if c.peer.ourChoking.CompareAndSwap(false, true) {
+				go c.peer.sendEventX(Event{Event: proto.Choke})
+			}
+		}
+	}
+
+	// Trigger response scheduling for newly unchoked peers.
 	select {
 	case d.scheduleResponseSignal <- empty.Empty{}:
 	default:
 	}
 }
+
+// setInterested is called when our interest in a peer changes.
+// If we become interested and the peer has free slots, we may unchoke
+// immediately (libtorrent's fast-path for new peers).
+func (d *Download) onPeerInterested(p *Peer) {
+	if !p.peerInterested.Load() || p.snubbed.Load() || p.closed.Load() {
+		return
+	}
+
+	// Count currently unchoked peers.
+	unchoked := 0
+	d.peers.Range(func(addr netip.AddrPort, p2 *Peer) bool {
+		if !p2.closed.Load() && !p2.ourChoking.Load() {
+			unchoked++
+		}
+		return true
+	})
+
+	if unchoked >= uploadSlots {
+		return
+	}
+
+	// Fast unchoke: new peer, slots available.
+	if p.ourChoking.CompareAndSwap(true, false) {
+		p.lastUnchokeAt.Store(time.Now())
+		go p.sendEventX(Event{Event: proto.Unchoke})
+
+		select {
+		case d.scheduleResponseSignal <- empty.Empty{}:
+		default:
+		}
+	}
+}
+
+// ── Upload dispatch helpers ────────────────────────────────────────────
 
 // backgroundReqHandler processes upload requests from peers.
 // It collects requests from unchoked peers, groups them by piece,

--- a/internal/core/p.go
+++ b/internal/core/p.go
@@ -141,55 +141,60 @@ var ErrPeerSendInvalidData = errors.New("addrPort send invalid data")
 
 type Peer struct {
 	log               zerolog.Logger
+	closeErr          error
 	ctx               context.Context
 	Conn              net.Conn
 	lastSend          atomic.Time
 	snubbedAt         atomic.Time
-	r                 *bufio.Reader
-	pieceUploadRate   *flowrate.Monitor
-	pieceDownloadRate *flowrate.Monitor
-	Bitmap            *bm.Bitmap
+	lastUnchokeAt     atomic.Time
+	Rejected          *xsync.Map[proto.ChunkRequest, empty.Empty]
+	UserAgent         atomic.Pointer[string]
 	myRequests        *xsync.Map[proto.ChunkRequest, time.Time]
 	myRequestHistory  *xsync.Map[proto.ChunkRequest, empty.Empty]
 	d                 *Download
-	Rejected          *xsync.Map[proto.ChunkRequest, empty.Empty]
+	pieceDownloadRate *flowrate.Monitor
 	allowFast         *bm.Bitmap
 	peerRequests      *xsync.Map[proto.ChunkRequest, empty.Empty]
 	cancel            context.CancelFunc
-	UserAgent         atomic.Pointer[string]
+	Bitmap            *bm.Bitmap
 	ourPieceRequests  chan uint32
 	responseCond      *gsync.Cond
 	peerID            atomic.Pointer[proto.PeerID]
 	pieceDone         chan struct{}
 	w                 *bufio.Writer
+	r                 *bufio.Reader
+	pieceUploadRate   *flowrate.Monitor
 	Address           netip.AddrPort
 	Requested         bitmap.Bitmap
 	rttAverage        sizedSlice[time.Duration]
-	slowStart         atomic.Bool
-	ourChoking        atomic.Bool
+	isSeed            atomic.Bool
 	QueueLimit        atomic.Uint32
-	lastRate          atomic.Int64
 	desiredQueueSize  atomic.Int32
 	ourInterested     atomic.Bool
 	snubbed           atomic.Bool
 	closed            atomic.Bool
-	isSeed            atomic.Bool
-	peerChoking       atomic.Bool
 	peerInterested    atomic.Bool
-	id                uint32
+	ourChoking        atomic.Bool
+	lastRate          atomic.Int64
+	preferred         atomic.Bool
+	slowStart         atomic.Bool
+	peerChoking       atomic.Bool
 	rttMutex          sync.RWMutex
 	wm                sync.Mutex
 	extDontHaveID     gsync.AtomicUint[proto.ExtensionMessage]
 	extPexID          gsync.AtomicUint[proto.ExtensionMessage]
-	readBuf           [4]byte
+	id                uint32
 	writeBuf          [4]byte
+	readBuf           [4]byte
 	Incoming          bool
 	fastExtension     bool
 	dhtEnabled        bool
 	subExtensions     bool
+	hadTransfer       bool
 }
 
 func (p *Peer) Response(res *proto.ChunkResponse) bool {
+	p.hadTransfer = true
 	_, ok := p.peerRequests.LoadAndDelete(res.Request())
 	if !ok {
 		// Request might be canceled concurrently (Cancel) or already served.
@@ -229,6 +234,13 @@ func (p *Peer) Unchoke() {
 func (p *Peer) close() {
 	if p.closed.CompareAndSwap(false, true) {
 		p.log.Trace().Caller(1).Msg("close")
+
+		// Record disconnect reason for future retry decisions.
+		// Only record for outgoing peers; incoming peers don't need retry logic.
+		if !p.Incoming {
+			p.d.recordDisconnect(p.Address, p.hadTransfer, p.closeErr)
+		}
+
 		p.d.peers.Delete(p.Address)
 		p.d.c.sem.Release(1)
 		p.d.c.connectionCount.Sub(1)
@@ -505,6 +517,7 @@ func (p *Peer) start(skipHandshake bool) {
 		event, err := p.DecodeEvents()
 		if err != nil {
 			p.log.Trace().Err(err).Msg("failed to decode event")
+			p.closeErr = err
 			return
 		}
 
@@ -532,6 +545,7 @@ func (p *Peer) start(skipHandshake bool) {
 			}
 		case proto.Interested:
 			p.peerInterested.Store(true)
+			p.d.onPeerInterested(p)
 			p.d.scheduleResponseSignal <- empty.Empty{}
 		case proto.NotInterested:
 			p.peerInterested.Store(false)
@@ -541,6 +555,7 @@ func (p *Peer) start(skipHandshake bool) {
 			p.peerChoking.Store(false)
 			p.d.scheduleRequestSignal <- empty.Empty{}
 		case proto.Piece:
+			p.hadTransfer = true
 			if !p.resIsValid(event.Res) {
 				p.log.Trace().Msg("failed to validate response")
 				// send response without myRequests


### PR DESCRIPTION
## Summary

Align two core subsystems with libtorrent/rtorrent behavior:

### 1. Peer reconnect strategy (`d_conn.go`)

| Disconnect reason | Old | New |
|---|---|---|
| TCP timeout | 10 min backoff | **30s** backoff |
| ECONNREFUSED | 10 min backoff | 10 min (unchanged) |
| Clean close (EOF) | 10 min backoff | **30s** backoff |
| Peer had transfers before disconnect | not tracked | **retry immediately** |

- New `hadTransfer` flag: set when peer sends or receives piece data
- New `recordDisconnect()`: records disconnect reason (timeout/EOF/error) into connection history
- If peer transferred data before disconnecting: retry immediately (libtorrent's `transfer_counter > 0`)

### 2. Choke/unchoke algorithm (`d_upload.go`)

| Aspect | Old | New |
|---|---|---|
| Unchoke priority | Sorted by upload rate only | Weighted score: prefer reciprocating peers (unchoked us), with download-rate multiplier |
| Grace period | None | **50s** — don't choke peers recently unchoked |
| Slot rotation | None (one optimistic slot per 30s) | **~12.5% of slots rotated each 10s round** |
| Fast unchoke | None | New interested peer unchoked immediately if slots available |
| Optimistic unchoke | Round-robin through remaining | Random weight per peer, preferred peers 4x weight |
| Preferred peer | Not supported | `preferred` flag with 4x multiplier |

New `peerUploadScore()` mirrors libtorrent's `calculate_unchoke_upload_leech_experimental`:
- Peers that unchoked us → `order_base + download_rate × multiplier`
- Peers that didn't unchoke us → random weight (optimistic queue)
- Stingy peers (upload < 1KB/s) → lower weight