### PR TITLE
fix(core): re-add disconnected peers to pending for reconnect

### DIFF
--- a/internal/core/d_conn.go
+++ b/internal/core/d_conn.go
@@ -56,11 +56,17 @@ func (d *Download) connectToPeers() {
 	d.pendingPeersMutex.Lock()
 	defer d.pendingPeersMutex.Unlock()
 
+	// Collect skipped peers (e.g., backoff not expired) so we can re-push
+	// them after the loop. This mirrors libtorrent's persistent available_list
+	// where peers stay until they can be retried.
+	var retryLater []peerWithPriority
+
 	for d.pendingPeers.Len() > 0 {
 		pp := d.pendingPeers.Pop()
 
 		if item, ok := d.connectionHistory.Get(pp.addrPort); ok {
 			if d.canRetry(item) {
+				retryLater = append(retryLater, pp)
 				continue
 			}
 		}
@@ -70,6 +76,7 @@ func (d *Download) connectToPeers() {
 		}
 
 		if !d.c.sem.TryAcquire(1) {
+			retryLater = append(retryLater, pp)
 			break
 		}
 		d.c.connectionCount.Add(1)
@@ -110,6 +117,12 @@ func (d *Download) connectToPeers() {
 
 			NewOutgoingPeer(conn, d, pp.addrPort)
 		})
+	}
+
+	// Re-push peers that were skipped (backoff not expired or sem full)
+	// so they can be retried on the next signal.
+	for _, pp := range retryLater {
+		d.pendingPeers.Push(pp)
 	}
 }
 

--- a/internal/core/d_loop.go
+++ b/internal/core/d_loop.go
@@ -123,17 +123,24 @@ func (d *Download) startBackground() {
 	d.goBackground(d.backgroundReqHandler)
 
 	d.goBackground(func() {
+		// Periodic reconnect timer so backoff-expired peers get retried.
+		// libtorrent does this every 10s via receive_connect_peers.
+		reconnectTicker := time.NewTicker(10 * time.Second)
+		defer reconnectTicker.Stop()
+
 		for {
 			select {
 			case <-d.ctx.Done():
 				return
 			case <-d.pendingPeersSignal:
-				if !d.wait(Seeding | Downloading) {
-					continue
-				}
-
-				d.connectToPeers()
+			case <-reconnectTicker.C:
 			}
+
+			if !d.wait(Seeding | Downloading) {
+				continue
+			}
+
+			d.connectToPeers()
 		}
 	})
 

--- a/internal/core/p.go
+++ b/internal/core/p.go
@@ -247,6 +247,22 @@ func (p *Peer) close() {
 		p.cancel()
 		_ = p.Conn.Close()
 		p.d.buildNetworkPieces <- empty.Empty{}
+
+		// Re-queue for reconnect so connectToPeers gets another chance.
+		// canRetry backoff prevents tight reconnect loops.
+		if !p.Incoming && p.d.HasState(Downloading|Seeding) {
+			p.d.pendingPeersMutex.Lock()
+			p.d.pendingPeers.Push(peerWithPriority{
+				addrPort: p.Address,
+				priority: p.d.c.PeerPriority(p.Address),
+			})
+			p.d.pendingPeersMutex.Unlock()
+
+			select {
+			case p.d.pendingPeersSignal <- empty.Empty{}:
+			default:
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

After initial tracker announce, peers gradually disconnect but never reconnect until the next tracker announce (30 min interval). This causes torrents to drop from multiple peers to 1 or 0, with 32-51 pending peers sitting idle.

Root cause: Neptune has no mechanism to retry disconnected peers. The pending peer queue is drained once on startup and only refilled by tracker announces. Peer.close() removes the peer but doesn't re-queue it.

## Fix

Three changes aligning with libtorrent's `available_list` + periodic `receive_connect_peers` pattern:

1. **p.go `close()`**: Re-push disconnected outgoing peer to `pendingPeers` and signal `connectToPeers`. `canRetry` backoff prevents tight reconnect loops.

2. **d_conn.go `connectToPeers()`**: Collect skipped peers (backoff not expired or sem full) in `retryLater` and re-push after the loop, instead of discarding them. Mirrors libtorrent's persistent available_list where peers stay until retriable.

3. **d_loop.go `startBackground()`**: Add 10-second periodic reconnect ticker that triggers `connectToPeers`, matching libtorrent's scheduler calling `receive_connect_peers()` every 10s.