### PR TITLE
feat(debug): add file list and wanted pieces to debug page

### DIFF
--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -520,13 +520,15 @@ func (c *Client) DebugHandlers() http.Handler {
 
 		debugPrintTrackers(w, d)
 		debugPrintPeers(w, d)
+		debugPrintFiles(w, d)
 
 		if r.URL.Query().Get("mode") == "full" {
-			// Show compressed piece ranges: have and missing.
+			// Show compressed piece ranges: have, wanted, and missing.
 			writePieceRanges(w, "have", d.bm)
+			writePieceRanges(w, "wanted", d.selectedPiecesBm)
 			missing := bm.New(d.info.NumPieces)
 			missing.Fill()
-			writePieceRanges(w, "missing", missing.WithAndNot(d.bm))
+			writePieceRanges(w, "missing", missing.WithAndNot(d.bm).WithAnd(d.selectedPiecesBm))
 		}
 
 		debugPrintPendingPeers(w, d)
@@ -591,6 +593,50 @@ func debugPrintPeers(w io.Writer, d *Download) {
 	})
 
 	t.SortBy([]table.SortBy{{Name: colAddress}})
+
+	_, _ = io.WriteString(w, t.Render())
+	_, _ = fmt.Fprintln(w)
+}
+
+func debugPrintFiles(w io.Writer, d *Download) {
+	t := table.NewWriter()
+	t.AppendHeader(table.Row{"#", "size", "progress", "selected", "path"})
+	t.SortBy([]table.SortBy{{Name: "#"}})
+
+	var offset int64
+	for i, file := range d.info.Files {
+		selected := "yes"
+		if d.selectedFilesSet != nil {
+			if _, ok := d.selectedFilesSet[i]; !ok {
+				selected = "no"
+			}
+		}
+
+		startPiece := as.Uint32(offset / d.info.PieceLength)
+		endPiece := min(as.Uint32((offset+file.Length+d.info.PieceLength-1)/d.info.PieceLength), d.info.NumPieces)
+
+		var doneCount uint32
+		for pi := startPiece; pi < endPiece; pi++ {
+			if d.bm.Contains(pi) {
+				doneCount++
+			}
+		}
+		totalPieces := endPiece - startPiece
+		progress := 0.0
+		if totalPieces > 0 {
+			progress = float64(doneCount) / float64(totalPieces) * 100
+		}
+
+		t.AppendRow(table.Row{
+			i,
+			humanize.IBytes(uint64(file.Length)),
+			fmt.Sprintf("%.1f%%", progress),
+			selected,
+			filepath.Join(file.RawPath...),
+		})
+
+		offset += file.Length
+	}
 
 	_, _ = io.WriteString(w, t.Render())
 	_, _ = fmt.Fprintln(w)


### PR DESCRIPTION
## Changes

Debug page (`?mode=full`) now displays:

1. **File list table** — index, size, per-file progress, selected status
2. **Wanted bitmap** — shows `selectedPiecesBm` alongside have/missing
3. **Missing** now computed as `wanted AND NOT have`, so unselected pieces don't show up as missing

Before:
```
have: 5727 pieces
missing: 5889 pieces  (includes unselected files!)
```

After:
```
have: 5727 pieces
wanted: 11616 pieces
missing: 5889 pieces   (only wanted pieces)
```

This makes it easy to see if `completed=0` is a real bug or just file selection mismatch.