### PR TITLE
fix(core): prevent double-assigning same piece to multiple peers

### DIFF
--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -122,6 +122,7 @@ type Download struct {
 	peers                  *xsync.Map[netip.AddrPort, *Peer]
 	connectionHistory      *lru.Cache[netip.AddrPort, connHistory]
 	bm                     *bm.Bitmap
+	pieceInFlight          *bm.Bitmap // pieces currently assigned to a peer, matching libtorrent's untouched_bitfield
 	err                    atomic.Pointer[error]
 	pendingPeers           *heap.Heap[peerWithPriority]
 	cancel                 context.CancelFunc
@@ -274,7 +275,8 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 
 		private: info.Private,
 
-		bm: bm.New(info.NumPieces),
+		bm:            bm.New(info.NumPieces),
+		pieceInFlight: bm.New(info.NumPieces),
 
 		bitfieldSize: (info.NumPieces + 7) / 8,
 

--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -382,6 +382,7 @@ func (d *Download) checkPiece(pieceIndex uint32) error {
 	copy(digest[:], hasher.Sum(nil))
 
 	if digest != d.info.Pieces[pieceIndex] {
+		d.pieceInFlight.Unset(pieceIndex)
 		d.corruptedPiecesMu.Lock()
 		d.corruptedPieces[pieceIndex]++
 		d.corruptedPiecesMu.Unlock()
@@ -397,6 +398,7 @@ func (d *Download) checkPiece(pieceIndex uint32) error {
 	}
 
 	notHave := d.bm.SetX(pieceIndex)
+	d.pieceInFlight.Unset(pieceIndex)
 
 	if notHave {
 		d.completed.Add(pieceSize)
@@ -493,6 +495,11 @@ func (d *Download) updateRarePieces() {
 		}
 
 		if !d.selectedPiecesBm.Contains(uint32(index)) {
+			continue
+		}
+
+		// Skip pieces already assigned to another peer (mirrors libtorrent's untouched_bitfield).
+		if d.pieceInFlight.Contains(uint32(index)) {
 			continue
 		}
 
@@ -684,6 +691,7 @@ func (d *Download) assignPiecesToPeers(nextPiece func() (uint32, bool)) {
 			select {
 			case pi.peer.ourPieceRequests <- pieceIndex:
 				pi.peer.Requested.Set(pieceIndex)
+				d.pieceInFlight.Set(pieceIndex) // global tracking, mirrors libtorrent untouched_bitfield
 				pi.capacity--
 			default:
 				// channel full, move to next peer


### PR DESCRIPTION
## Problem

The scheduler (`updateRarePieces`) only checked `d.bm` (completed pieces) when building the rare piece queue. Pieces that were already assigned to a peer (in-flight) would be re-assigned to other peers on the next scheduling cycle because there was no global tracking of in-progress pieces.

This caused:
- Multiple peers downloading the same piece simultaneously
- `downloaded` inflating (all peers' chunks counted)
- `completed` only incrementing once (first to verify)
- Artificially high waste (`downloaded - completed`)

## Fix

Added `pieceInFlight` bitmap (matching libtorrent's `untouched_bitfield`):
- `pieceInFlight.Set()` when a piece is assigned to a peer
- `pieceInFlight.Unset()` when the piece is verified (pass or fail)
- `updateRarePieces` skips pieces in `pieceInFlight`

This mirrors libtorrent's `ChunkSelector::using_index` / `not_using_index` pattern.