### PR TITLE
fix(debug): show file list only in full mode debug page

### DIFF
--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -520,9 +520,9 @@ func (c *Client) DebugHandlers() http.Handler {
 
 		debugPrintTrackers(w, d)
 		debugPrintPeers(w, d)
-		debugPrintFiles(w, d)
 
 		if r.URL.Query().Get("mode") == "full" {
+			debugPrintFiles(w, d)
 			// Show compressed piece ranges: have, wanted, and missing.
 			writePieceRanges(w, "have", d.bm)
 			writePieceRanges(w, "wanted", d.selectedPiecesBm)


### PR DESCRIPTION
The file list table (`debugPrintFiles`) was incorrectly shown in the slim debug page. Move it inside `?mode=full` block.