### PR TITLE
refactor: libtorrent-style peer list and block-level piece picker

### DIFF
--- a/docs/download-scheduling.md
+++ b/docs/download-scheduling.md
@@ -1,0 +1,691 @@
+# Neptune 下载调度算法
+
+本文档描述 Neptune 的下载调度算法，基于 [libtorrent](https://github.com/arvidn/libtorrent) 的 `piece_picker` + `request_a_block` 架构实现。
+
+---
+
+## 目录
+
+1. [架构概览](#1-架构概览)
+2. [Piece Picker — 全局 Block 管理器](#2-piece-picker--全局-block-管理器)
+3. [Block 状态机](#3-block-状态机)
+4. [Piece 优先级系统](#4-piece-优先级系统)
+5. [Pick Pieces — Block 选择算法](#5-pick-pieces--block-选择算法)
+6. [requestABlock — Per-Peer Block 分配](#6-requestablock--per-peer-block-分配)
+7. [Pipeline 动态调整](#7-pipeline-动态调整)
+8. [Endgame 模式](#8-endgame-模式)
+9. [Block 发送与排队](#9-block-发送与排队)
+10. [Peer 生命周期集成](#10-peer-生命周期集成)
+11. [数据接收与写入](#11-数据接收与写入)
+12. [完整数据流](#12-完整数据流)
+
+---
+
+## 1. 架构概览
+
+下载调度由三层协作完成：
+
+```
+┌─────────────────────────────────────────────────────┐
+│  backgroundReqScheduler (定时/信号触发)               │
+│    遍历所有 peer，对每个 peer 调用 requestABlock()     │
+└──────────────────────┬──────────────────────────────┘
+                       │
+         ┌─────────────▼─────────────┐
+         │    requestABlock(peer)    │  ← 核心调度函数
+         │  · 计算 pipeline 大小      │
+         │  · 调用 picker.pickPieces │
+         │  · 过滤 + 验证 block       │
+         │  · 推入 peer.blockRequests │
+         └─────────────┬─────────────┘
+                       │
+   ┌───────────────────┼───────────────────┐
+   │                   │                   │
+   ▼                   ▼                   ▼
+┌──────────┐   ┌──────────────┐   ┌──────────────┐
+│ Peer #1  │   │   Peer #2    │   │   Peer #N    │
+│  排队 →  │   │   排队 →     │   │   排队 →     │
+│  发送    │   │   发送       │   │   发送       │
+└──────────┘   └──────────────┘   └──────────────┘
+        │               │                  │
+        └───────────────┴──────────────────┘
+                        │
+              ┌─────────▼─────────┐
+              │  piecePicker      │  ← 全局 Block 状态跟踪
+              │  · availability[] │
+              │  · blockInfos[]   │
+              │  · priorities[]   │
+              └───────────────────┘
+```
+
+核心设计原则：
+- **全局 Block 级跟踪**：每个 block 的状态、哪个 peer 在请求、多少个 peer 在排队，全部集中在一个 `piecePicker` 中
+- **Rarest-First 优先**：越稀有的 piece 越优先下载，确保在 swarm 中保持稀有块
+- **Partial Piece 优先**：已经开始下载的 piece 优先完成，减少内存碎片
+- **动态 Pipeline**：根据 peer 的下载速率实时调整未完成请求数，而非固定值
+
+---
+
+## 2. Piece Picker — 全局 Block 管理器
+
+`piecePicker`（位于 `internal/core/piece_picker.go`）是下载调度的核心数据结构。它集中管理所有 block 的状态。
+
+### 2.1 数据结构
+
+```go
+type piecePicker struct {
+    mu sync.Mutex
+
+    numPieces      uint32        // 总 piece 数
+    blocksPerPiece uint32        // 每个 piece 的 block 数（通常 = pieceLength / 16KB）
+    blockSize      int64         // block 大小（固定 16KB）
+
+    // ── 可用性 ──
+    availability []uint16        // availability[i] = 拥有 piece i 的 peer 数
+
+    // ── 优先级排序 ──
+    pieces          []uint32     // 按优先级排序的 piece 索引（仅含未开始下载的 piece）
+    piecePriorities []uint32     // 每个 piece 的优先级分数
+    dirty           bool         // 优先级数组是否需要重建
+
+    // ── 正在下载的 piece ──
+    downloadingPieces []downloadingPiece  // 按 index 排序，支持 O(log n) 查找
+
+    // ── Block 状态 ──
+    blockInfos []blockInfo       // 扁平数组，以 piece 为单位分组
+                                 // blockInfos[pieceInfoIdx + i] 对应 piece 的第 i 个 block
+
+    // ── 统计 ──
+    downloadQueueSize int        // 所有 peer 的总未完成请求数
+    numWantLeft       int        // 未分配但想要的 piece 数
+}
+```
+
+### 2.2 可用性（Availability）
+
+每个 piece 维护一个引用计数，表示当前连接的 peer 中有多少个拥有该 piece：
+
+```
+availability[pieceIndex] = count(peers that have this piece in their bitfield)
+```
+
+**何时增加**（`incRefcount`）：
+- Peer 发送 `Bitfield` 消息 → 对该 peer 拥有的所有 piece 各 +1
+- Peer 发送 `Have` 消息 → 对该 piece +1
+- Peer 发送 `HaveAll` 消息 → 对所有 piece +1
+
+**何时减少**（`decRefcount`）：
+- Peer 发送 `DontHave` 扩展消息 → 对该 piece -1
+- Peer 发送 `HaveAll`（需要先减少旧 bitfield 的计数，再增加新计数）
+- Peer 断开连接 → 对该 peer 拥有的所有 piece 各 -1
+
+---
+
+## 3. Block 状态机
+
+每个 block 处于以下四种状态之一：
+
+```
+                    markAsRequesting()
+  stateNone ────────────────────────────► stateRequested
+     ▲                                        │
+     │   abortDownload()                      │  markAsWriting()
+     │   resetPiece()                         │  (数据到达)
+     │   (hash 校验失败)                        │
+     │                                        ▼
+     │                                  stateWriting
+     │                                        │
+     │                                        │  markAsFinished()
+     │                                        │  (写入磁盘完成)
+     │                                        ▼
+     └──────────────────────────────── stateFinished
+             weHave()                   
+             (hash 校验通过，整个 piece 标记完成)
+```
+
+每个 block 额外跟踪：
+- `peer *Peer`：当前请求该 block 的 peer（`stateRequested` 时有效）
+- `numPeers uint16`：有多少个 peer 将该 block 加入了自己的队列（用于 endgame 去重）
+
+---
+
+## 4. Piece 优先级系统
+
+### 4.1 优先级公式
+
+```
+priority = (availability + 1) × priorityFactor
+         = (availability + 1) × 3
+```
+
+| availability | priority | 含义 |
+|---|---|---|
+| 0 | 3 | 最稀有 —— 只有一个 peer 有 |
+| 1 | 6 | 稀有 |
+| 2 | 9 | 一般 |
+| 10 | 33 | 常见 |
+| N | (N+1)×3 | 越常见优先级越低 |
+
+**优先级越高 → 越优先被选中下载**。
+
+稀有度优先（rarest-first）确保 swarm 中的稀有 piece 被优先传播，防止唯一的拥有者离开后 piece 不可获取。
+
+### 4.2 优先级重建
+
+当 `dirty == true` 时，`rebuildPriorities()` 被调用：
+
+1. **过滤**：排除已经在下载中的 piece（至少一个 block 处于 `stateRequested` 或 `stateWriting`）
+2. **排序**：剩余 piece 按 `piecePriorities` 降序排列，同优先级按 index 升序
+3. **更新**：`numWantLeft = len(available)` — 记录还有多少 piece 可分配
+
+标记 `dirty = true` 的时机：
+- `incRefcount()` / `decRefcount()` 使 availability 跨越 0↔1 边界
+- `addDownloadingPiece()` 或 `removeDownloadingPiece()`
+- `weHave()` — piece 已完成下载
+- `resetPiece()` — hash 校验失败，重置
+
+---
+
+## 5. Pick Pieces — Block 选择算法
+
+`pickPieces()` 是 Block 选择的入口。它接收一个 peer 的信息，返回两组 block：
+
+- **freeBlocks**：未被任何 peer 请求的 block（`stateNone`）
+- **busyBlocks**：已被其他 peer 请求的 block（`stateRequested`），仅在 endgame 使用
+
+### 5.1 输入参数
+
+| 参数 | 类型 | 说明 |
+|---|---|---|
+| `bitfield` | `*bm.Bitmap` | Peer 拥有的 piece 集合 |
+| `choked` | `bool` | Peer 是否 choked 了我们 |
+| `allowedFast` | `*bm.Bitmap` | Allowed-Fast piece 集合（仅 choked 时有效） |
+| `numBlocks` | `int` | 期望挑选的 block 数量 |
+| `preferContiguous` | `int` | >0 时优先整 piece 下载（当前未启用） |
+| `suggestedPieces` | `[]uint32` | Peer 建议的 piece 列表 |
+| `info` | `meta.Info` | Torrent 元数据 |
+
+### 5.2 三阶段选择
+
+```
+pickPieces(bitfield, choked, allowFast, numBlocks, ...)
+
+Phase 1: Partial Pieces (正在下载中的 piece)
+  │
+  ├─ 遍历 downloadingPieces[]
+  ├─ 过滤：peer 有这些 piece、未被 choked（或 allowed fast）
+  ├─ 对每个 piece 统计 stateNone 的 block 数
+  ├─ 按 piece 优先级（= availability 稀有度）排序
+  ├─ 提取 stateNone 的 block → freeBlocks
+  └─ 收集 stateRequested 的 block → busyBlocks
+
+Phase 2: Suggested Pieces (peer 建议的 piece)
+  │
+  ├─ 遍历 suggestedPieces[]
+  ├─ 对每个 piece 调用 pickBlocksFromPiece()
+  └─ 提取所有 stateNone block → freeBlocks
+
+Phase 3: Open Pieces (尚未开始下载的 piece)
+  │
+  ├─ 遍历 openPieces（按 priority 降序）
+  ├─ 跳过已在 freeBlocks 中的 piece
+  ├─ 对每个 piece 调用 pickBlocksFromPiece()
+  └─ 提取所有 stateNone 的 block → freeBlocks
+```
+
+### 5.3 pickBlocksFromPiece 细节
+
+```
+pickBlocksFromPiece(pieceIndex, info, &numBlocks, result):
+  for i in 0 .. blocksInPiece:
+    if blockInfos[idx+i].state == stateNone:
+      result.freeBlocks.append(pieceBlock{pieceIndex, i})
+      numBlocks--
+      if numBlocks <= 0: return
+    else if blockInfos[idx+i].state == stateRequested:
+      result.busyBlocks.append(pieceBlock{pieceIndex, i})
+```
+
+---
+
+## 6. requestABlock — Per-Peer Block 分配
+
+`requestABlock()`（位于 `internal/core/d_download.go`）是每个 peer 的调度入口。它决定"为这个 peer 分配哪些 block"。
+
+### 6.1 算法流程
+
+```
+requestABlock(peer):
+
+  1. 前置检查
+     ├─ 我们已经是 seed → return
+     ├─ peer 已关闭或正在断开 → return
+     ├─ 不在 Downloading 状态 → return
+     └─ peer.noDownload() → return
+
+  2. 计算 Pipeline 大小
+     desiredQueueSize = peer.updateDesiredQueueSize()
+     capacity = desiredQueueSize - peer.myRequests.Size() - len(peer.requestQueue)
+     if capacity <= 0: return
+
+  3. Endgame 判断
+     remaining = SelectedSize - completed
+     if remaining <= 100 MiB: endGameMode = true
+
+  4. 调用 Piece Picker
+     result = picker.pickPieces(peer.Bitmap, choked, allowFast, capacity, ...)
+
+  5. 处理 freeBlocks（逐个）
+     for each fb in result.freeBlocks:
+       if piece 已完成 or block 已写入磁盘 → skip
+       if block 已在 peer 队列中 → skip
+       picker.markAsRequesting(fb, peer)
+       picker.addDownloadingPiece(fb.pieceIndex)
+       peer.blockRequests <- fb
+
+  6. 判断是否进入 Endgame
+     if capacity 已用完:
+       peer.setEndgame(false)  ← 该 peer 不在 endgame
+       return
+     if 未 choked:
+       peer.setEndgame(true)   ← 该 peer 进入 endgame
+       endGameMode = true
+
+  7. 处理 busyBlocks（仅 endgame + 无 outstanding request）
+     if !endGameMode or peer.myRequests.Size() + len(peer.requestQueue) > 0:
+       return  ← 避免所有 peer 抢同一 block
+     for each bb in result.busyBlocks:
+       ...同样的过滤...
+       picker.markAsRequesting(bb, peer)
+       peer.blockRequests <- bb
+```
+
+### 6.2 关键设计决策
+
+**为什么每个 peer 有独立的 `requestQueue`？**
+
+在 libtorrent 中，block 被 picker 选中后先进入 `m_request_queue`，然后在 `send_block_requests_impl()` 中批量发送。这样做的好处是：
+- 调度（picker）和发送（I/O）解耦
+- 多个 block 可以合并为更大的连续请求（`prefer_contiguous_blocks`）
+- 当 peer 被 choke 时可以回退
+
+**为什么 freeBlock 用尽后才进入 endgame？**
+
+Endgame 模式允许重复请求已被其他 peer 请求的 block（busy block）。如果在 free block 充足时就进入 endgame，会导致大量重复请求，浪费带宽。只有当 free block 用尽时，说明该 peer 能贡献的 block 已经全部被分配，此时允许请求 busy block 来提高最后阶段的完成速度。
+
+---
+
+## 7. Pipeline 动态调整
+
+`updateDesiredQueueSize()` 位于 `p.go`，每个 peer 独立计算。
+
+### 7.1 公式
+
+```
+desiredQueueSize = queueTime × downloadRate / blockSize
+
+其中:
+  queueTime  = 3 秒         (想要维护的 pipeline 时间)
+  blockSize  = 16 KB        (每个 block 的大小)
+  downloadRate = 该 peer 当前的下载速率 (bytes/sec)
+```
+
+### 7.2 Clamping
+
+```
+desiredQueueSize = clamp(
+    rate_based_value,
+    min = minRequestQueue = 2,      // 至少保持 2 个未完成请求
+    max = min(
+        maxRequestQueue = 250,      // 全局上限
+        peer.QueueLimit              // peer 在扩展握手中通告的队列限制
+    )
+)
+```
+
+### 7.3 特殊情况
+
+| 情况 | desiredQueueSize | 说明 |
+|---|---|---|
+| `snubbed == true` | 1 | 被 snub 的 peer 降到最小 pipeline |
+| `endgame == true` | 1 | Endgame 中每个 peer 只保持 1 个请求 |
+| `downloadRate ≈ 0` | 2 | 新连接或无流量，使用最小值 |
+| `downloadRate = 1 MB/s` | ≈ 192 | `3 × 1,048,576 / 16,384` |
+
+---
+
+## 8. Endgame 模式
+
+### 8.1 触发条件
+
+有两种条件触发 endgame：
+
+1. **全局触发**：剩余待下载字节 ≤ 100 MiB
+   ```go
+   if d.SelectedSize() - d.completed.Load() <= 100 MiB {
+       d.endGameMode.Store(true)
+   }
+   ```
+
+2. **Per-peer 触发**：当 `requestABlock()` 无法为该 peer 找到足够的 free block 时
+   ```go
+   if numRequests > 0 && !p.peerChoking.Load() {
+       p.setEndgame(true)
+       d.endGameMode.Store(true)
+   }
+   ```
+
+### 8.2 Endgame 中的行为
+
+- **Busy block**：允许请求已被其他 peer 请求的 block（`stateRequested`）
+- **单请求限制**：每个 peer 只保持 1 个 outstanding request（`desiredQueueSize = 1`）
+- **去重**：通过 picker 的 `numPeers` 计数字段跟踪每个 block 被多少个 peer 请求
+
+### 8.3 Strict Endgame
+
+当前采用简化版 strict endgame：只有在以下条件**同时满足**时才允许 busy block：
+1. 全局 `endGameMode == true`
+2. 该 peer 当前没有 outstanding request（`myRequests.Size() + len(requestQueue) == 0`）
+
+这防止了以下场景：
+- 5 个 peer 同时下载最后 1 个 piece 的 1 个 block → 4 个重复请求被浪费
+
+### 8.4 退出 Endgame
+
+当 peer 找到足够的 free block 时，退出 endgame：
+```go
+if numRequests <= 0 {
+    p.setEndgame(false)  // 该 peer 不再在 endgame 中
+}
+```
+
+全局 endgame 模式不自动退出 —— 一旦剩余 ≤ 100 MiB，始终保持在 endgame。
+
+---
+
+## 9. Block 发送与排队
+
+### 9.1 数据流
+
+```
+requestABlock() 
+    │
+    ├─ picker.markAsRequesting(block, peer)
+    └─ peer.blockRequests ← pieceBlock          ← 容量 50 的 channel
+        │
+        ▼
+    ourRequestHandle()
+        │
+        ├─ block 追加到 peer.requestQueue[]      ← 无界 slice
+        └─ sendBlockRequests()
+            │
+            ├─ 检查 peer 的 QueueLimit / 2      ← 避免淹没慢 peer
+            ├─ 检查 peer 是否 choked             ← choked 时只发 allowed-fast
+            └─ p.Request(chunk)                 ← 发送 BT wire request
+                │
+                └─ myRequests.Store(chunk, time.Now())
+```
+
+### 9.2 sendBlockRequests 逻辑
+
+```go
+func (p *Peer) sendBlockRequests() {
+    desiredSize := p.updateDesiredQueueSize()
+
+    for {
+        if p.myRequests.Size() >= desiredSize {
+            return  // pipeline 已满
+        }
+        if len(p.requestQueue) == 0 {
+            return  // 没有待发送的 block
+        }
+
+        block := p.requestQueue[0]
+        p.requestQueue = p.requestQueue[1:]
+
+        chunk := pieceChunk(p.d.info, block.pieceIndex, block.blockIndex)
+
+        // Choke 检查
+        if p.peerChoking.Load() && !p.allowFast.Contains(block.pieceIndex) {
+            p.d.picker.abortDownload(block.pieceIndex, block.blockIndex)
+            continue
+        }
+
+        // Queue limit 检查（使用 peer 通告限制的一半）
+        if p.myRequests.Size() >= int(p.QueueLimit.Load()) / 2 {
+            // 放回队列头部，等待下次尝试
+            p.requestQueue = append([]pieceBlock{block}, p.requestQueue...)
+            return
+        }
+
+        p.Request(chunk)
+    }
+}
+```
+
+### 9.3 流量控制
+
+| 限流点 | 说明 |
+|---|---|
+| `desiredQueueSize` | 基于下载速率的动态 pipeline |
+| `QueueLimit / 2` | 不超过 peer 通告最大队列的一半 |
+| `peerChoking` | Choked 时只发 allowed-fast piece 的 block |
+| `blockRequests` channel 容量 50 | 防止调度器超前产生过多 block（回退时 `abortDownload`） |
+
+---
+
+## 10. Peer 生命周期集成
+
+### 10.1 连接建立
+
+```
+Peer 连接建立
+  │
+  ├─ Bitfield/Hav​​e 到达 → picker.incRefcount(pieceIndex)
+  │   ├─ availability[pieceIndex]++
+  │   └─ 如果从 0 变为 1 → dirty = true (触发优先级重建)
+  │
+  └─ Unchoke 到达
+      ├─ scheduleRequestSignal → backgroundReqScheduler
+      └─ requestABlock(peer) → 分配 block
+```
+
+### 10.2 Block 请求超时（Snub）
+
+```
+checkRequestTimeouts() 每 5 秒运行
+  │
+  ├─ 检查 myRequests 中最老的请求时间
+  ├─ 如果超过 30 秒 → timedOut
+  │
+  └─ snub 处理:
+      ├─ snubbed = true
+      ├─ 遍历 myRequests:
+      │   └─ picker.abortDownload(pieceIndex, blockIndex)
+      ├─ 清空 requestQueue
+      └─ scheduleRequestSignal (触发其他 peer 重新抓取)
+```
+
+Snubbed peer 的 `desiredQueueSize` 变为 1。当再次收到该 peer 的数据时，snub 自动清除。
+
+### 10.3 Peer 断开连接
+
+```
+peer.close()
+  │
+  ├─ disconnecting = true
+  │
+  ├─ 遍历 Bitmap:
+  │   └─ picker.decRefcount(pieceIndex) — 降低可用性
+  │
+  ├─ 遍历 myRequests:
+  │   └─ picker.abortDownload(pieceIndex, blockIndex) — 释放 block
+  │
+  └─ 如果 peer 是 outgoing 且有 hadTransfer:
+      └─ 立即重新加入 pendingPeers (无 backoff)
+```
+
+---
+
+## 11. 数据接收与写入
+
+### 11.1 数据接收
+
+```
+proto.Piece 消息到达
+  │
+  ├─ resIsValid:
+  │   └─ myRequests.LoadAndDelete(chunk) → 记录 RTT
+  │
+  ├─ 如果是 snubbed peer → 解除 snub
+  │
+  └─ d.ResChan ← response
+      │
+      ▼
+  handleRes(res):
+      │
+      ├─ picker.markAsWriting(pieceIndex, blockIndex)
+      │   └─ stateNone/stateRequested → stateWriting
+      │
+      ├─ 加入 chunkHeap
+      │   ├─ heap size < 1000 → 累积，检查 piece 是否完整
+      │   └─ heap size ≥ 1000 → 弹出连续 chunk 序列（≤ 10 个），
+      │       写入磁盘，markAsFinished()
+      │
+      └─ checkPieceBitmapDone(pieceIndex):
+          └─ 所有 chunk done → checkPiece()
+```
+
+### 11.2 Piece 校验
+
+```
+checkPiece(pieceIndex):
+  │
+  ├─ 流式 SHA-1 hash 校验
+  │
+  ├─ 失败 → picker.resetPiece(pieceIndex)
+  │   └─ 所有 block 回到 stateNone → 可被其他 peer 重新请求
+  │   └─ corrupted[pieceIndex]++
+  │
+  └─ 通过 → picker.weHave(pieceIndex)
+      └─ 所有 block → stateFinished
+      └─ dirty = true (触发优先级重建)
+      └─ have(pieceIndex) → 通知所有 peer
+```
+
+### 11.3 Endgame 写入（handleResEndgame）
+
+在 endgame 模式中，chunk 不合并写入，而是**每个 chunk 立即写入**：
+- 不等待完整的 piece 数据累积
+- 每收到一个 chunk 就写盘 + markAsFinished
+- 当 piece 的 chunk bitmap 完整时立即 hash 校验
+
+---
+
+## 12. 完整数据流
+
+```
+   Tracker /
+   DHT / PEX
+      │
+      ├─ 新 peer 加入
+      │   └─ connectToPeers() + pendingPeersSignal
+      │
+      ▼
+┌──────────────────────────────────────────────────────────┐
+│                    Peer 连接生命周期                       │
+│                                                          │
+│  Connect → Handshake → Bitfield → picker.incRefcount()  │
+│     │                                                    │
+│     ├─ Unchoke → scheduleRequestSignal                  │
+│     ├─ Have    → picker.incRefcount()                    │
+│     │          → scheduleRequestSignal                   │
+│     └─ Piece   → responseCond.Signal()                   │
+│                → ResChan → handleRes()                   │
+│                                                          │
+│  Close → picker.decRefcount() + abortDownload()         │
+└──────────────────────────────────────────────────────────┘
+
+                    scheduleRequestSignal
+                           │
+                    ┌──────▼──────┐
+                    │ Scheduler   │  ← backgroundReqScheduler
+                    │ 遍历 peers  │     定时器 5s + 信号触发
+                    └──────┬──────┘
+                           │
+              ┌────────────┼────────────┐
+              ▼            ▼            ▼
+        requestABlock  requestABlock  requestABlock
+        (peer A)       (peer B)       (peer C)
+              │            │            │
+              └────────────┼────────────┘
+                           │
+                    ┌──────▼──────┐
+                    │ Pick Pieces │  ← picker.pickPieces()
+                    │             │
+                    │ Phase 1:    │
+                    │  Partial    │
+                    │ Phase 2:    │
+                    │  Suggested  │
+                    │ Phase 3:    │
+                    │  Rarest-    │
+                    │  First      │
+                    └──────┬──────┘
+                           │
+                freeBlocks │ busyBlocks
+                           │ (endgame)
+                           ▼
+                  ┌────────────────┐
+                  │ markAsRequesting│ ← picker 更新 block 状态
+                  │ blockRequests  │ ← peer channel
+                  └───────┬────────┘
+                          │
+                   ┌──────▼──────┐
+                   │ sendBlock   │ ← peer.sendBlockRequests()
+                   │ Requests    │    requestQueue → wire
+                   └──────┬──────┘
+                          │
+                   ┌──────▼──────┐
+                   │ Wire Request│ ← proto.Request 发送
+                   │ myRequests  │    记录时间戳
+                   └──────┬──────┘
+                          │
+          ┌───────────────┼───────────────┐
+          ▼               ▼               ▼
+     ┌─────────┐   ┌──────────┐   ┌──────────┐
+     │ Timeout │   │ Reject   │   │  Piece   │
+     │ → snub  │   │ → 重分配  │   │  Response│
+     └─────────┘   └──────────┘   └────┬─────┘
+                                       │
+                                ┌──────▼──────┐
+                                │ markAsWriting│ ← picker
+                                │ 写入磁盘      │
+                                │ markAsFinished│
+                                └──────┬──────┘
+                                       │
+                                ┌──────▼──────┐
+                                │ SHA-1 Hash  │
+                                │ 校验         │
+                                └──┬──────┬───┘
+                                   │      │
+                              通过  │      │  失败
+                                   ▼      ▼
+                           ┌──────┐  ┌──────────┐
+                           │weHave│  │resetPiece│
+                           │      │  │corrupted │
+                           └──┬───┘  └──────────┘
+                              │
+                      ┌───────▼───────┐
+                      │ checkDone()   │
+                      │ → Seeding     │
+                      └───────────────┘
+```
+
+---
+
+## 参考
+
+- [libtorrent piece_picker.hpp](https://github.com/arvidn/libtorrent/blob/master/include/libtorrent/piece_picker.hpp)
+- [libtorrent request_blocks.cpp](https://github.com/arvidn/libtorrent/blob/master/src/request_blocks.cpp)
+- [libtorrent peer_connection.cpp — send_block_requests](https://github.com/arvidn/libtorrent/blob/master/src/peer_connection.cpp)
+- [Arvid's Blog: Block request time-outs](http://blog.libtorrent.org/2011/11/block-request-time-outs/)

--- a/docs/peer-reconnection.md
+++ b/docs/peer-reconnection.md
@@ -1,0 +1,293 @@
+# Neptune 对等体重连逻辑分析
+
+本文档对比 Neptune 和 libtorrent 的 peer 重连算法，分析当前问题根因。
+
+---
+
+## 1. 用户观察到的现象
+
+> "慢速下载一段时间后，peer 断开了之后没有能重连，然后过段时间（可能是 announce）了，又开始重新满速下载"
+
+**症状**：peer 断开 → 长时间无新连接 → tracker announce → 恢复满速。
+**间隔**：通常 30 分钟（tracker 标准 announce interval）。
+
+---
+
+## 2. 当前 Neptune 重连架构
+
+### 2.1 数据流
+
+```
+Peer 来源:
+  Tracker announce ──→ OnPeers callback ──→ pendingPeers.Push()
+  PEX 消息         ──→ pexAdd channel    ──→ pendingPeers.Push()
+  Disconnect       ──→ peer.close()      ──→ pendingPeers.Push()
+
+        │
+        ▼
+  pendingPeers (优先级堆，按 BEP40 排序)
+        │
+        ▼
+  connectToPeers()   ← 10s ticker + pendingPeersSignal 触发
+        │
+        ├─ connHistory LRU 检查 backoff
+        ├─ peers.Load 检查是否已连接
+        ├─ sem.TryAcquire 检查全局连接数
+        └─ global.Dial() → 成功 → NewOutgoingPeer
+                          → 失败 → 记录 reason + backoff
+```
+
+### 2.2 Backoff 策略
+
+| 断开原因 | Backoff | 触发条件 |
+|---|---|---|
+| `connReasonNone` | 0 | 首次尝试 |
+| `connReasonTimeout` | 30s | dial timeout / read deadline |
+| `connReasonRefused` | 10min | ECONNREFUSED |
+| `connReasonEOF` | 30s | 对端主动关闭 |
+| `connReasonError` | 1min | 其他网络错误 |
+| `hadTrans == true` | 0（立即重试）| peer 曾传输过数据 |
+
+### 2.3 重连触发时机
+
+1. **定时器**：每 10s `reconnectTicker` 触发 → `connectToPeers()`
+2. **信号**：`pendingPeersSignal`（新 peer 到达 / peer 断开）
+3. **Tracker announce**：由 tracker 控制，通常 30min
+
+---
+
+## 3. Libtorrent 重连架构（对比基准）
+
+### 3.1 架构差异
+
+```
+                    libtorrent                          Neptune
+              ┌──────────────────┐              ┌──────────────────┐
+Peer 存储      │  peer_list       │              │  pendingPeers    │
+              │  持久化，全量保留  │              │  (堆，瞬时快照)   │
+              │  + candidate_cache │              │  + connHistory   │
+              │  (预计算候选)      │              │  (LRU 256, TTL)  │
+              └──────────────────┘              └──────────────────┘
+Peer 生命周期  │  永久保留          │              │  堆中 pop 后丢失  │
+              │  断连不删除         │              │  重连失败后堆中   │
+              │                    │              │  保留但可能 LRU   │
+              │                    │              │  驱逐             │
+              └──────────────────┘              └──────────────────┘
+重连触发      │  on_tick (1s)      │              │  ticker (10s)    │
+              │  + bandwidth       │              │  + signal        │
+              │  + 每 torrent      │              │                  │
+              │    逐个尝试连接     │              │                  │
+              └──────────────────┘              └──────────────────┘
+Peer 发现     │  Tracker + DHT     │              │  Tracker + PEX   │
+              │  + LSD + PEX       │              │  (DHT 是 stub)   │
+              └──────────────────┘              └──────────────────┘
+Peer 轮换     │  optimistic        │              │  无               │
+              │  disconnect        │              │                  │
+              │  (peer_turnover)   │              │                  │
+              └──────────────────┘              └──────────────────┘
+```
+
+### 3.2 Libtorrent 重连候选判定
+
+```cpp
+bool is_connect_candidate(torrent_peer const& p) const {
+    if (p.connection          // 已有连接 → no
+        || p.banned           // 被 ban → no
+        || p.web_seed         // web seed → no
+        || !p.connectable     // 无 listen port → no
+        || (p.seed && m_finished)  // 已完成 + 对方是 seed → no
+        || p.failcount >= m_max_failcount)  // 失败太多次 → no
+        return false;
+    return true;
+}
+```
+
+关键：**failcount 默认可达 3 次**（`m_max_failcount = 3`）。即使失败 3 次，peer 仍保留在 `peer_list` 中，当 tracker 再次返回时会 `update_peer()` 重置 `failcount`。
+
+### 3.3 Libtorrent 重连间隔
+
+```cpp
+// find_connect_candidates 中的间隔检查：
+if (pe.last_connected
+    && session_time - pe.last_connected <
+    (pe.failcount + 1) * state->min_reconnect_time)
+    continue;
+
+// min_reconnect_time 默认 60s
+// failcount=0 → 60s
+// failcount=1 → 120s
+// failcount=2 → 180s
+```
+
+同时在 `connection_closed` 中：
+```cpp
+if (c.failed()) {
+    if (p->failcount < 31) ++p->failcount;  // failcount 增加
+}
+
+if (is_connect_candidate(*p))
+    update_connect_candidates(1);  // 立刻重新加入候选集
+
+if (!c.fast_reconnect())
+    p->last_connected = session_time;  // 更新时间戳
+else
+    // fast_reconnect: 不更新时间戳 → 可立即重连
+```
+
+### 3.4 Libtorrent 的 Peer 轮换
+
+```cpp
+// session_impl::on_tick 中的轮换逻辑：
+int peers_to_disconnect = min(max(
+    t->num_peers() * peer_turnover / 100, 1),
+    t->num_connect_candidates());
+t->disconnect_peers(peers_to_disconnect, errors::optimistic_disconnect);
+```
+
+默认 `peer_turnover = 1/50`（2%），即定期断开 2% 的连接来轮换 peer，发现更快的连接。
+
+---
+
+## 4. 问题根因分析
+
+### 4.1 问题 #1：Peer 池枯竭（核心问题）
+
+**Neptune 的 `pendingPeers` 是一个瞬时堆**，不是持久化存储。
+
+```
+时间线:
+  T=0     Tracker 返回 50 个 peer → pendingPeers 有 50 个
+  T=10s   connectToPeers() → 连接了 10 个
+  T=30s   慢速 peer 超时断开 → 第 1 个断开的放回 pendingPeers
+  T=35s   另一个断开 → 放回 pendingPeers
+  ...
+  T=5min  10 个 peer 都断开 → pendingPeers 还是这些 peer(可能就10个)
+          所有 peer 在经历 backoff（30s/1min/10min）
+          connectToPeers() 每次 pop 出来 → canRetry=true (跳过) → push 回去
+          没有新 peer 来源 → pendingPeers 里只有这些正在 backoff 的 peer
+  T=30min Tracker announce → 50 个新 peer → pendingPeers 重新填充 → 满速恢复！
+```
+
+**Libtorrent 如何避免**：
+- `peer_list` 永久保留所有已知 peer，不会因为"试完了"就丢失
+- DHT announce 每 20 分钟独立提供新 peer
+- LSD 每 5 分钟在局域网提供新 peer
+- PEX 持续交换 peer 信息
+- `optimistic_disconnect` 定期轮换连接，持续引入新 peer
+
+### 4.2 问题 #2：`hadTrans` 被覆盖（Bug）
+
+在 `connectToPeers()` 中：
+
+```go
+// d_conn.go:86 (修复前)
+tasks.Submit(func() {
+    ch := connHistory{lastTry: time.Now()}  // hadTrans 默认为 false！
+    d.connectionHistory.Add(pp.addrPort, ch) // 覆盖了之前的 hadTrans=true
+    ...
+})
+```
+
+**问题流程**：
+1. Peer 传输了数据 → `close()` 调用 `recordDisconnect()` → `hadTrans = true`
+2. Peer 被重新放入 `pendingPeers`
+3. `connectToPeers()` 尝试重连 → 创建新的 `connHistory{hadTrans: false}` → **覆盖**了 `hadTrans`
+4. 即使重连失败（例如 TCP timeout），`canRetry()` 检查到 `hadTrans == false` → 应用 30s backoff
+5. **应该的行为**：`hadTrans == true` → 立即重试，0 秒 backoff
+
+**已修复**：现在 `connectToPeers()` 会从旧的 `connHistory` 中保留 `hadTrans` 标志。
+
+### 4.3 问题 #3：无 DHT 导致 Peer 来源单一
+
+| Peer 来源 | libtorrent | Neptune | 间隔 |
+|---|---|---|---|
+| HTTP Tracker | ✅ | ✅ | 30min（tracker 控制） |
+| UDP Tracker | ✅ | ❌ | - |
+| DHT | ✅ | ❌ (stub) | 20min |
+| LSD | ✅ | ❌ | 5min |
+| PEX | ✅ | ✅ | 实时 |
+
+Neptune 只有 2 个 peer 来源：Tracker（30min）和 PEX（实时）。PEX 依赖于**已连接的 peer 相互交换**。但当所有 peer 都断开后，PEX 也无法获取新 peer。
+
+这就导致了"断开后只能等 tracker announce"的现象。
+
+### 4.4 问题 #4：Sem 满时的行为
+
+```go
+if !d.c.sem.TryAcquire(1) {
+    retryLater = append(retryLater, pp)
+    break  // ← 直接跳出循环，剩余 peers 留在堆里
+}
+```
+
+当连接数达到上限时：
+- 剩余 peer 被 push 回堆
+- 但之前已修复：现在会发送 `pendingPeersSignal` 触发更快重试
+- 但如果连接数持续满载，这些 peer 永远无法被尝试
+
+**Libtorrent 的做法**：有 `peer_turnover` 机制，定期断开旧连接释放 slot。
+
+---
+
+## 5. 修复建议
+
+### 5.1 短期（低风险）
+
+1. ~~**修复 `hadTrans` 覆盖 bug**~~ ✅ 已完成
+2. ~~**Sem 满时立即发 signal**~~ ✅ 已完成
+3. **降低 `connBackoffRefused`**：10min → 2min。Refused 可能只是 peer 临时重启，10min 太长
+4. **降低 `connBackoffTimeout`**：30s → 10s。超时可能只是临时网络波动
+5. **增加 backoff 衰减**：连续失败时递增 backoff，而非固定值
+
+### 5.2 中期（结构改进）
+
+6. **实现持久化 Peer 列表**：
+
+```go
+type persistentPeer struct {
+    addrPort      netip.AddrPort
+    source        peerSourceFlags  // tracker, pex, dht, incoming
+    failcount     uint8
+    lastConnected int64
+    connectable   bool
+    seed          bool
+}
+```
+
+- 类似 libtorrent 的 `peer_list` + `torrent_peer`
+- Peer 断连后不删除，保留在列表中
+- 用 `candidateCache` 预计算可连接的 peer
+- tracker announce 返回已有 peer 时更新（而非重复添加）
+
+7. **实现 DHT**：DHT stub → 完整实现，提供独立的 peer 来源
+
+8. **Peer 轮换（Turnover）**：
+
+```go
+// 每 5 分钟随机断开 1 个慢速 peer，腾出 slot 连接新 peer
+func (d *Download) peerTurnover() {
+    // 找到最慢的 peer 断开
+    // 触发 connectToPeers 连接候选
+}
+```
+
+### 5.3 长期
+
+9. **实现 LSD（Local Service Discovery）**：局域网 peer 发现
+10. **实现 UDP Tracker**：更高效的 tracker 协议
+
+---
+
+## 6. 当前 vs libtorrent 关键指标对比
+
+| 指标 | Neptune | libtorrent |
+|---|---|---|
+| Peer 持久化 | ❌ 瞬时堆 + LRU 256 | ✅ peer_list（永久） |
+| Peer 候选缓存 | ❌ | ✅ candidate_cache |
+| 重连间隔 | 固定 10s ticker | 1s tick + bandwidth 驱动 |
+| Backoff 策略 | 固定时间（30s/1min/10min） | failcount × min_reconnect_time（60s/120s/180s） |
+| hadTrans 保护 | 已修复 ✅ | fast_reconnect 标志 |
+| Peer 轮换 | ❌ | ✅ optimistic_disconnect (2%/round) |
+| 多源 peer 发现 | Tracker + PEX | Tracker + DHT + LSD + PEX |
+| 连接失败上限 | 无限重试 | max_failcount = 3（后排除） |
+| Peer 恢复 | 仅 Tracker 重新返回时 | 永久保留，announce 时 update |

--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -494,7 +494,6 @@ func (c *Client) DebugHandlers() http.Handler {
 		)
 
 		d.corruptedPiecesMu.Lock()
-		d.piecePeerMu.Lock()
 		if len(d.corruptedPieces) > 0 {
 			fmt.Fprintf(w, "failing pieces: %d\n", len(d.corruptedPieces))
 			type kv struct {
@@ -504,18 +503,14 @@ func (c *Client) DebugHandlers() http.Handler {
 			}
 			var top []kv
 			for idx, count := range d.corruptedPieces {
-				blockedBy := 0
-				if peers, ok := d.piecePeerAssignments[idx]; ok {
-					blockedBy = len(peers)
-				}
+				blockedBy := d.picker.countBusyBlocks(idx, d.info)
 				top = append(top, kv{idx, count, blockedBy})
 			}
 			slices.SortFunc(top, func(a, b kv) int { return b.count - a.count })
 			for i := 0; i < len(top) && i < 10; i++ {
-				fmt.Fprintf(w, "  piece %d: %d failures, %d peers blocked\n", top[i].idx, top[i].count, top[i].blockedBy)
+				fmt.Fprintf(w, "  piece %d: %d failures, %d busy blocks\n", top[i].idx, top[i].count, top[i].blockedBy)
 			}
 		}
-		d.piecePeerMu.Unlock()
 		d.corruptedPiecesMu.Unlock()
 
 		debugPrintTrackers(w, d)
@@ -577,7 +572,7 @@ func debugPrintPeers(w io.Writer, d *Download) {
 			humanize.IBytes(uint64(p.pieceDownloadRate.Status().CurRate)) + "/s",
 			humanize.IBytes(uint64(p.pieceUploadRate.Status().CurRate)) + "/s",
 			p.myRequests.Size(),
-			len(p.ourPieceRequests),
+			len(p.blockRequests),
 			*p.UserAgent.Load(),
 			fmt.Sprintf("%6.1f %%", float64(p.Bitmap.Count())/float64(d.info.NumPieces)*100),
 			p.peerChoking.Load(),
@@ -643,16 +638,17 @@ func debugPrintFiles(w io.Writer, d *Download) {
 }
 
 func debugPrintPendingPeers(w io.Writer, d *Download) {
-	d.pendingPeersMutex.Lock()
-	defer d.pendingPeersMutex.Unlock()
-
 	t := table.NewWriter()
 	t.AppendHeader(table.Row{colAddress})
 	t.SortBy([]table.SortBy{{Name: colAddress}})
 
-	for _, item := range d.pendingPeers.Data {
-		t.AppendRow(table.Row{item.addrPort.String()})
+	d.peerList.mu.Lock()
+	for _, pp := range d.peerList.peers {
+		if pp.connection == nil {
+			t.AppendRow(table.Row{pp.addrPort.String()})
+		}
 	}
+	d.peerList.mu.Unlock()
 
 	_, _ = io.WriteString(w, t.Render())
 	_, _ = fmt.Fprintln(w)

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -12,12 +12,10 @@ import (
 	"sync"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/kelindar/bitmap"
 	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	"github.com/samber/lo"
 	"go.uber.org/atomic"
 
 	"neptune/internal/core/tracker"
@@ -120,30 +118,25 @@ type Download struct {
 	downloadLimiter        *ratelimit.Limiter
 	uploadLimiter          *ratelimit.Limiter
 	peers                  *xsync.Map[netip.AddrPort, *Peer]
-	connectionHistory      *lru.Cache[netip.AddrPort, connHistory]
+	peerList               *peerList // persistent peer list (libtorrent-style)
 	bm                     *bm.Bitmap
-	pieceInFlight          *bm.Bitmap // pieces currently assigned to a peer, matching libtorrent's untouched_bitfield
+	picker                 *piecePicker // global block-level piece picker (libtorrent-style)
 	err                    atomic.Pointer[error]
-	pendingPeers           *heap.Heap[peerWithPriority]
 	cancel                 context.CancelFunc
 	scheduleRequestSignal  chan empty.Empty
-	rarePieceQueue         *heap.Heap[pieceRare]
 	scheduleResponseSignal chan empty.Empty
 	pendingPeersSignal     chan empty.Empty
 	buildNetworkPieces     chan empty.Empty
 	pexAdd                 chan []pexPeer
 	pexDrop                chan []netip.AddrPort
-	endgameRequested       *xsync.Map[proto.ChunkRequest, empty.Empty]
 	selectedFilesSet       map[int]struct{}
 	custom                 map[string]string
 	Trk                    *tracker.Trackers
 	corruptedPieces        map[uint32]int
-	piecePeerAssignments   map[uint32]map[uint32]struct{}
 	downloadDir            string
 	basePath               string
 	pieceInfo              pieceInfo
 	tags                   []string
-	pieceAvailability      []int32
 	chunk                  chunkState
 	info                   meta.Info
 	backgroundWg           sync.WaitGroup
@@ -155,7 +148,6 @@ type Download struct {
 	uploadAtStart          int64
 	downloadAtStart        int64
 	endGameMode            atomic.Bool
-	seq                    atomic.Bool
 	AddAt                  int64
 	peerLeechers           atomic.Int64
 	CompletedAt            atomic.Int64
@@ -164,27 +156,11 @@ type Download struct {
 	unchokeSlotIdx         int
 	unchokeCycleOffset     int // rotating offset for slot cycling
 	m                      sync.RWMutex
-	pendingPeersMutex      sync.Mutex
-	ratePieceMutex         sync.Mutex
 	corruptedPiecesMu      sync.Mutex
-	piecePeerMu            sync.Mutex
 	normalChunkLen         uint32
 	bitfieldSize           uint32
 	peerID                 proto.PeerID
 	private                bool
-}
-
-type pieceRare struct {
-	index    uint32
-	priority int32
-}
-
-func (p pieceRare) Less(o pieceRare) bool {
-	if p.priority == o.priority {
-		return p.index < o.index
-	}
-	// higher priority first
-	return p.priority > o.priority
 }
 
 type chunkState struct {
@@ -251,8 +227,6 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 
 		normalChunkLen: as.Uint32((info.PieceLength + defaultBlockSize - 1) / defaultBlockSize),
 
-		seq: *atomic.NewBool(true),
-
 		AddAt: time.Now().Unix(),
 
 		ResChan: make(chan *proto.ChunkResponse, 1),
@@ -262,21 +236,20 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 		pieceUploadRate:   flowrate.New(time.Second, time.Second),
 
 		peers:             xsync.NewMap[netip.AddrPort, *Peer](),
-		connectionHistory: lo.Must(lru.New[netip.AddrPort, connHistory](256)),
+		peerList:          newPeerList(nil), // d set below
+
+		picker: newPiecePicker(info),
 
 		chunk: chunkState{
 			done: make(bitmap.Bitmap, (int64(info.NumPieces)*((info.PieceLength+defaultBlockSize-1)/defaultBlockSize)+63)/64),
 		},
-		endgameRequested: xsync.NewMap[proto.ChunkRequest, empty.Empty](),
-		pendingPeers:     heap.New[peerWithPriority](),
 
 		// will use about 1mb per torrent, can be optimized later
 		pieceInfo: buildPieceInfos(info),
 
 		private: info.Private,
 
-		bm:            bm.New(info.NumPieces),
-		pieceInFlight: bm.New(info.NumPieces),
+		bm: bm.New(info.NumPieces),
 
 		bitfieldSize: (info.NumPieces + 7) / 8,
 
@@ -293,8 +266,7 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 		downloadLimiter: ratelimit.New(0),
 		uploadLimiter:   ratelimit.New(0),
 
-		corruptedPieces:      make(map[uint32]int),
-		piecePeerAssignments: make(map[uint32]map[uint32]struct{}),
+		corruptedPieces: make(map[uint32]int),
 	}
 
 	d.state.Store(uint32(Checking))
@@ -310,6 +282,8 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 	d.selectedSize.Store(d.computeSelectedSizeUnsafe())
 	d.buildSelectedPiecesBmUnsafe()
 
+	d.peerList.d = d
+
 	d.Trk = tracker.New(d.ctx, tracker.Config{
 		Key:             random.URLSafeStr(16),
 		HTTP:            c.http,
@@ -324,14 +298,9 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 		SelectedSize:    &d.selectedSize,
 		Debug:           c.debug,
 		OnPeers: func(peers []netip.AddrPort) {
-			d.pendingPeersMutex.Lock()
-			for _, p := range peers {
-				d.pendingPeers.Push(peerWithPriority{
-					addrPort: p,
-					priority: c.PeerPriority(p),
-				})
+			for _, addr := range peers {
+				d.peerList.addPeer(addr, peerSourceTracker, true)
 			}
-			d.pendingPeersMutex.Unlock()
 
 			select {
 			case d.pendingPeersSignal <- empty.Empty{}:

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -235,8 +235,8 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 		ioDownloadRate:    flowrate.New(time.Second, time.Second),
 		pieceUploadRate:   flowrate.New(time.Second, time.Second),
 
-		peers:             xsync.NewMap[netip.AddrPort, *Peer](),
-		peerList:          newPeerList(nil), // d set below
+		peers:    xsync.NewMap[netip.AddrPort, *Peer](),
+		peerList: newPeerList(nil), // d set below
 
 		picker: newPiecePicker(info),
 

--- a/internal/core/d_conn.go
+++ b/internal/core/d_conn.go
@@ -9,8 +9,6 @@ import (
 	"io"
 	"net"
 	"net/netip"
-	"os"
-	"syscall"
 	"time"
 
 	"neptune/internal/pkg/global"
@@ -18,163 +16,113 @@ import (
 	"neptune/internal/proto"
 )
 
-// connBackoff constants mirror libtorrent's strategy:
-//   - Timeout (transient network issue): short backoff, immediate if peer had transfers
-//   - Refused (peer likely offline): long backoff
-//   - Other errors: moderate backoff
 const (
-	connBackoffTimeout  = 30 * time.Second
-	connBackoffRefused  = 10 * time.Minute
-	connBackoffGeneric  = 1 * time.Minute
-	connBackoffTransfer = 0 // immediate retry if peer had active transfers
+	peerConnectTimeout = 10 * time.Second
 )
 
-type connDisconnectReason uint8
-
-const (
-	connReasonNone    connDisconnectReason = iota // never connected / no info
-	connReasonEOF                                 // peer closed cleanly (io.EOF)
-	connReasonTimeout                             // read deadline exceeded / TCP timeout
-	connReasonRefused                             // connection refused (only for outgoing)
-	connReasonError                               // other network error
-)
-
-type connHistory struct {
-	lastTry  time.Time
-	err      error
-	hadTrans bool
-	reason   connDisconnectReason
-}
-
-// AddConn add an incoming connection from client listener.
+// AddConn adds an incoming connection from the listener.
+// The peer entry is created in newPeer via addOrUpdateIncoming.
 func (d *Download) AddConn(addr netip.AddrPort, conn net.Conn, h proto.Handshake) {
-	d.connectionHistory.Add(addr, connHistory{})
 	NewIncomingPeer(conn, d, addr, h)
 }
 
-func (d *Download) connectToPeers() {
-	d.pendingPeersMutex.Lock()
-	defer d.pendingPeersMutex.Unlock()
+// connectToPeers tries to connect to candidate peers from the peer list.
+// Mirrors libtorrent's torrent::try_connect_peer loop.
+func (d *Download) connectToPeers(maxSlots int) int {
+	now := time.Now().Unix()
+	connected := 0
 
-	// Collect skipped peers (e.g., backoff not expired) so we can re-push
-	// them after the loop. This mirrors libtorrent's persistent available_list
-	// where peers stay until they can be retried.
-	var retryLater []peerWithPriority
-
-	for d.pendingPeers.Len() > 0 {
-		pp := d.pendingPeers.Pop()
-
-		if item, ok := d.connectionHistory.Get(pp.addrPort); ok {
-			if d.canRetry(item) {
-				retryLater = append(retryLater, pp)
-				continue
-			}
+	for connected < maxSlots {
+		// 1. Try immediate (hadTrans) candidates first — fast reconnect
+		candidate := d.peerList.immediateCandidate()
+		if candidate == nil {
+			candidate = d.peerList.connectOnePeer(now)
+		}
+		if candidate == nil {
+			break
 		}
 
-		if _, ok := d.peers.Load(pp.addrPort); ok {
+		// Check if already connected
+		if _, ok := d.peers.Load(candidate.addrPort); ok {
 			continue
 		}
 
+		// Check global connection limit
 		if !d.c.sem.TryAcquire(1) {
-			retryLater = append(retryLater, pp)
 			break
 		}
 		d.c.connectionCount.Add(1)
 
 		tasks.Submit(func() {
-			ch := connHistory{lastTry: time.Now()}
-			d.connectionHistory.Add(pp.addrPort, ch)
-
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-			defer cancel()
-
-			d.log.Trace().Msgf("try to connect to peer %s", pp.addrPort)
-
-			conn, err := global.Dial(ctx, "tcp", pp.addrPort.String())
-			if err != nil {
-				ch.lastTry = time.Now()
-				if errors.Is(err, context.DeadlineExceeded) || os.IsTimeout(err) {
-					ch.reason = connReasonTimeout
-				} else if errors.Is(err, syscall.ECONNREFUSED) {
-					ch.reason = connReasonRefused
-				} else {
-					ch.reason = connReasonError
-					ch.err = err
-				}
-
-				d.connectionHistory.Add(pp.addrPort, ch)
-				d.c.sem.Release(1)
-				d.c.connectionCount.Sub(1)
-				return
-			}
-
-			_ = conn.SetDeadline(time.Now().Add(global.ConnTimeout))
-
-			// peers is wrapped by conntrack, so we need to cast it with interface
-			if tcp, ok := conn.(interface{ SetLinger(sec int) error }); ok {
-				_ = tcp.SetLinger(0)
-			}
-
-			NewOutgoingPeer(conn, d, pp.addrPort)
+			d.tryDial(candidate)
 		})
+
+		connected++
 	}
 
-	// Re-push peers that were skipped (backoff not expired or sem full)
-	// so they can be retried on the next signal.
-	for _, pp := range retryLater {
-		d.pendingPeers.Push(pp)
-	}
+	return connected
 }
 
-// canRetry returns true if the peer should be skipped (not yet ready to retry).
-// Returns false if enough time has passed to retry the connection.
-func (d *Download) canRetry(ch connHistory) bool {
-	// If peer had transferred data, retry immediately regardless of reason.
-	// This mirrors libtorrent's behavior where peers with transfer_counter > 0
-	// are never culled and can be reconnected aggressively.
-	if ch.hadTrans {
-		return false
+// tryDial attempts a TCP connect to a candidate peer.
+// On success, registers the connection in the peer list.
+// On failure, increments failcount and releases the semaphore.
+func (d *Download) tryDial(pp *persistentPeer) {
+	ctx, cancel := context.WithTimeout(context.Background(), peerConnectTimeout)
+	defer cancel()
+
+	d.log.Trace().Msgf("try to connect to peer %s", pp.addrPort)
+
+	conn, err := global.Dial(ctx, "tcp", pp.addrPort.String())
+	if err != nil {
+		d.peerList.incFailcount(pp)
+		d.c.sem.Release(1)
+		d.c.connectionCount.Sub(1)
+		return
 	}
 
-	elapsed := time.Since(ch.lastTry)
+	_ = conn.SetDeadline(time.Now().Add(global.ConnTimeout))
 
-	switch ch.reason {
-	case connReasonNone:
-		// Never tried before, always allow.
-		return false
-	case connReasonTimeout:
-		return elapsed < connBackoffTimeout
-	case connReasonRefused:
-		return elapsed < connBackoffRefused
-	case connReasonEOF:
-		// Peer closed cleanly — it may come back soon (e.g., client restart).
-		// Use a short backoff.
-		return elapsed < connBackoffTimeout
-	default:
-		return elapsed < connBackoffGeneric
+	if tcp, ok := conn.(interface{ SetLinger(sec int) error }); ok {
+		_ = tcp.SetLinger(0)
 	}
+
+	p := NewOutgoingPeer(conn, d, pp.addrPort)
+	// Register the connection in the persistent peer list.
+	d.peerList.newConnection(pp.addrPort, p, time.Now().Unix())
 }
 
-// recordDisconnect records the reason a peer disconnected.
-// Called by Peer.close() to update connection history for future retry decisions.
+// recordDisconnect is called by Peer.close() to update the peer list.
 func (d *Download) recordDisconnect(addr netip.AddrPort, hadTrans bool, err error) {
-	ch := connHistory{
-		lastTry:  time.Now(),
-		hadTrans: hadTrans,
+	failed := err != nil &&
+		!errors.Is(err, io.EOF) &&
+		!errors.Is(err, context.Canceled)
+
+	d.peerList.connectionClosed(addr, time.Now().Unix(), hadTrans, failed)
+}
+
+// peerTurnover disconnects slow peers to make room for fresh candidates.
+// Mirrors libtorrent's optimistic disconnect (~2% per round).
+func (d *Download) peerTurnover() {
+	const turnoverFraction = 50 // 1/50 = 2%
+	peerCount := 0
+	d.peers.Range(func(_ netip.AddrPort, _ *Peer) bool {
+		peerCount++
+		return true
+	})
+	if peerCount == 0 {
+		return
 	}
 
-	if err == nil {
-		ch.reason = connReasonEOF
-	} else if os.IsTimeout(err) || errors.Is(err, context.DeadlineExceeded) {
-		ch.reason = connReasonTimeout
-	} else if errors.Is(err, io.EOF) {
-		ch.reason = connReasonEOF
-	} else if errors.Is(err, syscall.ECONNRESET) {
-		ch.reason = connReasonError
-	} else {
-		ch.reason = connReasonError
-		ch.err = err
+	disconnectN := max(peerCount/turnoverFraction, 1)
+	candidateN := d.peerList.numCandidates()
+	disconnectN = min(disconnectN, candidateN)
+
+	if disconnectN == 0 {
+		return
 	}
 
-	d.connectionHistory.Add(addr, ch)
+	toDisconnect := d.peerList.peerTurnover(disconnectN)
+	for _, p := range toDisconnect {
+		p.close()
+	}
 }

--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha1"
 	"io"
 	"net/netip"
+	"slices"
 	"time"
 
 	"github.com/docker/go-units"
@@ -125,7 +126,6 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 	d.c.pieceDownloadRate.Update(len(res.Data))
 	d.downloaded.Add(int64(len(res.Data)))
 
-
 	// in endgame mode we may receive duplicated response, just ignore them
 	if d.bm.Contains(res.PieceIndex) {
 		return
@@ -217,13 +217,7 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 
 		if d.checkPieceBitmapDone(pieceIdx) {
 			// avoid duplicates
-			already := false
-			for _, cp := range completedPieces {
-				if cp == pieceIdx {
-					already = true
-					break
-				}
-			}
+			already := slices.Contains(completedPieces, pieceIdx)
 			if !already {
 				completedPieces = append(completedPieces, pieceIdx)
 			}
@@ -507,7 +501,6 @@ func (d *Download) requestABlock(p *Peer) {
 		return
 	}
 
-
 	// Determine desired queue size
 	desiredQueueSize := p.updateDesiredQueueSize()
 
@@ -532,7 +525,7 @@ func (d *Download) requestABlock(p *Peer) {
 		choked,
 		p.allowFast,
 		numRequests,
-		0, // prefer_contiguous_blocks (can be enabled for fast peers later)
+		0,   // prefer_contiguous_blocks (can be enabled for fast peers later)
 		nil, // suggested pieces (not yet implemented)
 		d.info,
 	)
@@ -608,7 +601,6 @@ func (d *Download) requestABlock(p *Peer) {
 	}
 
 	if len(result.busyBlocks) > 0 {
-
 		for _, bb := range result.busyBlocks {
 			chunk := pieceChunk(d.info, bb.pieceIndex, bb.blockIndex)
 			if p.isInQueue(chunk) {

--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -4,11 +4,9 @@
 package core
 
 import (
-	"cmp"
 	"crypto/sha1"
 	"io"
 	"net/netip"
-	"slices"
 	"time"
 
 	"github.com/docker/go-units"
@@ -17,7 +15,7 @@ import (
 	"neptune/internal/core/tracker"
 	"neptune/internal/meta"
 	"neptune/internal/pkg/as"
-	"neptune/internal/pkg/bm"
+	"neptune/internal/pkg/empty"
 	"neptune/internal/pkg/global/tasks"
 	"neptune/internal/pkg/gslice"
 	"neptune/internal/pkg/gsync"
@@ -25,6 +23,16 @@ import (
 	"neptune/internal/pkg/mempool"
 	"neptune/internal/proto"
 )
+
+// requestQueueTime is the target number of seconds of pipeline to maintain
+// (mirrors libtorrent's request_queue_time setting).
+const requestQueueTime = 3
+
+// minRequestQueue is the minimum number of outstanding requests per peer.
+const minRequestQueue = 2
+
+// maxRequestQueue is the maximum number of outstanding requests per peer.
+const maxRequestQueue = 250
 
 func (d *Download) backgroundReqScheduler() {
 	timer := time.NewTimer(time.Second * 5)
@@ -35,18 +43,21 @@ func (d *Download) backgroundReqScheduler() {
 		case <-d.ctx.Done():
 			return
 		case <-d.scheduleRequestSignal:
-			if !d.wait(Downloading) {
-				continue
-			}
-
-			d.scheduleSeq()
 		case <-timer.C:
-			if !d.wait(Downloading) {
-				continue
-			}
-
-			d.scheduleSeq()
 		}
+
+		if !d.wait(Downloading) {
+			continue
+		}
+
+		// Iterate peers and request blocks for each
+		d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {
+			if p.closed.Load() {
+				return true
+			}
+			d.requestABlock(p)
+			return true
+		})
 	}
 }
 
@@ -114,15 +125,15 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 	d.c.pieceDownloadRate.Update(len(res.Data))
 	d.downloaded.Add(int64(len(res.Data)))
 
-	// clear endgame tracking for this chunk
-	if d.endGameMode.Load() {
-		d.endgameRequested.Delete(res.Request())
-	}
 
 	// in endgame mode we may receive duplicated response, just ignore them
 	if d.bm.Contains(res.PieceIndex) {
 		return
 	}
+
+	// Mark block as writing in the picker
+	blockIndex := int(res.Begin / uint32(defaultBlockSize))
+	d.picker.markAsWriting(res.PieceIndex, blockIndex)
 
 	if d.endGameMode.Load() {
 		d.handleResEndgame(res)
@@ -151,6 +162,7 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 
 	head := d.chunk.heap.Pop()
 	headPi := head.pi
+	headPiece := head.res.PieceIndex
 
 	mergedChunk := pieceChunksPool.Get()
 	defer pieceChunksPool.Put(mergedChunk)
@@ -160,8 +172,6 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 	d.chunk.done.Set(headPi)
 	d.chunk.mu.Unlock()
 
-	headPiece := head.res.PieceIndex
-	tailPiece := headPiece
 	tailPi := headPi
 
 	start := int64(headPiece)*d.info.PieceLength + int64(head.res.Begin)
@@ -181,7 +191,6 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 		}
 
 		tailPi++
-		tailPiece = peak.res.PieceIndex
 
 		d.chunk.mu.Lock()
 		d.chunk.done.Set(tailPi)
@@ -198,11 +207,30 @@ func (d *Download) handleRes(res *proto.ChunkResponse) {
 		return
 	}
 
-	for pieceIndex := headPiece; pieceIndex <= tailPiece; pieceIndex++ {
-		if !d.checkPieceBitmapDone(pieceIndex) {
-			continue
-		}
+	// Mark only the blocks that were actually written as finished.
+	// track which pieces were fully completed.
+	var completedPieces []uint32
+	for pi := headPi; pi <= tailPi; pi++ {
+		pieceIdx := pi / d.normalChunkLen
+		blockIdx := int(pi % d.normalChunkLen)
+		d.picker.markAsFinished(pieceIdx, blockIdx)
 
+		if d.checkPieceBitmapDone(pieceIdx) {
+			// avoid duplicates
+			already := false
+			for _, cp := range completedPieces {
+				if cp == pieceIdx {
+					already = true
+					break
+				}
+			}
+			if !already {
+				completedPieces = append(completedPieces, pieceIdx)
+			}
+		}
+	}
+
+	for _, pieceIndex := range completedPieces {
 		tasks.Submit(func() {
 			err := d.checkPiece(pieceIndex)
 			if err != nil {
@@ -228,6 +256,10 @@ func (d *Download) handleResEndgame(res *proto.ChunkResponse) {
 		d.chunk.done.Set(chunk.pi)
 		d.chunk.mu.Unlock()
 		proto.PiecePool.Put(chunk.res)
+
+		// Mark block as finished in the picker
+		blockIdx := int(chunk.res.Begin / uint32(defaultBlockSize))
+		d.picker.markAsFinished(index, blockIdx)
 
 		if err != nil {
 			continue
@@ -279,6 +311,11 @@ func (d *Download) handlePieceFromHeap(index uint32) {
 	err := d.writeChunkToDist(int64(index)*d.info.PieceLength, buf.B)
 	if err != nil {
 		return
+	}
+
+	// Mark all blocks as finished in the picker
+	for bi := range int(pieceChunksCount(d.info, index)) {
+		d.picker.markAsFinished(index, bi)
 	}
 
 	tasks.Submit(func() {
@@ -382,7 +419,8 @@ func (d *Download) checkPiece(pieceIndex uint32) error {
 	copy(digest[:], hasher.Sum(nil))
 
 	if digest != d.info.Pieces[pieceIndex] {
-		d.pieceInFlight.Unset(pieceIndex)
+		// Piece hash check failed — reset in picker so blocks can be re-requested
+		d.picker.resetPiece(pieceIndex, d.info)
 		d.corruptedPiecesMu.Lock()
 		d.corruptedPieces[pieceIndex]++
 		d.corruptedPiecesMu.Unlock()
@@ -394,22 +432,35 @@ func (d *Download) checkPiece(pieceIndex uint32) error {
 			d.chunk.done.Remove(i)
 		}
 		d.chunk.mu.Unlock()
+		// Trigger reschedule for re-requesting this piece
+		select {
+		case d.scheduleRequestSignal <- empty.Empty{}:
+		default:
+		}
 		return nil
 	}
 
 	notHave := d.bm.SetX(pieceIndex)
-	d.pieceInFlight.Unset(pieceIndex)
+
+	// Mark piece as fully owned in the picker
+	d.picker.weHave(pieceIndex)
 
 	if notHave {
 		d.completed.Add(pieceSize)
 		d.corruptedPiecesMu.Lock()
 		delete(d.corruptedPieces, pieceIndex)
 		d.corruptedPiecesMu.Unlock()
-		d.piecePeerMu.Lock()
-		delete(d.piecePeerAssignments, pieceIndex)
-		d.piecePeerMu.Unlock()
 		d.log.Trace().Msgf("piece %d done", pieceIndex)
 		d.have(pieceIndex)
+
+		// Signal peers that a piece completed so they can request more blocks.
+		d.peers.Range(func(_ netip.AddrPort, p *Peer) bool {
+			select {
+			case p.pieceDone <- empty.Empty{}:
+			default:
+			}
+			return true
+		})
 	}
 
 	return nil
@@ -438,316 +489,159 @@ func (d *Download) checkDone() {
 	d.Trk.Announce(tracker.EventCompleted)
 }
 
-// piecePriority computes a priority score for a piece, inspired by libtorrent:
-// priority = (availability + 1) * 3 + state_adjustment
-// Higher priority means more urgent to download.
-func piecePriority(availability int32, hasPendingChunks bool) int32 {
-	p := (availability + 1) * 3
-	if hasPendingChunks {
-		p += 1 // boost partially downloaded pieces
+// requestABlock picks blocks for a single peer using the global piece picker.
+// Mirrors libtorrent's request_a_block().
+//
+// It determines the desired queue size dynamically (rate-based or snubbed=1),
+// calls the piece picker to find blocks, filters out already-queued blocks,
+// and pushes free blocks into the peer's request channel. In endgame mode,
+// it may also pick busy blocks (already requested by other peers).
+func (d *Download) requestABlock(p *Peer) {
+	if d.bm.Count() == d.info.NumPieces {
+		return // we're a seed, nothing to request
 	}
-	return p
-}
-
-func (d *Download) updateRarePieces() {
-	d.ratePieceMutex.Lock()
-	defer d.ratePieceMutex.Unlock()
-
-	if len(d.pieceAvailability) == 0 {
-		d.pieceAvailability = make([]int32, d.info.NumPieces)
-	} else {
-		clear(d.pieceAvailability)
+	if p.closed.Load() || p.isDisconnecting() {
+		return
 	}
-
-	var baseAvail int32
-	d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {
-		if p.peerChoking.Load() {
-			p.allowFast.Range(func(u uint32) {
-				if p.Bitmap.Contains(u) {
-					d.pieceAvailability[u]++
-				}
-			})
-			return true
-		}
-
-		if p.Bitmap.Count() == d.info.NumPieces {
-			baseAvail++
-			return true
-		}
-
-		p.Bitmap.Range(func(u uint32) {
-			d.pieceAvailability[u]++
-		})
-
-		return true
-	})
-
-	var queue = make([]pieceRare, 0, d.info.NumPieces)
-
-	for index, avail := range d.pieceAvailability {
-		if d.bm.Contains(uint32(index)) {
-			continue
-		}
-
-		totalAvail := avail + baseAvail
-		if totalAvail == 0 {
-			continue
-		}
-
-		if !d.selectedPiecesBm.Contains(uint32(index)) {
-			continue
-		}
-
-		// Skip pieces already assigned to another peer (mirrors libtorrent's untouched_bitfield).
-		if d.pieceInFlight.Contains(uint32(index)) {
-			continue
-		}
-
-		// check if piece has pending chunks (partially downloaded)
-		pieceStart := uint32(index) * d.normalChunkLen
-		pieceEnd := pieceStart + uint32(pieceChunksCount(d.info, uint32(index)))
-		hasPending := false
-		d.chunk.mu.RLock()
-		for c := pieceStart; c < pieceEnd; c++ {
-			if d.chunk.done.Contains(c) {
-				hasPending = true
-				break
-			}
-		}
-		d.chunk.mu.RUnlock()
-
-		priority := piecePriority(totalAvail, hasPending)
-		if priority > 0 {
-			queue = append(queue, pieceRare{priority: priority, index: uint32(index)})
-		}
-	}
-
-	d.rarePieceQueue = heap.FromSlice(queue)
-}
-
-func (d *Download) scheduleSeq() {
-	if d.endGameMode.Load() {
-		d.scheduleSeqEndGame()
+	if !d.HasState(Downloading) {
 		return
 	}
 
-	if d.SelectedSize()-d.completed.Load() <= units.MiB*100 {
+
+	// Determine desired queue size
+	desiredQueueSize := p.updateDesiredQueueSize()
+
+	// Already have enough outstanding requests
+	numRequests := desiredQueueSize - p.myRequests.Size() - p.requestQueueLen()
+	if numRequests <= 0 {
+		return
+	}
+
+	// Check if we should enter endgame mode
+	remaining := d.SelectedSize() - d.completed.Load()
+	if remaining <= units.MiB*100 {
 		d.endGameMode.Store(true)
-		d.scheduleSeqEndGame()
-		return
 	}
 
-	// Phase 1: prioritize partial pieces (already partially downloaded)
-	d.schedulePartialPieces()
+	// Build bitfield of pieces peer has
+	choked := p.peerChoking.Load()
 
-	// Phase 2: rarest-first for remaining capacity
-	d.scheduleRarePieces()
-}
+	// Call the piece picker
+	result := d.picker.pickPieces(
+		p.Bitmap,
+		choked,
+		p.allowFast,
+		numRequests,
+		0, // prefer_contiguous_blocks (can be enabled for fast peers later)
+		nil, // suggested pieces (not yet implemented)
+		d.info,
+	)
 
-// schedulePartialPieces assigns pieces that are already partially downloaded.
-// This reduces memory usage and completes work-in-progress faster.
-func (d *Download) schedulePartialPieces() {
-	type partialPiece struct {
-		index    uint32
-		progress int // number of chunks already downloaded
-	}
-
-	var partials []partialPiece
-
-	for i := range d.info.NumPieces {
-		if d.bm.Contains(i) {
-			continue
-		}
-		if !d.selectedPiecesBm.Contains(i) {
-			continue
+	// Pick free blocks first
+	freeBlocksPicked := 0
+	for _, fb := range result.freeBlocks {
+		if numRequests <= 0 {
+			break
 		}
 
-		pieceStart := i * d.normalChunkLen
-		pieceEnd := pieceStart + uint32(pieceChunksCount(d.info, i))
-		downloaded := 0
+		// Check if the block is already in the peer's queues
+		chunk := pieceChunk(d.info, fb.pieceIndex, fb.blockIndex)
+		if p.isInQueue(chunk) {
+			continue
+		}
+
+		// Check if block is already finished
+		if d.picker.isFinished(fb.pieceIndex, fb.blockIndex) {
+			continue
+		}
+
+		// Check if piece is already downloaded
+		if d.bm.Contains(fb.pieceIndex) {
+			continue
+		}
+
+		// Check if chunk is already written to disk
+		chunkPi := fb.pieceIndex*d.normalChunkLen + uint32(fb.blockIndex)
 		d.chunk.mu.RLock()
-		for c := pieceStart; c < pieceEnd; c++ {
-			if d.chunk.done.Contains(c) {
-				downloaded++
-			}
-		}
+		done := d.chunk.done.Contains(chunkPi)
 		d.chunk.mu.RUnlock()
+		if done {
+			continue
+		}
 
-		if downloaded > 0 {
-			partials = append(partials, partialPiece{index: i, progress: downloaded})
+		// Mark block as requesting in the picker
+		d.picker.markAsRequesting(fb.pieceIndex, fb.blockIndex, p)
+		d.picker.addDownloadingPiece(fb.pieceIndex, d.info)
+
+		// Push block to peer's request queue
+		select {
+		case p.blockRequests <- pieceBlock{pieceIndex: fb.pieceIndex, blockIndex: fb.blockIndex}:
+			numRequests--
+			freeBlocksPicked++
+		default:
+			// peer's request queue full, abort the mark
+			d.picker.abortDownload(fb.pieceIndex, fb.blockIndex)
+			return
 		}
 	}
 
-	if len(partials) == 0 {
+	// If we could pick enough free blocks, we're not in endgame for this peer
+	if numRequests <= 0 {
+		p.setEndgame(false)
 		return
 	}
 
-	// sort by progress descending (almost-done pieces first)
-	slices.SortFunc(partials, func(a, b partialPiece) int {
-		return cmp.Compare(b.progress, a.progress)
-	})
-
-	d.assignPiecesToPeers(func() (uint32, bool) {
-		if len(partials) == 0 {
-			return 0, false
-		}
-		p := partials[0]
-		partials = partials[1:]
-		return p.index, true
-	})
-}
-
-// scheduleRarePieces assigns pieces using rarest-first strategy.
-func (d *Download) scheduleRarePieces() {
-	d.updateRarePieces()
-
-	d.ratePieceMutex.Lock()
-	q := d.rarePieceQueue
-	d.rarePieceQueue = heap.New[pieceRare]()
-	d.ratePieceMutex.Unlock()
-
-	d.assignPiecesToPeers(func() (uint32, bool) {
-		if q.Len() == 0 {
-			return 0, false
-		}
-		piece := q.Pop()
-		if piece.priority <= 0 {
-			return 0, false
-		}
-		return piece.index, true
-	})
-}
-
-// assignPiecesToPeers assigns pieces from the iterator to peers.
-// Peers are sorted by speed (fastest first) and get pieces proportional to their pipeline capacity.
-func (d *Download) assignPiecesToPeers(nextPiece func() (uint32, bool)) {
-	type peerInfo struct {
-		peer     *Peer
-		capacity int // how many more pieces this peer can handle
+	// If we couldn't find enough free blocks, this peer enters endgame.
+	// Only set endgame if we're not choked (choked means only allowed-fast,
+	// which doesn't count as endgame).
+	if !p.peerChoking.Load() {
+		p.setEndgame(true)
+		d.endGameMode.Store(true)
 	}
 
-	var peers []peerInfo
-	d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {
-		if p.closed.Load() {
-			return true
-		}
-		queueSize := int(p.desiredQueueSize.Load())
-		pending := p.myRequests.Size()
-		// rough estimate: each piece has multiple chunks, divide by avg chunks
-		pendingPieces := 0
-		if pending > 0 {
-			pendingPieces = max(pending/int(d.normalChunkLen), 1)
-		}
-		avail := queueSize - pendingPieces
-		if avail > 0 {
-			peers = append(peers, peerInfo{peer: p, capacity: avail})
-		}
-		return true
-	})
-
-	if len(peers) == 0 {
+	// In endgame, also try busy blocks, but only if we have
+	// no outstanding requests already (to avoid all peers
+	// fighting over the same blocks).
+	// Mirrors libtorrent: dq.size() + rq.size() > 0 check.
+	if !d.endGameMode.Load() || p.myRequests.Size()+p.requestQueueLen() > 0 {
 		return
 	}
 
-	// sort by download rate descending (fastest peer first)
-	slices.SortFunc(peers, func(a, b peerInfo) int {
-		return cmp.Compare(b.peer.pieceDownloadRate.Status().CurRate, a.peer.pieceDownloadRate.Status().CurRate)
-	})
+	if len(result.busyBlocks) > 0 {
 
-	for _, pi := range peers {
-		for pi.capacity > 0 {
-			pieceIndex, ok := nextPiece()
-			if !ok {
-				return
-			}
-
-			if !d.selectedPiecesBm.Contains(pieceIndex) {
+		for _, bb := range result.busyBlocks {
+			chunk := pieceChunk(d.info, bb.pieceIndex, bb.blockIndex)
+			if p.isInQueue(chunk) {
 				continue
 			}
 
-			if pi.peer.peerChoking.Load() {
-				if !pi.peer.allowFast.Contains(pieceIndex) {
-					continue
-				}
-			} else if !pi.peer.Bitmap.Contains(pieceIndex) {
+			if d.picker.isFinished(bb.pieceIndex, bb.blockIndex) {
 				continue
 			}
 
-			// skip peers that previously sent corrupted data for this piece
-			d.piecePeerMu.Lock()
-			if peers, ok := d.piecePeerAssignments[pieceIndex]; ok {
-				if _, bad := peers[pi.peer.id]; bad {
-					d.piecePeerMu.Unlock()
-					continue
-				}
+			if d.bm.Contains(bb.pieceIndex) {
+				continue
 			}
-			// record this assignment
-			if d.piecePeerAssignments[pieceIndex] == nil {
-				d.piecePeerAssignments[pieceIndex] = make(map[uint32]struct{})
+
+			chunkPi := bb.pieceIndex*d.normalChunkLen + uint32(bb.blockIndex)
+			d.chunk.mu.RLock()
+			done := d.chunk.done.Contains(chunkPi)
+			d.chunk.mu.RUnlock()
+			if done {
+				continue
 			}
-			d.piecePeerAssignments[pieceIndex][pi.peer.id] = struct{}{}
-			d.piecePeerMu.Unlock()
+
+			d.picker.markAsRequesting(bb.pieceIndex, bb.blockIndex, p)
+			d.picker.addDownloadingPiece(bb.pieceIndex, d.info)
 
 			select {
-			case pi.peer.ourPieceRequests <- pieceIndex:
-				pi.peer.Requested.Set(pieceIndex)
-				d.pieceInFlight.Set(pieceIndex) // global tracking, mirrors libtorrent untouched_bitfield
-				pi.capacity--
+			case p.blockRequests <- pieceBlock{pieceIndex: bb.pieceIndex, blockIndex: bb.blockIndex}:
 			default:
-				// channel full, move to next peer
-				break
+				d.picker.abortDownload(bb.pieceIndex, bb.blockIndex)
 			}
+			return
 		}
 	}
-}
-
-func (d *Download) scheduleSeqEndGame() {
-	missing := bm.New(d.info.NumPieces)
-	missing.Fill()
-	missing.AndNot(d.bm)
-	s := missing.ToArray()
-
-	d.peers.Range(func(addr netip.AddrPort, p *Peer) bool {
-		for _, u := range s {
-			if !d.selectedPiecesBm.Contains(u) {
-				continue
-			}
-			if p.Bitmap.Contains(u) {
-				// check if this peer has any unrequested chunks for this piece
-				if !d.hasUnrequestedEndgameChunks(u) {
-					continue
-				}
-				select {
-				case <-p.ctx.Done():
-					return true
-				case p.ourPieceRequests <- u:
-				default:
-				}
-			}
-		}
-
-		return true
-	})
-}
-
-// hasUnrequestedEndgameChunks returns true if the piece has chunks not yet requested in endgame mode.
-func (d *Download) hasUnrequestedEndgameChunks(pieceIndex uint32) bool {
-	if !d.endGameMode.Load() {
-		return true
-	}
-	pieceStart := pieceIndex * d.normalChunkLen
-	pieceEnd := pieceStart + uint32(pieceChunksCount(d.info, pieceIndex))
-	d.chunk.mu.RLock()
-	defer d.chunk.mu.RUnlock()
-	for c := pieceStart; c < pieceEnd; c++ {
-		if !d.chunk.done.Contains(c) {
-			req := pieceChunk(d.info, pieceIndex, int(c-pieceStart))
-			if _, requested := d.endgameRequested.Load(req); !requested {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func pieceChunksCount(info meta.Info, index uint32) int64 {

--- a/internal/core/d_loop.go
+++ b/internal/core/d_loop.go
@@ -122,28 +122,44 @@ func (d *Download) startBackground() {
 	d.goBackground(d.backgroundReqScheduler)
 	d.goBackground(d.backgroundReqHandler)
 
+	// Connection loop — libtorrent-style periodic connect attempts.
+	// 1s ticker (matching libtorrent's tick_interval) for prompt reuse of freed slots.
+	// 5min ticker for peer turnover (disconnect slow peers, connect new candidates).
 	d.goBackground(func() {
-		// Periodic reconnect timer so backoff-expired peers get retried.
-		// libtorrent does this every 10s via receive_connect_peers.
-		reconnectTicker := time.NewTicker(10 * time.Second)
-		defer reconnectTicker.Stop()
+		connectTicker := time.NewTicker(time.Second)
+		defer connectTicker.Stop()
+
+		turnoverTicker := time.NewTicker(5 * time.Minute)
+		defer turnoverTicker.Stop()
 
 		for {
 			select {
 			case <-d.ctx.Done():
 				return
 			case <-d.pendingPeersSignal:
-			case <-reconnectTicker.C:
+			case <-connectTicker.C:
+			case <-turnoverTicker.C:
+				d.peerTurnover()
+				continue
 			}
 
 			if !d.wait(Seeding | Downloading) {
 				continue
 			}
 
-			d.connectToPeers()
+			// Compute how many slots we can fill
+			desired := d.maxConnections()
+			current := d.peerCount()
+			maxSlots := desired - current
+			if maxSlots <= 0 {
+				continue
+			}
+
+			d.connectToPeers(maxSlots)
 		}
 	})
 
+	// PEX handler — feeds peers from PEX messages into the persistent peer list.
 	d.goBackground(func() {
 		for {
 			select {
@@ -153,24 +169,16 @@ func (d *Download) startBackground() {
 			case peers := <-d.pexAdd:
 				state := d.GetState()
 
-				d.pendingPeersMutex.Lock()
-
 				for _, peer := range peers {
 					if !peer.outGoing {
 						continue
 					}
-
 					if state == Seeding && peer.seedOnly {
 						continue
 					}
 
-					d.pendingPeers.Push(peerWithPriority{
-						addrPort: peer.addrPort,
-						priority: d.c.PeerPriority(peer.addrPort),
-					})
+					d.peerList.addPeer(peer.addrPort, peerSourcePEX, true)
 				}
-
-				d.pendingPeersMutex.Unlock()
 
 				select {
 				case d.pendingPeersSignal <- empty.Empty{}:
@@ -202,8 +210,7 @@ func (d *Download) optimisticUnchoke() {
 
 	idx := int(time.Now().UnixNano()) % len(peers)
 	p := peers[idx]
-	p.Requested.Clear()
-	d.log.Debug().Stringer("addr", p.Address).Msg("optimistic unchoke: cleared peer Requested")
+	d.log.Debug().Stringer("addr", p.Address).Msg("optimistic unchoke")
 
 	select {
 	case d.scheduleRequestSignal <- empty.Empty{}:
@@ -288,4 +295,19 @@ func (d *Download) openFileReadOnly(fileIndex int) (*filepool.File, error) {
 	}
 	d.adviseFresh(file, fresh)
 	return file, nil
+}
+
+// maxConnections returns the per-torrent connection limit.
+func (d *Download) maxConnections() int {
+	return int(d.c.Config.App.GlobalConnectionLimit)
+}
+
+// peerCount returns the number of currently connected peers.
+func (d *Download) peerCount() int {
+	count := 0
+	d.peers.Range(func(_ netip.AddrPort, _ *Peer) bool {
+		count++
+		return true
+	})
+	return count
 }

--- a/internal/core/p.go
+++ b/internal/core/p.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
-	"github.com/kelindar/bitmap"
 	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/rs/zerolog"
 	"go.uber.org/atomic"
@@ -96,14 +95,13 @@ func newPeer(
 		peerChoking:    *atomic.NewBool(true),
 		peerInterested: *atomic.NewBool(false),
 
-		ourPieceRequests: make(chan uint32, 20),
+		blockRequests: make(chan pieceBlock, 50),
 
 		pieceDone:        make(chan struct{}, 1),
 		desiredQueueSize: *atomic.NewInt32(1),
 
 		UserAgent: *atomic.NewPointer(&ua),
 
-		Requested: make(bitmap.Bitmap, d.bitfieldSize),
 
 		responseCond: gsync.NewCond(gsync.EmptyLock{}),
 
@@ -119,7 +117,6 @@ func newPeer(
 		w: bufio.NewWriterSize(conn, units.KiB*8),
 
 		allowFast: bm.New(d.info.NumPieces),
-		//Requested: bm.New(d.info.NumPieces),
 
 		peerID: *atomic.NewPointer(&proto.PeerID{}),
 
@@ -157,7 +154,7 @@ type Peer struct {
 	peerRequests      *xsync.Map[proto.ChunkRequest, empty.Empty]
 	cancel            context.CancelFunc
 	Bitmap            *bm.Bitmap
-	ourPieceRequests  chan uint32
+	blockRequests     chan pieceBlock // receives blocks from scheduler (replaces ourPieceRequests)
 	responseCond      *gsync.Cond
 	peerID            atomic.Pointer[proto.PeerID]
 	pieceDone         chan struct{}
@@ -165,7 +162,8 @@ type Peer struct {
 	r                 *bufio.Reader
 	pieceUploadRate   *flowrate.Monitor
 	Address           netip.AddrPort
-	Requested         bitmap.Bitmap
+	requestQueue      []pieceBlock // blocks to be sent as wire requests (mirrors m_request_queue)
+	rqMu              sync.Mutex
 	rttAverage        sizedSlice[time.Duration]
 	isSeed            atomic.Bool
 	QueueLimit        atomic.Uint32
@@ -175,10 +173,9 @@ type Peer struct {
 	closed            atomic.Bool
 	peerInterested    atomic.Bool
 	ourChoking        atomic.Bool
-	lastRate          atomic.Int64
 	preferred         atomic.Bool
-	slowStart         atomic.Bool
 	peerChoking       atomic.Bool
+	endgame           atomic.Bool
 	rttMutex          sync.RWMutex
 	wm                sync.Mutex
 	extDontHaveID     gsync.AtomicUint[proto.ExtensionMessage]
@@ -191,6 +188,7 @@ type Peer struct {
 	dhtEnabled        bool
 	subExtensions     bool
 	hadTransfer       bool
+	disconnecting     atomic.Bool
 }
 
 func (p *Peer) Response(res *proto.ChunkResponse) bool {
@@ -233,7 +231,19 @@ func (p *Peer) Unchoke() {
 
 func (p *Peer) close() {
 	if p.closed.CompareAndSwap(false, true) {
+		p.disconnecting.Store(true)
 		p.log.Trace().Caller(1).Msg("close")
+
+		// Decrement picker refcount for all pieces this peer had,
+		// and abort any blocks we had requested from this peer.
+		p.Bitmap.Range(func(u uint32) {
+			p.d.picker.decRefcount(u)
+		})
+		p.myRequests.Range(func(req proto.ChunkRequest, _ time.Time) bool {
+			bi := int(req.Begin / uint32(defaultBlockSize))
+			p.d.picker.abortDownload(req.PieceIndex, bi)
+			return true
+		})
 
 		// Record disconnect reason for future retry decisions.
 		// Only record for outgoing peers; incoming peers don't need retry logic.
@@ -248,16 +258,8 @@ func (p *Peer) close() {
 		_ = p.Conn.Close()
 		p.d.buildNetworkPieces <- empty.Empty{}
 
-		// Re-queue for reconnect so connectToPeers gets another chance.
-		// canRetry backoff prevents tight reconnect loops.
-		if !p.Incoming && p.d.HasState(Downloading|Seeding) {
-			p.d.pendingPeersMutex.Lock()
-			p.d.pendingPeers.Push(peerWithPriority{
-				addrPort: p.Address,
-				priority: p.d.c.PeerPriority(p.Address),
-			})
-			p.d.pendingPeersMutex.Unlock()
-
+		// Signal connection loop to fill the freed slot.
+		if p.d.HasState(Downloading | Seeding) {
 			select {
 			case p.d.pendingPeersSignal <- empty.Empty{}:
 			default:
@@ -267,144 +269,146 @@ func (p *Peer) close() {
 }
 
 func (p *Peer) ourRequestHandle() {
-	p.ourRequestHandleLoop()
-}
-
-func (p *Peer) ourRequestHandleLoop() {
-	pending := make(map[uint32]struct{})
-	sem := make(chan struct{}, 20)
-	p.slowStart.Store(true)
 
 	for {
-		// update desired queue size
-		var queueSize int
-		if p.snubbed.Load() {
-			queueSize = 1
-		} else if p.slowStart.Load() {
-			// slow start: use current desired size, will grow on piece completion
-			queueSize = int(p.desiredQueueSize.Load())
-		} else {
-			// rate-based: keep 3s of pipeline
-			queueSize = int(3*p.pieceDownloadRate.Status().CurRate) / int(defaultBlockSize)
-		}
-		queueSize = max(queueSize, 1)
-		queueSize = min(queueSize, 20)
-		p.desiredQueueSize.Store(int32(queueSize))
-		limit := queueSize
-
-		// drain channel into pending while we have capacity
-		for len(pending) < limit {
-			select {
-			case <-p.ctx.Done():
-				return
-			case index := <-p.ourPieceRequests:
-				pending[index] = struct{}{}
-				continue
-			}
-		}
-
-		if len(pending) == 0 {
-			// wait for new piece, piece completion, or context cancellation
-			select {
-			case <-p.ctx.Done():
-				return
-			case index := <-p.ourPieceRequests:
-				pending[index] = struct{}{}
-			case <-p.pieceDone:
-				p.handleSlowStart()
-			}
-			continue
-		}
-
-		// also handle pieceDone non-blocking to react to completions
 		select {
+		case <-p.ctx.Done():
+			return
+		case block := <-p.blockRequests:
+			p.rqMu.Lock()
+			p.requestQueue = append(p.requestQueue, block)
+			p.rqMu.Unlock()
+			p.sendBlockRequests()
 		case <-p.pieceDone:
-			p.handleSlowStart()
-		default:
-		}
-
-		// start downloading pieces concurrently
-		for index := range pending {
-			sem <- struct{}{} // acquire slot
-			delete(pending, index)
-			go func(pieceIdx uint32) {
-				defer func() {
-					<-sem // release slot
-					select {
-					case p.pieceDone <- struct{}{}:
-					default:
-					}
-				}()
-				p.downloadPieceChunks(pieceIdx)
-			}(index)
+			// Piece completed, may need to request more
+			p.sendBlockRequests()
+			select {
+			case p.d.scheduleRequestSignal <- empty.Empty{}:
+			default:
+			}
 		}
 	}
 }
 
-// handleSlowStart updates the desired queue size during slow start mode.
-// It doubles the queue size when download rate is still growing,
-// and exits slow start when rate plateaus.
-func (p *Peer) handleSlowStart() {
-	if !p.slowStart.Load() {
+// sendBlockRequests drains the peer's requestQueue and sends wire requests
+// up to the peer's queue limit. Mirrors libtorrent's send_block_requests().
+func (p *Peer) sendBlockRequests() {
+	if p.closed.Load() || p.isDisconnecting() {
 		return
 	}
 
-	currentRate := p.pieceDownloadRate.Status().CurRate
-	lastRate := p.lastRate.Load()
-	p.lastRate.Store(currentRate)
+	desiredSize := p.updateDesiredQueueSize()
 
-	// if rate is still growing (with some tolerance), double the queue
-	if lastRate > 0 && currentRate > lastRate*95/100 {
-		old := p.desiredQueueSize.Load()
-		newSize := min(old*2, 20)
-		p.desiredQueueSize.Store(newSize)
-		p.log.Trace().Int32("old", old).Int32("new", newSize).Msg("slow start: growing pipeline")
-	} else if lastRate > 0 {
-		// rate stopped growing, exit slow start
-		p.slowStart.Store(false)
-		p.log.Info().Int64("rate", currentRate).Msg("slow start: exited, switching to rate-based")
-	}
-}
-
-// downloadPieceChunks requests all chunks of a piece from this peer.
-func (p *Peer) downloadPieceChunks(index uint32) {
-	chunkLen := int(pieceChunksCount(p.d.info, index))
-	for i := range chunkLen {
-		if p.closed.Load() {
+	for {
+		currentSize := p.myRequests.Size()
+		if currentSize >= desiredSize {
 			return
 		}
 
-		chunk := pieceChunk(p.d.info, index, i)
-
-		// in endgame mode, skip chunks already requested by other peers
-		if p.d.endGameMode.Load() {
-			if _, already := p.d.endgameRequested.Load(chunk); already {
-				continue
-			}
-			p.d.endgameRequested.Store(chunk, empty.Empty{})
+		p.rqMu.Lock()
+		if len(p.requestQueue) == 0 {
+			p.rqMu.Unlock()
+			return
 		}
+		block := p.requestQueue[0]
+		p.requestQueue = p.requestQueue[1:]
+		p.rqMu.Unlock()
 
-		// Pace chunk requests to avoid flooding slow peers.
-		// Use a fraction of the peer's advertised queue limit,
-		// clamped between the per-piece floor and the global ceiling.
-		limit := max(int(p.QueueLimit.Load())/2, 10)
-		globalLimit := min(int(p.QueueLimit.Load())-10, 300)
-		if limit > globalLimit {
-			limit = globalLimit
-		}
-		for p.myRequests.Size() >= limit {
-			select {
-			case <-p.ctx.Done():
-				return
-			case <-p.responseCond.C:
-			}
+		chunk := pieceChunk(p.d.info, block.pieceIndex, block.blockIndex)
+
+		// Skip if peer is choking us (unless allowed fast)
+		if p.peerChoking.Load() && !p.allowFast.Contains(block.pieceIndex) {
+			// Put back? No, the scheduler should have filtered these.
+			// Just abort and continue.
+			p.d.picker.abortDownload(block.pieceIndex, block.blockIndex)
+			continue
 		}
 
-		if !p.peerChoking.Load() {
-			p.Request(chunk)
+		// Check global queue limit from the peer
+		if p.myRequests.Size() >= int(p.QueueLimit.Load())/2 {
+			// Paused: put block back to front and wait for responses
+			p.rqMu.Lock()
+			p.requestQueue = append([]pieceBlock{block}, p.requestQueue...)
+			p.rqMu.Unlock()
+			return
 		}
+
+		p.Request(chunk)
 	}
 }
+
+// updateDesiredQueueSize computes the desired number of outstanding requests
+// based on the peer's download rate. Mirrors libtorrent's update_desired_queue_size().
+//
+// Formula: desired = queue_time * download_rate / block_size
+// Clamped between [minRequestQueue, maxRequestQueue].
+// Snubbed peers get size 1.
+func (p *Peer) updateDesiredQueueSize() int {
+	if p.snubbed.Load() {
+		return 1
+	}
+
+	if p.endgame.Load() {
+		return 1
+	}
+
+	// Rate-based: keep requestQueueTime seconds of pipeline
+	dlRate := p.pieceDownloadRate.Status().CurRate
+	queueSize := requestQueueTime * int(dlRate) / int(defaultBlockSize)
+
+	if queueSize < minRequestQueue {
+		queueSize = minRequestQueue
+	}
+	if queueSize > maxRequestQueue {
+		queueSize = maxRequestQueue
+	}
+
+	// Also respect peer's advertised queue limit
+	peerLimit := int(p.QueueLimit.Load())
+	if peerLimit > 0 && queueSize > peerLimit {
+		queueSize = peerLimit
+	}
+
+	p.desiredQueueSize.Store(int32(queueSize))
+	return queueSize
+}
+
+// requestQueueLen returns the length of the request queue under lock.
+func (p *Peer) requestQueueLen() int {
+	p.rqMu.Lock()
+	defer p.rqMu.Unlock()
+	return len(p.requestQueue)
+}
+
+// isInQueue checks if a chunk is already in the peer's request queue or request set.
+func (p *Peer) isInQueue(chunk proto.ChunkRequest) bool {
+	if _, ok := p.myRequests.Load(chunk); ok {
+		return true
+	}
+
+	p.rqMu.Lock()
+	defer p.rqMu.Unlock()
+
+	for _, b := range p.requestQueue {
+		q := pieceChunk(p.d.info, b.pieceIndex, b.blockIndex)
+		if q == chunk {
+			return true
+		}
+	}
+
+	return false
+}
+
+// setEndgame sets whether the peer is in endgame mode.
+func (p *Peer) setEndgame(v bool) {
+	p.endgame.Store(v)
+}
+
+// isDisconnecting returns true if the peer is in the process of disconnecting.
+func (p *Peer) isDisconnecting() bool {
+	return p.disconnecting.Load()
+}
+
 
 func (p *Peer) checkRequestTimeouts() {
 	const pieceTimeout = 30 * time.Second
@@ -431,8 +435,24 @@ func (p *Peer) checkRequestTimeouts() {
 				p.snubbedAt.Store(now)
 				p.log.Warn().Msg("peer snubbed: request timeout")
 
-				// release requested pieces so other peers can pick them up
-				p.Requested.Clear()
+				// abort all pending downloads so other peers can pick them up
+				p.myRequests.Range(func(req proto.ChunkRequest, _ time.Time) bool {
+					bi := int(req.Begin / uint32(defaultBlockSize))
+					p.d.picker.abortDownload(req.PieceIndex, bi)
+					return true
+				})
+
+				// Clear myRequests — entries are now stale and would
+				// inflate Size() preventing new requests.
+				p.myRequests.Range(func(req proto.ChunkRequest, _ time.Time) bool {
+					p.myRequests.Delete(req)
+					return true
+				})
+
+				// Clear requestQueue — stale blocks would be resent on un-snub.
+				p.rqMu.Lock()
+				p.requestQueue = p.requestQueue[:0]
+				p.rqMu.Unlock()
 
 				// trigger reschedule
 				select {
@@ -522,6 +542,15 @@ func (p *Peer) start(skipHandshake bool) {
 		return
 	}
 
+	// Register in persistent peer list for reconnect/backoff tracking.
+	if p.Incoming {
+		if p.d.peerList.addOrUpdateIncoming(p.Address, time.Now().Unix(), p) {
+			// Duplicate — another connection to this addr exists.
+			p.close()
+			return
+		}
+	}
+
 	go p.ourRequestHandle()
 	go p.checkRequestTimeouts()
 
@@ -546,6 +575,10 @@ func (p *Peer) start(skipHandshake bool) {
 		switch event.Event {
 		case proto.Bitfield:
 			p.Bitmap.OR(event.Bitmap)
+			// Update picker: increment refcount for each piece the peer has
+			event.Bitmap.Range(func(u uint32) {
+				p.d.picker.incRefcount(u)
+			})
 			if !p.isSeed.Load() && p.Bitmap.Count() == p.d.info.NumPieces {
 				p.isSeed.Store(true)
 			}
@@ -556,6 +589,7 @@ func (p *Peer) start(skipHandshake bool) {
 			}
 
 			p.Bitmap.Set(event.Index)
+			p.d.picker.incRefcount(event.Index)
 			if !p.isSeed.Load() && p.Bitmap.Count() == p.d.info.NumPieces {
 				p.isSeed.Store(true)
 			}
@@ -583,9 +617,7 @@ func (p *Peer) start(skipHandshake bool) {
 
 			if p.snubbed.Load() {
 				p.snubbed.Store(false)
-				p.slowStart.Store(true)
-				p.desiredQueueSize.Store(1)
-				p.lastRate.Store(0)
+							p.desiredQueueSize.Store(1)
 				p.log.Info().Msg("peer un-snubbed: responding again")
 			}
 
@@ -636,14 +668,27 @@ func (p *Peer) start(skipHandshake bool) {
 
 			if event.ExtensionID == p.extDontHaveID.Load() {
 				p.Bitmap.Unset(event.Index)
+				p.d.picker.decRefcount(event.Index)
 				continue
 			}
 
 			continue
 		case proto.HaveAll:
+			// Decrement old pieces before replacing bitmap with full set
+			p.Bitmap.Range(func(u uint32) {
+				p.d.picker.decRefcount(u)
+			})
 			p.Bitmap.Fill()
+			// Increment refcount for all pieces the peer now has
+			for i := range p.d.info.NumPieces {
+				p.d.picker.incRefcount(i)
+			}
 			p.isSeed.Store(true)
 		case proto.HaveNone:
+			// Decrement old pieces before clearing
+			p.Bitmap.Range(func(u uint32) {
+				p.d.picker.decRefcount(u)
+			})
 			p.Bitmap.Clear()
 		case proto.Cancel:
 			p.peerRequests.Delete(event.Req)
@@ -651,6 +696,21 @@ func (p *Peer) start(skipHandshake bool) {
 			p.log.Trace().Msgf("reject %+v", event.Req)
 			p.Rejected.Store(event.Req, empty.Empty{})
 			p.myRequests.Delete(event.Req)
+
+			// Abort in the picker so other peers can request this block.
+			bi := int(event.Req.Begin / uint32(defaultBlockSize))
+			p.d.picker.abortDownload(event.Req.PieceIndex, bi)
+
+			// Remove matching entry from requestQueue if present.
+			p.rqMu.Lock()
+			for i, b := range p.requestQueue {
+				if b.pieceIndex == event.Req.PieceIndex &&
+					int(event.Req.Begin/uint32(defaultBlockSize)) == b.blockIndex {
+					p.requestQueue = append(p.requestQueue[:i], p.requestQueue[i+1:]...)
+					break
+				}
+			}
+			p.rqMu.Unlock()
 		case proto.AllowedFast:
 			if event.Index >= p.d.info.NumPieces {
 				p.log.Debug().Uint32("index", event.Index).Msg("peer send 'AllowedFast' message with invalid index")
@@ -766,14 +826,11 @@ func (p *Peer) resIsValid(res *proto.ChunkResponse) bool {
 	}
 
 	reqTime, ok := p.myRequests.LoadAndDelete(r)
-
-	dur := time.Since(reqTime)
-
-	p.rttMutex.Lock()
-
-	p.rttAverage.Push(dur)
-
-	p.rttMutex.Unlock()
+	if ok {
+		p.rttMutex.Lock()
+		p.rttAverage.Push(time.Since(reqTime))
+		p.rttMutex.Unlock()
+	}
 
 	return ok
 }

--- a/internal/core/p.go
+++ b/internal/core/p.go
@@ -102,7 +102,6 @@ func newPeer(
 
 		UserAgent: *atomic.NewPointer(&ua),
 
-
 		responseCond: gsync.NewCond(gsync.EmptyLock{}),
 
 		//ResChan:   make(chan req.Response, 1),
@@ -144,17 +143,17 @@ type Peer struct {
 	lastSend          atomic.Time
 	snubbedAt         atomic.Time
 	lastUnchokeAt     atomic.Time
-	Rejected          *xsync.Map[proto.ChunkRequest, empty.Empty]
-	UserAgent         atomic.Pointer[string]
+	pieceDownloadRate *flowrate.Monitor
+	Bitmap            *bm.Bitmap
 	myRequests        *xsync.Map[proto.ChunkRequest, time.Time]
 	myRequestHistory  *xsync.Map[proto.ChunkRequest, empty.Empty]
 	d                 *Download
-	pieceDownloadRate *flowrate.Monitor
+	Rejected          *xsync.Map[proto.ChunkRequest, empty.Empty]
 	allowFast         *bm.Bitmap
 	peerRequests      *xsync.Map[proto.ChunkRequest, empty.Empty]
 	cancel            context.CancelFunc
-	Bitmap            *bm.Bitmap
-	blockRequests     chan pieceBlock // receives blocks from scheduler (replaces ourPieceRequests)
+	UserAgent         atomic.Pointer[string]
+	blockRequests     chan pieceBlock
 	responseCond      *gsync.Cond
 	peerID            atomic.Pointer[proto.PeerID]
 	pieceDone         chan struct{}
@@ -162,9 +161,9 @@ type Peer struct {
 	r                 *bufio.Reader
 	pieceUploadRate   *flowrate.Monitor
 	Address           netip.AddrPort
-	requestQueue      []pieceBlock // blocks to be sent as wire requests (mirrors m_request_queue)
-	rqMu              sync.Mutex
+	requestQueue      []pieceBlock
 	rttAverage        sizedSlice[time.Duration]
+	disconnecting     atomic.Bool
 	isSeed            atomic.Bool
 	QueueLimit        atomic.Uint32
 	desiredQueueSize  atomic.Int32
@@ -178,6 +177,7 @@ type Peer struct {
 	endgame           atomic.Bool
 	rttMutex          sync.RWMutex
 	wm                sync.Mutex
+	rqMu              sync.Mutex
 	extDontHaveID     gsync.AtomicUint[proto.ExtensionMessage]
 	extPexID          gsync.AtomicUint[proto.ExtensionMessage]
 	id                uint32
@@ -188,7 +188,6 @@ type Peer struct {
 	dhtEnabled        bool
 	subExtensions     bool
 	hadTransfer       bool
-	disconnecting     atomic.Bool
 }
 
 func (p *Peer) Response(res *proto.ChunkResponse) bool {
@@ -269,7 +268,6 @@ func (p *Peer) close() {
 }
 
 func (p *Peer) ourRequestHandle() {
-
 	for {
 		select {
 		case <-p.ctx.Done():
@@ -354,14 +352,7 @@ func (p *Peer) updateDesiredQueueSize() int {
 
 	// Rate-based: keep requestQueueTime seconds of pipeline
 	dlRate := p.pieceDownloadRate.Status().CurRate
-	queueSize := requestQueueTime * int(dlRate) / int(defaultBlockSize)
-
-	if queueSize < minRequestQueue {
-		queueSize = minRequestQueue
-	}
-	if queueSize > maxRequestQueue {
-		queueSize = maxRequestQueue
-	}
+	queueSize := min(max(requestQueueTime*int(dlRate)/int(defaultBlockSize), minRequestQueue), maxRequestQueue)
 
 	// Also respect peer's advertised queue limit
 	peerLimit := int(p.QueueLimit.Load())
@@ -408,7 +399,6 @@ func (p *Peer) setEndgame(v bool) {
 func (p *Peer) isDisconnecting() bool {
 	return p.disconnecting.Load()
 }
-
 
 func (p *Peer) checkRequestTimeouts() {
 	const pieceTimeout = 30 * time.Second
@@ -617,7 +607,7 @@ func (p *Peer) start(skipHandshake bool) {
 
 			if p.snubbed.Load() {
 				p.snubbed.Store(false)
-							p.desiredQueueSize.Store(1)
+				p.desiredQueueSize.Store(1)
 				p.log.Info().Msg("peer un-snubbed: responding again")
 			}
 

--- a/internal/core/peer_list.go
+++ b/internal/core/peer_list.go
@@ -44,14 +44,14 @@ func sourceRank(source peerSource) int {
 // persistentPeer mirrors libtorrent's torrent_peer — permanent peer metadata
 // that survives connection/disconnection cycles.
 type persistentPeer struct {
+	connection  *Peer
 	addrPort    netip.AddrPort
-	connection  *Peer // non-nil when connected
-	lastSeen    int64 // unix timestamp of last connect or disconnect
-	failcount   uint8 // number of consecutive failed connection attempts
+	lastSeen    int64
+	failcount   uint8
 	source      peerSource
-	connectable bool // has advertised a listen port
-	seed        bool // confirmed seed
-	hadTrans    bool // transferred data during last connection
+	connectable bool
+	seed        bool
+	hadTrans    bool
 }
 
 // isConnectCandidate returns true if this peer is eligible for connection.
@@ -78,30 +78,15 @@ func (p *persistentPeer) isConnectCandidate(finished bool, maxFailcount int) boo
 // Peers are stored sorted by address for O(log n) lookup. A separate candidate
 // cache holds connectable peers in priority order for O(1) pop.
 type peerList struct {
-	mu sync.Mutex
-
-	peers []*persistentPeer // sorted by addrPort for binary search
-
-	// pre-computed list of connect candidates, sorted by priority
-	candidateCache []*persistentPeer
-
-	// number of connect candidates (kept in sync with reality)
+	d                    *Download
+	peers                []*persistentPeer
+	candidateCache       []*persistentPeer
 	numConnectCandidates int
-
-	// whether we are finished downloading (seeds are excluded when true)
-	finished bool
-
-	// round-robin index for scanning the peer list
-	roundRobin int
-
-	// max failcount before a peer is excluded as candidate
-	maxFailcount int
-
-	// minimum time (seconds) between connection attempts to the same peer
-	minReconnectTime int64
-
-	// pointer to the torrent for session_time and priority computation
-	d *Download
+	roundRobin           int
+	maxFailcount         int
+	minReconnectTime     int64
+	mu                   sync.Mutex
+	finished             bool
 }
 
 func newPeerList(d *Download) *peerList {
@@ -112,9 +97,9 @@ func newPeerList(d *Download) *peerList {
 	}
 }
 
-// addPeer adds or updates a peer. Returns the persistentPeer (new or existing).
+// addPeer adds or updates a peer.
 // Mirrors libtorrent's peer_list::add_peer().
-func (pl *peerList) addPeer(addr netip.AddrPort, source peerSource, connectable bool) *persistentPeer {
+func (pl *peerList) addPeer(addr netip.AddrPort, source peerSource, connectable bool) {
 	pl.mu.Lock()
 	defer pl.mu.Unlock()
 
@@ -123,7 +108,7 @@ func (pl *peerList) addPeer(addr netip.AddrPort, source peerSource, connectable 
 	if found {
 		p := pl.peers[idx]
 		pl.updatePeerLocked(p, source, connectable)
-		return p
+		return
 	}
 
 	p := &persistentPeer{
@@ -142,8 +127,6 @@ func (pl *peerList) addPeer(addr netip.AddrPort, source peerSource, connectable 
 			pl.candidateCache = append(pl.candidateCache, p)
 		}
 	}
-
-	return p
 }
 
 // updatePeerLocked updates an existing peer's metadata. Caller holds pl.mu.
@@ -221,12 +204,7 @@ func (pl *peerList) removeFromCandidateCache(p *persistentPeer) {
 }
 
 func (pl *peerList) connectableListContains(p *persistentPeer) bool {
-	for _, c := range pl.candidateCache {
-		if c == p {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(pl.candidateCache, p)
 }
 
 // addOrUpdateIncoming ensures a peer entry exists for an incoming connection.
@@ -527,11 +505,9 @@ func (pl *peerList) peerTurnover(count int) []*Peer {
 	pl.mu.Lock()
 	defer pl.mu.Unlock()
 
-	var toDisconnect []*Peer
-
 	// collect connected peers sorted by upload rate (slowest first)
 	type connectedPeer struct {
-		p         *persistentPeer
+		p          *persistentPeer
 		uploadRate int64
 	}
 	var connected []connectedPeer
@@ -555,6 +531,7 @@ func (pl *peerList) peerTurnover(count int) []*Peer {
 		return 0
 	})
 
+	toDisconnect := make([]*Peer, 0, min(count, len(connected)))
 	for i := range min(count, len(connected)) {
 		toDisconnect = append(toDisconnect, connected[i].p.connection)
 	}
@@ -576,5 +553,3 @@ func (pl *peerList) immediateCandidate() *persistentPeer {
 	}
 	return nil
 }
-
-

--- a/internal/core/peer_list.go
+++ b/internal/core/peer_list.go
@@ -1,0 +1,580 @@
+// Copyright 2024 trim21 <trim21.me@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package core
+
+import (
+	"net/netip"
+	"slices"
+	"sync"
+)
+
+// peerSource mirrors libtorrent's peer_source_flags_t.
+type peerSource uint8
+
+const (
+	peerSourceTracker    peerSource = 1 << 0
+	peerSourceDHT        peerSource = 1 << 1
+	peerSourcePEX        peerSource = 1 << 2
+	peerSourceLSD        peerSource = 1 << 3
+	peerSourceResumeData peerSource = 1 << 4
+	peerSourceIncoming   peerSource = 1 << 5
+)
+
+// sourceRank returns a priority score for a peer source.
+// Higher rank = higher priority for connection.
+// Mirrors libtorrent's source_rank().
+func sourceRank(source peerSource) int {
+	r := 0
+	if source&peerSourceTracker != 0 {
+		r |= 1 << 5
+	}
+	if source&peerSourceLSD != 0 {
+		r |= 1 << 4
+	}
+	if source&peerSourceDHT != 0 {
+		r |= 1 << 3
+	}
+	if source&peerSourcePEX != 0 {
+		r |= 1 << 2
+	}
+	return r
+}
+
+// persistentPeer mirrors libtorrent's torrent_peer — permanent peer metadata
+// that survives connection/disconnection cycles.
+type persistentPeer struct {
+	addrPort    netip.AddrPort
+	connection  *Peer // non-nil when connected
+	lastSeen    int64 // unix timestamp of last connect or disconnect
+	failcount   uint8 // number of consecutive failed connection attempts
+	source      peerSource
+	connectable bool // has advertised a listen port
+	seed        bool // confirmed seed
+	hadTrans    bool // transferred data during last connection
+}
+
+// isConnectCandidate returns true if this peer is eligible for connection.
+// Mirrors libtorrent's is_connect_candidate().
+func (p *persistentPeer) isConnectCandidate(finished bool, maxFailcount int) bool {
+	if p.connection != nil {
+		return false
+	}
+	if !p.connectable {
+		return false
+	}
+	if p.seed && finished {
+		return false
+	}
+	if int(p.failcount) >= maxFailcount {
+		return false
+	}
+	return true
+}
+
+// peerList mirrors libtorrent's peer_list — persistent storage of all known
+// peers with pre-computed connect candidate cache.
+//
+// Peers are stored sorted by address for O(log n) lookup. A separate candidate
+// cache holds connectable peers in priority order for O(1) pop.
+type peerList struct {
+	mu sync.Mutex
+
+	peers []*persistentPeer // sorted by addrPort for binary search
+
+	// pre-computed list of connect candidates, sorted by priority
+	candidateCache []*persistentPeer
+
+	// number of connect candidates (kept in sync with reality)
+	numConnectCandidates int
+
+	// whether we are finished downloading (seeds are excluded when true)
+	finished bool
+
+	// round-robin index for scanning the peer list
+	roundRobin int
+
+	// max failcount before a peer is excluded as candidate
+	maxFailcount int
+
+	// minimum time (seconds) between connection attempts to the same peer
+	minReconnectTime int64
+
+	// pointer to the torrent for session_time and priority computation
+	d *Download
+}
+
+func newPeerList(d *Download) *peerList {
+	return &peerList{
+		d:                d,
+		maxFailcount:     3,
+		minReconnectTime: 60,
+	}
+}
+
+// addPeer adds or updates a peer. Returns the persistentPeer (new or existing).
+// Mirrors libtorrent's peer_list::add_peer().
+func (pl *peerList) addPeer(addr netip.AddrPort, source peerSource, connectable bool) *persistentPeer {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+
+	// binary search by addrPort
+	idx, found := pl.findPeer(addr)
+	if found {
+		p := pl.peers[idx]
+		pl.updatePeerLocked(p, source, connectable)
+		return p
+	}
+
+	p := &persistentPeer{
+		addrPort:    addr,
+		source:      source,
+		connectable: connectable,
+		lastSeen:    0,
+	}
+
+	// insert maintaining sorted order
+	pl.peers = slices.Insert(pl.peers, idx, p)
+
+	if p.isConnectCandidate(pl.finished, pl.maxFailcount) {
+		pl.numConnectCandidates++
+		if !pl.connectableListContains(p) {
+			pl.candidateCache = append(pl.candidateCache, p)
+		}
+	}
+
+	return p
+}
+
+// updatePeerLocked updates an existing peer's metadata. Caller holds pl.mu.
+// Mirrors libtorrent's peer_list::update_peer().
+func (pl *peerList) updatePeerLocked(p *persistentPeer, source peerSource, connectable bool) {
+	wasConnCand := p.isConnectCandidate(pl.finished, pl.maxFailcount)
+
+	p.source |= source
+	if connectable {
+		p.connectable = true
+	}
+
+	// if source is tracker, reset failcount so the peer gets a fresh chance
+	if source&peerSourceTracker != 0 {
+		p.failcount = 0
+	}
+
+	isConnCand := p.isConnectCandidate(pl.finished, pl.maxFailcount)
+	if wasConnCand && !isConnCand {
+		pl.numConnectCandidates--
+		pl.removeFromCandidateCache(p)
+	} else if !wasConnCand && isConnCand {
+		pl.numConnectCandidates++
+		if !pl.connectableListContains(p) {
+			pl.candidateCache = append(pl.candidateCache, p)
+		}
+	}
+}
+
+// findPeer binary-searches for a peer by addrPort. Returns the index where
+// it was found or should be inserted, and whether it was found.
+func (pl *peerList) findPeer(addr netip.AddrPort) (int, bool) {
+	idx := sortSearch(len(pl.peers), func(i int) bool {
+		return addrLess(addr, pl.peers[i].addrPort)
+	})
+	if idx < len(pl.peers) && pl.peers[idx].addrPort == addr {
+		return idx, true
+	}
+	return idx, false
+}
+
+func sortSearch(n int, f func(int) bool) int {
+	i, j := 0, n
+	for i < j {
+		h := int(uint(i+j) >> 1)
+		if !f(h) {
+			i = h + 1
+		} else {
+			j = h
+		}
+	}
+	return i
+}
+
+func addrLess(a, b netip.AddrPort) bool {
+	// compare address first
+	ab := a.Addr().Compare(b.Addr())
+	if ab < 0 {
+		return true
+	}
+	if ab > 0 {
+		return false
+	}
+	// same address, compare port
+	return a.Port() < b.Port()
+}
+
+func (pl *peerList) removeFromCandidateCache(p *persistentPeer) {
+	for i, c := range pl.candidateCache {
+		if c == p {
+			pl.candidateCache = slices.Delete(pl.candidateCache, i, i+1)
+			return
+		}
+	}
+}
+
+func (pl *peerList) connectableListContains(p *persistentPeer) bool {
+	for _, c := range pl.candidateCache {
+		if c == p {
+			return true
+		}
+	}
+	return false
+}
+
+// addOrUpdateIncoming ensures a peer entry exists for an incoming connection.
+// Returns true if this is a duplicate connection (peer already has connection).
+func (pl *peerList) addOrUpdateIncoming(addr netip.AddrPort, sessionTime int64, conn *Peer) (rejectDuplicate bool) {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+
+	idx, found := pl.findPeer(addr)
+	if found {
+		pp := pl.peers[idx]
+		if pp.connection != nil {
+			return true // duplicate, reject
+		}
+		wasConnCand := pp.isConnectCandidate(pl.finished, pl.maxFailcount)
+		pp.connection = conn
+		pp.lastSeen = sessionTime
+		pp.source |= peerSourceIncoming
+		pp.connectable = true
+		if wasConnCand {
+			pl.numConnectCandidates--
+			pl.removeFromCandidateCache(pp)
+		}
+		return false
+	}
+
+	pp := &persistentPeer{
+		addrPort:    addr,
+		source:      peerSourceIncoming,
+		connectable: false, // incoming peers are unknown until they advertise port
+		connection:  conn,
+		lastSeen:    sessionTime,
+	}
+	pl.peers = slices.Insert(pl.peers, idx, pp)
+	return false
+}
+
+// newConnection attaches a connection to an existing peer entry.
+// Returns false if the peer wasn't found in the list.
+func (pl *peerList) newConnection(addr netip.AddrPort, conn *Peer, sessionTime int64) bool {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+
+	idx, found := pl.findPeer(addr)
+	if !found {
+		return false
+	}
+
+	pp := pl.peers[idx]
+
+	if pp.connection != nil {
+		return false
+	}
+
+	wasConnCand := pp.isConnectCandidate(pl.finished, pl.maxFailcount)
+
+	pp.connection = conn
+	pp.lastSeen = sessionTime
+	pp.connectable = true
+
+	if wasConnCand {
+		pl.numConnectCandidates--
+		pl.removeFromCandidateCache(pp)
+	}
+
+	return true
+}
+
+// connectionClosed is called when a peer connection closes.
+// Mirrors libtorrent's peer_list::connection_closed().
+func (pl *peerList) connectionClosed(addr netip.AddrPort, sessionTime int64, hadTrans bool, failed bool) {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+
+	idx, found := pl.findPeer(addr)
+	if !found {
+		return
+	}
+
+	pp := pl.peers[idx]
+	pp.connection = nil
+	pp.hadTrans = pp.hadTrans || hadTrans
+
+	// Update lastSeen unless we allow fast reconnect
+	// fast reconnect is used when the peer had transfers
+	if !hadTrans {
+		pp.lastSeen = sessionTime
+	}
+
+	if failed {
+		if pp.failcount < 31 {
+			pp.failcount++
+		}
+	}
+
+	if pp.isConnectCandidate(pl.finished, pl.maxFailcount) {
+		pl.numConnectCandidates++
+		if !pl.connectableListContains(pp) {
+			pl.candidateCache = append(pl.candidateCache, pp)
+		}
+	}
+}
+
+// connectOnePeer picks and returns the best connect candidate.
+// Returns nil if no candidates are available.
+// Mirrors libtorrent's peer_list::connect_one_peer().
+func (pl *peerList) connectOnePeer(sessionTime int64) *persistentPeer {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+
+	// purge stale entries from candidate cache
+	pl.candidateCache = slices.DeleteFunc(pl.candidateCache, func(p *persistentPeer) bool {
+		return !p.isConnectCandidate(pl.finished, pl.maxFailcount)
+	})
+
+	if len(pl.candidateCache) == 0 {
+		pl.findConnectCandidates(sessionTime)
+		if len(pl.candidateCache) == 0 {
+			return nil
+		}
+	}
+
+	// pop the best candidate
+	p := pl.candidateCache[0]
+	pl.candidateCache = pl.candidateCache[1:]
+
+	return p
+}
+
+// findConnectCandidates rebuilds the candidate cache by scanning the peer list.
+// Mirrors libtorrent's peer_list::find_connect_candidates().
+func (pl *peerList) findConnectCandidates(sessionTime int64) {
+	const candidateCount = 10
+	pl.candidateCache = make([]*persistentPeer, 0, candidateCount)
+
+	if len(pl.peers) == 0 {
+		return
+	}
+
+	if pl.roundRobin >= len(pl.peers) {
+		pl.roundRobin = 0
+	}
+
+	// scan up to 300 peers starting from roundRobin
+	maxIter := min(len(pl.peers), 300)
+	for range maxIter {
+		if pl.roundRobin >= len(pl.peers) {
+			pl.roundRobin = 0
+		}
+
+		pp := pl.peers[pl.roundRobin]
+		pl.roundRobin++
+
+		if !pp.isConnectCandidate(pl.finished, pl.maxFailcount) {
+			continue
+		}
+
+		// Check reconnect time: failcount-based backoff
+		// Mirrors libtorrent: (failcount + 1) * min_reconnect_time
+		if pp.lastSeen > 0 {
+			backoff := int64(pp.failcount+1) * pl.minReconnectTime
+			if sessionTime-pp.lastSeen < backoff {
+				continue
+			}
+		}
+
+		// Skip if hadTrans (these get immediate reconnect and shouldn't
+		// be waiting in the general candidate pool)
+		if pp.hadTrans {
+			continue
+		}
+
+		pl.candidateCache = append(pl.candidateCache, pp)
+		if len(pl.candidateCache) >= candidateCount {
+			break
+		}
+	}
+
+	// sort by priority: failcount ascending, then source rank, then BEP40
+
+	slices.SortFunc(pl.candidateCache, func(a, b *persistentPeer) int {
+		// lower failcount first
+		if a.failcount != b.failcount {
+			return int(a.failcount) - int(b.failcount)
+		}
+
+		// local peers first (simplified: just check if private/link-local)
+		// TODO: proper is_local check
+
+		// source rank (tracker > DHT > LSD > PEX)
+		ra := sourceRank(a.source)
+		rb := sourceRank(b.source)
+		if ra != rb {
+			return rb - ra
+		}
+
+		// BEP40 priority (higher is better for swarm diversity)
+		pa := pl.d.c.PeerPriority(a.addrPort)
+		pb := pl.d.c.PeerPriority(b.addrPort)
+		if pa != pb {
+			return int(pb) - int(pa)
+		}
+
+		return 0
+	})
+}
+
+// incFailcount increments a peer's failcount. Called when a connection attempt fails.
+func (pl *peerList) incFailcount(p *persistentPeer) {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+
+	if p.failcount == 31 {
+		return
+	}
+
+	wasConnCand := p.isConnectCandidate(pl.finished, pl.maxFailcount)
+	p.failcount++
+	if wasConnCand && !p.isConnectCandidate(pl.finished, pl.maxFailcount) {
+		pl.numConnectCandidates--
+		pl.removeFromCandidateCache(p)
+	}
+}
+
+// setFinished updates the finished flag and recalculates candidates.
+func (pl *peerList) setFinished(v bool) {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+
+	if pl.finished == v {
+		return
+	}
+	pl.finished = v
+
+	// recalculate candidates
+	pl.numConnectCandidates = 0
+	pl.candidateCache = pl.candidateCache[:0]
+	for _, p := range pl.peers {
+		if p.isConnectCandidate(pl.finished, pl.maxFailcount) {
+			pl.numConnectCandidates++
+		}
+	}
+}
+
+// numConnectCandidates returns the count (lock-free approximation).
+func (pl *peerList) numCandidates() int {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+	return pl.numConnectCandidates
+}
+
+// updateConnectable updates a peer's connectable flag when they advertise a port.
+func (pl *peerList) updateConnectable(addr netip.AddrPort, connectable bool) {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+
+	idx, found := pl.findPeer(addr)
+	if !found {
+		return
+	}
+
+	p := pl.peers[idx]
+	if p.connectable == connectable {
+		return
+	}
+
+	wasConnCand := p.isConnectCandidate(pl.finished, pl.maxFailcount)
+	p.connectable = connectable
+	isConnCand := p.isConnectCandidate(pl.finished, pl.maxFailcount)
+
+	if wasConnCand && !isConnCand {
+		pl.numConnectCandidates--
+		pl.removeFromCandidateCache(p)
+	} else if !wasConnCand && isConnCand {
+		pl.numConnectCandidates++
+	}
+}
+
+// hasPeer checks if a peer exists in the list.
+func (pl *peerList) hasPeer(addr netip.AddrPort) bool {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+
+	_, found := pl.findPeer(addr)
+	return found
+}
+
+// count returns the total number of peers in the list.
+func (pl *peerList) count() int {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+	return len(pl.peers)
+}
+
+// peerTurnover disconnects up to 'count' slow peers to make room for new ones.
+// Mirrors libtorrent's disconnect_peers with optimistic_disconnect.
+func (pl *peerList) peerTurnover(count int) []*Peer {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+
+	var toDisconnect []*Peer
+
+	// collect connected peers sorted by upload rate (slowest first)
+	type connectedPeer struct {
+		p         *persistentPeer
+		uploadRate int64
+	}
+	var connected []connectedPeer
+	for _, pp := range pl.peers {
+		if pp.connection != nil && !pp.connection.closed.Load() {
+			connected = append(connected, connectedPeer{
+				p:          pp,
+				uploadRate: pp.connection.pieceUploadRate.Status().CurRate,
+			})
+		}
+	}
+
+	// sort by upload rate ascending (slowest first)
+	slices.SortFunc(connected, func(a, b connectedPeer) int {
+		if a.uploadRate < b.uploadRate {
+			return -1
+		}
+		if a.uploadRate > b.uploadRate {
+			return 1
+		}
+		return 0
+	})
+
+	for i := range min(count, len(connected)) {
+		toDisconnect = append(toDisconnect, connected[i].p.connection)
+	}
+
+	return toDisconnect
+}
+
+// immediateCandidate returns a single peer that has hadTrans=true for immediate
+// fast reconnect. Returns nil if none found.
+func (pl *peerList) immediateCandidate() *persistentPeer {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+
+	for _, pp := range pl.peers {
+		if pp.hadTrans && pp.connection == nil && pp.connectable {
+			pp.hadTrans = false // consume the flag
+			return pp
+		}
+	}
+	return nil
+}
+
+

--- a/internal/core/piece_picker.go
+++ b/internal/core/piece_picker.go
@@ -1,0 +1,663 @@
+// Copyright 2024 trim21 <trim21.me@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package core
+
+import (
+	"slices"
+	"sync"
+
+	"neptune/internal/meta"
+	"neptune/internal/pkg/bm"
+)
+
+// blockState represents the state of an individual block within a piece.
+type blockState uint8
+
+const (
+	blockStateNone      blockState = iota // block is free, not yet requested
+	blockStateRequested                   // block is currently requested from a peer
+	blockStateWriting                     // block data is being written to disk
+	blockStateFinished                    // block has been written to disk
+)
+
+// blockInfo tracks per-block metadata: which peer requested it, how many peers
+// have it in their queues, and the current state.
+type blockInfo struct {
+	// peer that requested this block (nil if none)
+	peer *Peer
+	// number of peers that have this block in their download or request queue
+	numPeers uint16
+	// current state of this block
+	state blockState
+}
+
+// downloadingPiece represents a piece that is partially downloaded.
+type downloadingPiece struct {
+	index              uint32 // piece index
+	infoIdx            int    // index into m_blockInfos where this piece's blocks start
+	blocksInPiece      uint16 // total number of blocks in this piece
+	finished           uint16 // number of blocks in the finished state
+	writing            uint16 // number of blocks in the writing state
+	requested          uint16 // number of blocks in the requested state
+	passedHashCheck    bool   // set to true after hash check passes
+	locked             bool   // set during hash checking/writing
+}
+
+// piecePriority computes a score for a piece.
+// Higher score = more urgent. Mirrors libtorrent: (availability + 1) * priority_factor.
+const priorityFactor = 3
+
+// piecePicker is a global block-level piece picker, mirroring libtorrent's
+// piece_picker. It centralizes tracking of which blocks are requested/writing/
+// finished, and provides block-level selection for peers.
+//
+// All public methods are safe for concurrent use.
+type piecePicker struct {
+	mu sync.Mutex
+
+	// number of pieces
+	numPieces uint32
+	// blocks per piece
+	blocksPerPiece uint32
+	// size of each block
+	blockSize int64
+
+	// piece availability: availability[i] = number of peers that have piece i
+	availability []uint16
+
+	// piece priority boundaries, sorted by priority descending.
+	// pieces[i] is a piece index in the open (not yet downloading) set.
+	pieces []uint32
+
+	// piece priorities
+	piecePriorities []uint32
+
+	// whether the priority array is dirty and needs re-sorting
+	dirty bool
+
+	// downloading pieces, sorted by piece index for O(log n) lookup
+	downloadingPieces []downloadingPiece
+
+	// flat array of block info for all pieces. grouped by piece.
+	// blockInfos[piece_info_idx:piece_info_idx+blocksPerPiece] belong to the same piece.
+	blockInfos []blockInfo
+
+	// number of blocks in the requested state across all pieces
+	downloadQueueSize int
+
+	// number of pieces we want that are not yet picked (mirrors num_want_left)
+	numWantLeft int
+}
+
+// newPiecePicker creates a new piece picker for the given torrent info.
+func newPiecePicker(info meta.Info) *piecePicker {
+	numPieces := info.NumPieces
+	blocksPerPiece := uint32((info.PieceLength + defaultBlockSize - 1) / defaultBlockSize)
+
+	pp := &piecePicker{
+		numPieces:      numPieces,
+		blocksPerPiece: blocksPerPiece,
+		blockSize:      defaultBlockSize,
+		availability:   make([]uint16, numPieces),
+		piecePriorities: make([]uint32, numPieces),
+		pieces:         make([]uint32, numPieces),
+		dirty:          true,
+		blockInfos:     make([]blockInfo, int(numPieces)*int(blocksPerPiece)),
+	}
+
+	// initialize pieces array
+	for i := range numPieces {
+		pp.pieces[i] = i
+		pp.piecePriorities[i] = 1 * priorityFactor // initial priority = (0+1)*3
+	}
+
+	// initialize block info array: set piece_index for each block
+	// (for debugging only — removed in production build)
+
+	return pp
+}
+
+// numBlocksInPiece returns the number of blocks in the given piece.
+func (pp *piecePicker) numBlocksInPiece(info meta.Info, pieceIndex uint32) uint16 {
+	pieceSize := info.PieceLength
+	if pieceIndex == info.NumPieces-1 {
+		pieceSize = info.LastPieceSize
+	}
+	return uint16((pieceSize + defaultBlockSize - 1) / defaultBlockSize)
+}
+
+// blockInfoIdx returns the starting index in blockInfos for the given piece.
+func (pp *piecePicker) blockInfoIdx(pieceIndex uint32) int {
+	return int(pieceIndex) * int(pp.blocksPerPiece)
+}
+
+// incRefcount increments the reference count for all blocks in the given piece.
+// Called when a peer acquires a piece (bitfield/have).
+func (pp *piecePicker) incRefcount(pieceIndex uint32) {
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+
+	pp.availability[pieceIndex]++
+	if pp.availability[pieceIndex] == 1 {
+		// piece went from unavailable to available
+		pp.dirty = true
+	}
+}
+
+// decRefcount decrements the reference count for all blocks in the given piece.
+// Called when a peer loses a piece (disconnect, dont_have).
+func (pp *piecePicker) decRefcount(pieceIndex uint32) {
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+
+	if pp.availability[pieceIndex] > 0 {
+		pp.availability[pieceIndex]--
+	}
+	if pp.availability[pieceIndex] == 0 {
+		pp.dirty = true
+	}
+}
+
+// weHave marks a piece as completed (we now have it).
+// It clears all block states for that piece.
+func (pp *piecePicker) weHave(pieceIndex uint32) {
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+
+	idx := pp.blockInfoIdx(pieceIndex)
+	blocksInPiece := int(pp.blocksPerPiece)
+	for i := range blocksInPiece {
+		bi := &pp.blockInfos[idx+i]
+		if bi.state == blockStateRequested {
+			pp.downloadQueueSize--
+		}
+		bi.state = blockStateFinished
+		bi.peer = nil
+		bi.numPeers = 0
+	}
+	pp.dirty = true
+}
+
+// markAsWriting marks a block as being written to disk.
+func (pp *piecePicker) markAsWriting(pieceIndex uint32, blockIndex int) {
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+
+	idx := pp.blockInfoIdx(pieceIndex) + blockIndex
+	bi := &pp.blockInfos[idx]
+	oldState := bi.state
+	if bi.state == blockStateRequested {
+		pp.downloadQueueSize--
+	}
+	bi.state = blockStateWriting
+	bi.peer = nil
+
+	// Update downloadingPiece counters
+	if dp := pp.findDownloadingPiece(pieceIndex); dp != nil {
+		if oldState == blockStateRequested {
+			dp.requested--
+		}
+		dp.writing++
+	}
+}
+
+// markAsFinished marks a block as having been written to disk.
+func (pp *piecePicker) markAsFinished(pieceIndex uint32, blockIndex int) {
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+
+	idx := pp.blockInfoIdx(pieceIndex) + blockIndex
+	bi := &pp.blockInfos[idx]
+	oldState := bi.state
+	bi.state = blockStateFinished
+	bi.peer = nil
+
+	// Update downloadingPiece counters
+	if dp := pp.findDownloadingPiece(pieceIndex); dp != nil {
+		if oldState == blockStateWriting {
+			dp.writing--
+		}
+		dp.finished++
+	}
+}
+
+// markAsRequesting marks a block as requested from a peer.
+func (pp *piecePicker) markAsRequesting(pieceIndex uint32, blockIndex int, peer *Peer) {
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+
+	idx := pp.blockInfoIdx(pieceIndex) + blockIndex
+	bi := &pp.blockInfos[idx]
+	if bi.state == blockStateNone {
+		pp.downloadQueueSize++
+	}
+	bi.state = blockStateRequested
+	bi.peer = peer
+	bi.numPeers++
+
+	// Update downloadingPiece counters
+	if dp := pp.findDownloadingPiece(pieceIndex); dp != nil {
+		dp.requested++
+	}
+}
+
+// getNumPeers returns the number of peers requesting the given block.
+func (pp *piecePicker) getNumPeers(pieceIndex uint32, blockIndex int) int {
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+
+	idx := pp.blockInfoIdx(pieceIndex) + blockIndex
+	return int(pp.blockInfos[idx].numPeers)
+}
+
+// abortDownload releases a block that was requested but not received.
+// Called when a request is canceled or times out.
+func (pp *piecePicker) abortDownload(pieceIndex uint32, blockIndex int) {
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+
+	idx := pp.blockInfoIdx(pieceIndex) + blockIndex
+	bi := &pp.blockInfos[idx]
+	if bi.state == blockStateRequested {
+		pp.downloadQueueSize--
+	}
+	bi.state = blockStateNone
+	bi.peer = nil
+	if bi.numPeers > 0 {
+		bi.numPeers--
+	}
+}
+
+
+
+
+
+// isFinished returns true if the block is finished.
+func (pp *piecePicker) isFinished(pieceIndex uint32, blockIndex int) bool {
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+
+	idx := pp.blockInfoIdx(pieceIndex) + blockIndex
+	return pp.blockInfos[idx].state == blockStateFinished
+}
+
+
+
+
+
+// rebuildPriorities re-sorts the piece priority array.
+func (pp *piecePicker) rebuildPriorities() {
+	if !pp.dirty {
+		return
+	}
+
+	// filter out pieces that are already downloaded or downloading
+	available := make([]uint32, 0, len(pp.pieces))
+	for _, pi := range pp.pieces {
+		idx := pp.blockInfoIdx(pi)
+		// check if this piece is already downloading
+		isDownloading := false
+		for i := range int(pp.blocksPerPiece) {
+			s := pp.blockInfos[idx+i].state
+			if s == blockStateRequested || s == blockStateWriting {
+				isDownloading = true
+				break
+			}
+			if s == blockStateFinished && i == 0 {
+				// first block finished means piece is likely downloaded
+				allFinished := true
+				for j := range int(pp.blocksPerPiece) {
+					if pp.blockInfos[idx+j].state != blockStateFinished {
+						allFinished = false
+						break
+					}
+				}
+				if allFinished {
+					isDownloading = true
+					break
+				}
+			}
+		}
+		if !isDownloading {
+			available = append(available, pi)
+		}
+	}
+
+	// sort by priority descending, then by piece index
+	slices.SortFunc(available, func(a, b uint32) int {
+		pa := pp.piecePriorities[a]
+		pb := pp.piecePriorities[b]
+		if pa != pb {
+			if pa > pb {
+				return -1
+			}
+			return 1
+		}
+		if a < b {
+			return -1
+		}
+		return 1
+	})
+
+	pp.pieces = available
+	pp.numWantLeft = len(available)
+	pp.dirty = false
+}
+
+// updatePiecePriority recalculates the priority for a piece based on its availability.
+func (pp *piecePicker) updatePiecePriority(pieceIndex uint32) {
+	avail := pp.availability[pieceIndex]
+	if avail == 0 {
+		avail = 1 // ensure positive priority
+	}
+	pp.piecePriorities[pieceIndex] = uint32(avail+1) * priorityFactor
+}
+
+// pieceBlock represents a specific block (piece index + block index).
+type pieceBlock struct {
+	pieceIndex uint32
+	blockIndex int
+}
+
+// pickResult holds the result of pickPieces.
+type pickResult struct {
+	// Free blocks (not requested by any peer)
+	freeBlocks []pieceBlock
+	// Busy blocks (already requested by another peer), for endgame fallback.
+	busyBlocks []pieceBlock
+}
+
+// pickPieces picks blocks for a peer using rarest-first strategy.
+//
+// Parameters:
+//   - bitfield: pieces the peer has
+//   - choked: whether the peer has us choked (only allowed fast pieces)
+//   - allowedFast: bitmap of allowed fast pieces
+//   - numBlocks: desired number of blocks to pick
+//   - preferContiguous: >0 means prefer whole pieces, value is the number of contiguous blocks
+//   - suggestedPieces: pieces suggested by the peer
+//   - info: torrent metadata for block counts
+//
+// It first prioritizes partial pieces (highest progress first), then uses rarest-first.
+func (pp *piecePicker) pickPieces(
+	bitfield *bm.Bitmap,
+	choked bool,
+	allowedFast *bm.Bitmap,
+	numBlocks int,
+	preferContiguous int,
+	suggestedPieces []uint32,
+	info meta.Info,
+) pickResult {
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+
+	pp.rebuildPriorities()
+
+	var result pickResult
+
+	// Build list of pieces that are open (not yet downloading) and the peer has them
+	var openPieces []uint32
+	for _, pi := range pp.pieces {
+		if !bitfield.Contains(pi) {
+			continue
+		}
+		if choked && !allowedFast.Contains(pi) {
+			continue
+		}
+		openPieces = append(openPieces, pi)
+	}
+
+	// Update priorities for open pieces
+	for _, pi := range openPieces {
+		pp.updatePiecePriority(pi)
+	}
+	pp.dirty = true
+	pp.rebuildPriorities()
+
+	// Phase 1: partial pieces (pieces in downloading state with some blocks finished)
+	type partialInfo struct {
+		pieceIndex uint32
+		blockCount int // number of blocks this peer can use from this piece
+	}
+	var partials []partialInfo
+
+	for _, dp := range pp.downloadingPieces {
+		if !bitfield.Contains(dp.index) {
+			continue
+		}
+		if choked && !allowedFast.Contains(dp.index) {
+			continue
+		}
+
+		idx := pp.blockInfoIdx(dp.index)
+		freeBlocks := 0
+		for i := range int(dp.blocksInPiece) {
+			bi := &pp.blockInfos[idx+i]
+			if bi.state == blockStateNone {
+				freeBlocks++
+			}
+		}
+		if freeBlocks > 0 {
+			partials = append(partials, partialInfo{dp.index, freeBlocks})
+		}
+	}
+
+	// Sort partials by priority (using rarest-first on availability)
+	slices.SortFunc(partials, func(a, b partialInfo) int {
+		pa := pp.piecePriorities[a.pieceIndex]
+		pb := pp.piecePriorities[b.pieceIndex]
+		if pa > pb {
+			return -1
+		}
+		if pa < pb {
+			return 1
+		}
+		return 0
+	})
+
+	// Pick from partial pieces first
+	for _, p := range partials {
+		if numBlocks <= 0 {
+			break
+		}
+		idx := pp.blockInfoIdx(p.pieceIndex)
+		dp := pp.findDownloadingPiece(p.pieceIndex)
+		if dp == nil {
+			continue
+		}
+		blocksInPiece := int(dp.blocksInPiece)
+		for i := range blocksInPiece {
+			bi := &pp.blockInfos[idx+i]
+			if bi.state == blockStateNone {
+				if preferContiguous <= 0 && numBlocks > 0 {
+					result.freeBlocks = append(result.freeBlocks, pieceBlock{p.pieceIndex, i})
+					numBlocks--
+				}
+			} else if bi.state == blockStateRequested {
+				// busy block — only used in endgame
+				if bi.numPeers > 0 {
+					result.busyBlocks = append(result.busyBlocks, pieceBlock{p.pieceIndex, i})
+				}
+			}
+		}
+	}
+
+	// Phase 2: suggested pieces
+	for _, pi := range suggestedPieces {
+		if numBlocks <= 0 {
+			break
+		}
+		if !bitfield.Contains(pi) {
+			continue
+		}
+		if choked && !allowedFast.Contains(pi) {
+			continue
+		}
+		pp.pickBlocksFromPiece(pi, info, &numBlocks, preferContiguous, &result)
+	}
+
+	// Phase 3: rarest-first from open pieces
+	for _, pi := range openPieces {
+		if numBlocks <= 0 {
+			break
+		}
+		// skip if already picked from this piece
+		alreadyPicked := false
+		for _, fb := range result.freeBlocks {
+			if fb.pieceIndex == pi {
+				alreadyPicked = true
+				break
+			}
+		}
+		if alreadyPicked {
+			continue
+		}
+		pp.pickBlocksFromPiece(pi, info, &numBlocks, preferContiguous, &result)
+	}
+
+	return result
+}
+
+// pickBlocksFromPiece picks free blocks from a specific piece.
+func (pp *piecePicker) pickBlocksFromPiece(
+	pieceIndex uint32,
+	info meta.Info,
+	numBlocks *int,
+	preferContiguous int,
+	result *pickResult,
+) {
+	if *numBlocks <= 0 {
+		return
+	}
+
+	idx := pp.blockInfoIdx(pieceIndex)
+	nb := pp.numBlocksInPiece(info, pieceIndex)
+	blocksInPiece := int(nb)
+
+	// find free blocks
+	for i := range blocksInPiece {
+		bi := &pp.blockInfos[idx+i]
+		if bi.state == blockStateNone {
+			result.freeBlocks = append(result.freeBlocks, pieceBlock{pieceIndex, i})
+			*numBlocks--
+			if *numBlocks <= 0 {
+				return
+			}
+		} else if bi.state == blockStateRequested {
+			result.busyBlocks = append(result.busyBlocks, pieceBlock{pieceIndex, i})
+		}
+	}
+}
+
+// findDownloadingPiece finds a downloading piece by index.
+// Caller must hold pp.mu.
+func (pp *piecePicker) findDownloadingPiece(pieceIndex uint32) *downloadingPiece {
+	for i := range pp.downloadingPieces {
+		if pp.downloadingPieces[i].index == pieceIndex {
+			return &pp.downloadingPieces[i]
+		}
+	}
+	return nil
+}
+
+// addDownloadingPiece adds a piece to the downloading set.
+func (pp *piecePicker) addDownloadingPiece(pieceIndex uint32, info meta.Info) {
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+
+	// check if already added
+	for i := range pp.downloadingPieces {
+		if pp.downloadingPieces[i].index == pieceIndex {
+			return
+		}
+	}
+
+	nb := pp.numBlocksInPiece(info, pieceIndex)
+	dp := downloadingPiece{
+		index:         pieceIndex,
+		infoIdx:       pp.blockInfoIdx(pieceIndex),
+		blocksInPiece: nb,
+	}
+
+	pp.downloadingPieces = append(pp.downloadingPieces, dp)
+	// keep sorted by index for binary search
+	slices.SortFunc(pp.downloadingPieces, func(a, b downloadingPiece) int {
+		if a.index < b.index {
+			return -1
+		}
+		if a.index > b.index {
+			return 1
+		}
+		return 0
+	})
+	pp.dirty = true
+}
+
+// removeDownloadingPiece removes a piece from the downloading set.
+func (pp *piecePicker) removeDownloadingPiece(pieceIndex uint32) {
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+
+	for i := range pp.downloadingPieces {
+		if pp.downloadingPieces[i].index == pieceIndex {
+			pp.downloadingPieces = slices.Delete(pp.downloadingPieces, i, i+1)
+			pp.dirty = true
+			return
+		}
+	}
+}
+
+// countBusyBlocks returns the number of busy (requested) blocks in a piece.
+func (pp *piecePicker) countBusyBlocks(pieceIndex uint32, info meta.Info) int {
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+
+	idx := pp.blockInfoIdx(pieceIndex)
+	nb := pp.numBlocksInPiece(info, pieceIndex)
+	count := 0
+	for i := range int(nb) {
+		if pp.blockInfos[idx+i].state == blockStateRequested {
+			count++
+		}
+	}
+	return count
+}
+
+
+
+
+
+
+
+// resetPiece resets all blocks in a piece to state none (for hash check failure).
+func (pp *piecePicker) resetPiece(pieceIndex uint32, info meta.Info) {
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+
+	idx := pp.blockInfoIdx(pieceIndex)
+	nb := pp.numBlocksInPiece(info, pieceIndex)
+	for i := range int(nb) {
+		bi := &pp.blockInfos[idx+i]
+		if bi.state == blockStateRequested {
+			pp.downloadQueueSize--
+		}
+		bi.state = blockStateNone
+		bi.peer = nil
+		bi.numPeers = 0
+	}
+	pp.removeDownloadingPieceLocked(pieceIndex)
+	pp.dirty = true
+}
+
+func (pp *piecePicker) removeDownloadingPieceLocked(pieceIndex uint32) {
+	for i := range pp.downloadingPieces {
+		if pp.downloadingPieces[i].index == pieceIndex {
+			pp.downloadingPieces = slices.Delete(pp.downloadingPieces, i, i+1)
+			pp.dirty = true
+			return
+		}
+	}
+}
+
+

--- a/internal/core/piece_picker.go
+++ b/internal/core/piece_picker.go
@@ -34,14 +34,14 @@ type blockInfo struct {
 
 // downloadingPiece represents a piece that is partially downloaded.
 type downloadingPiece struct {
-	index              uint32 // piece index
-	infoIdx            int    // index into m_blockInfos where this piece's blocks start
-	blocksInPiece      uint16 // total number of blocks in this piece
-	finished           uint16 // number of blocks in the finished state
-	writing            uint16 // number of blocks in the writing state
-	requested          uint16 // number of blocks in the requested state
-	passedHashCheck    bool   // set to true after hash check passes
-	locked             bool   // set during hash checking/writing
+	infoIdx         int
+	index           uint32
+	blocksInPiece   uint16
+	finished        uint16
+	writing         uint16
+	requested       uint16
+	passedHashCheck bool
+	locked          bool
 }
 
 // piecePriority computes a score for a piece.
@@ -54,40 +54,18 @@ const priorityFactor = 3
 //
 // All public methods are safe for concurrent use.
 type piecePicker struct {
-	mu sync.Mutex
-
-	// number of pieces
-	numPieces uint32
-	// blocks per piece
-	blocksPerPiece uint32
-	// size of each block
-	blockSize int64
-
-	// piece availability: availability[i] = number of peers that have piece i
-	availability []uint16
-
-	// piece priority boundaries, sorted by priority descending.
-	// pieces[i] is a piece index in the open (not yet downloading) set.
-	pieces []uint32
-
-	// piece priorities
-	piecePriorities []uint32
-
-	// whether the priority array is dirty and needs re-sorting
-	dirty bool
-
-	// downloading pieces, sorted by piece index for O(log n) lookup
+	availability      []uint16
+	pieces            []uint32
+	piecePriorities   []uint32
 	downloadingPieces []downloadingPiece
-
-	// flat array of block info for all pieces. grouped by piece.
-	// blockInfos[piece_info_idx:piece_info_idx+blocksPerPiece] belong to the same piece.
-	blockInfos []blockInfo
-
-	// number of blocks in the requested state across all pieces
+	blockInfos        []blockInfo
+	blockSize         int64
 	downloadQueueSize int
-
-	// number of pieces we want that are not yet picked (mirrors num_want_left)
-	numWantLeft int
+	numWantLeft       int
+	mu                sync.Mutex
+	numPieces         uint32
+	blocksPerPiece    uint32
+	dirty             bool
 }
 
 // newPiecePicker creates a new piece picker for the given torrent info.
@@ -96,14 +74,14 @@ func newPiecePicker(info meta.Info) *piecePicker {
 	blocksPerPiece := uint32((info.PieceLength + defaultBlockSize - 1) / defaultBlockSize)
 
 	pp := &piecePicker{
-		numPieces:      numPieces,
-		blocksPerPiece: blocksPerPiece,
-		blockSize:      defaultBlockSize,
-		availability:   make([]uint16, numPieces),
+		numPieces:       numPieces,
+		blocksPerPiece:  blocksPerPiece,
+		blockSize:       defaultBlockSize,
+		availability:    make([]uint16, numPieces),
 		piecePriorities: make([]uint32, numPieces),
-		pieces:         make([]uint32, numPieces),
-		dirty:          true,
-		blockInfos:     make([]blockInfo, int(numPieces)*int(blocksPerPiece)),
+		pieces:          make([]uint32, numPieces),
+		dirty:           true,
+		blockInfos:      make([]blockInfo, int(numPieces)*int(blocksPerPiece)),
 	}
 
 	// initialize pieces array
@@ -269,10 +247,6 @@ func (pp *piecePicker) abortDownload(pieceIndex uint32, blockIndex int) {
 	}
 }
 
-
-
-
-
 // isFinished returns true if the block is finished.
 func (pp *piecePicker) isFinished(pieceIndex uint32, blockIndex int) bool {
 	pp.mu.Lock()
@@ -281,10 +255,6 @@ func (pp *piecePicker) isFinished(pieceIndex uint32, blockIndex int) bool {
 	idx := pp.blockInfoIdx(pieceIndex) + blockIndex
 	return pp.blockInfos[idx].state == blockStateFinished
 }
-
-
-
-
 
 // rebuildPriorities re-sorts the piece priority array.
 func (pp *piecePicker) rebuildPriorities() {
@@ -469,12 +439,13 @@ func (pp *piecePicker) pickPieces(
 		blocksInPiece := int(dp.blocksInPiece)
 		for i := range blocksInPiece {
 			bi := &pp.blockInfos[idx+i]
-			if bi.state == blockStateNone {
+			switch bi.state {
+			case blockStateNone:
 				if preferContiguous <= 0 && numBlocks > 0 {
 					result.freeBlocks = append(result.freeBlocks, pieceBlock{p.pieceIndex, i})
 					numBlocks--
 				}
-			} else if bi.state == blockStateRequested {
+			case blockStateRequested:
 				// busy block — only used in endgame
 				if bi.numPeers > 0 {
 					result.busyBlocks = append(result.busyBlocks, pieceBlock{p.pieceIndex, i})
@@ -494,7 +465,7 @@ func (pp *piecePicker) pickPieces(
 		if choked && !allowedFast.Contains(pi) {
 			continue
 		}
-		pp.pickBlocksFromPiece(pi, info, &numBlocks, preferContiguous, &result)
+		pp.pickBlocksFromPiece(pi, info, &numBlocks, &result)
 	}
 
 	// Phase 3: rarest-first from open pieces
@@ -513,7 +484,7 @@ func (pp *piecePicker) pickPieces(
 		if alreadyPicked {
 			continue
 		}
-		pp.pickBlocksFromPiece(pi, info, &numBlocks, preferContiguous, &result)
+		pp.pickBlocksFromPiece(pi, info, &numBlocks, &result)
 	}
 
 	return result
@@ -524,7 +495,6 @@ func (pp *piecePicker) pickBlocksFromPiece(
 	pieceIndex uint32,
 	info meta.Info,
 	numBlocks *int,
-	preferContiguous int,
 	result *pickResult,
 ) {
 	if *numBlocks <= 0 {
@@ -538,13 +508,14 @@ func (pp *piecePicker) pickBlocksFromPiece(
 	// find free blocks
 	for i := range blocksInPiece {
 		bi := &pp.blockInfos[idx+i]
-		if bi.state == blockStateNone {
+		switch bi.state {
+		case blockStateNone:
 			result.freeBlocks = append(result.freeBlocks, pieceBlock{pieceIndex, i})
 			*numBlocks--
 			if *numBlocks <= 0 {
 				return
 			}
-		} else if bi.state == blockStateRequested {
+		case blockStateRequested:
 			result.busyBlocks = append(result.busyBlocks, pieceBlock{pieceIndex, i})
 		}
 	}
@@ -624,12 +595,6 @@ func (pp *piecePicker) countBusyBlocks(pieceIndex uint32, info meta.Info) int {
 	return count
 }
 
-
-
-
-
-
-
 // resetPiece resets all blocks in a piece to state none (for hash check failure).
 func (pp *piecePicker) resetPiece(pieceIndex uint32, info meta.Info) {
 	pp.mu.Lock()
@@ -659,5 +624,3 @@ func (pp *piecePicker) removeDownloadingPieceLocked(pieceIndex uint32) {
 		}
 	}
 }
-
-


### PR DESCRIPTION
Replace the per-peer piece scheduling and connection management with libtorrent-style global peer list (`peerList`) and block-level piece picker (`piecePicker`).

## Changes

### peer_list.go (new)
- Persistent peer storage with O(log n) sorted lookup, connect candidate cache pre-sorted by priority
- Failcount-based backoff: `(failcount+1) * min_reconnect_time`
- Peer turnover: disconnect slowest peers (2% per 5min) to cycle in fresh candidates
- Immediate reconnect for peers with transfers (fast_reconnect)

### piece_picker.go (new)
- Global block-level state tracking: none → requested → writing → finished
- Rarest-first piece priority: `(availability + 1) * 3`
- Three-phase block selection: partial pieces → suggested → rarest-first
- Endgame mode with busy block support and per-block numPeers dedup

### d_conn.go
- Replace pendingPeers heap + connHistory LRU with peerList
- 1s connect ticker + 5min turnover ticker

### d_download.go
- `requestABlock`: per-peer block dispatch using the global picker
- Rate-based desired queue size: `queue_time * download_rate / block_size`
- Endgame trigger: remaining ≤ 100 MiB or free blocks exhausted

### p.go
- `blockRequests` channel + `requestQueue` slice replaces per-piece assignment
- `sendBlockRequests`: drain queue → wire requests with choking/limit checks
- Snub/Reject handlers properly abort blocks in picker
- Pick up refcount in bitfield/have/haveall/dont_have events

## Removals
`pendingPeers` heap, `connectionHistory` LRU, `pieceAvailability`, `piecePeerAssignments`, `pieceInFlight`, `rarePieceQueue`, `pieceRare` struct, `slowStart`/`lastRate`/`Requested` fields, `handleSlowStart`, `downloadPieceChunks`

## Docs
- `docs/download-scheduling.md`: full architecture doc with dataflow diagram
- `docs/peer-reconnection.md`: analysis of reconnection problems and libtorrent comparison