### PR TITLE
feat(config): support p2p port range (string type)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,23 +3,49 @@
 
 package config
 
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
 type Application struct {
-	DownloadDir     string `toml:"download-dir"`
-	MaxHTTPParallel int    `toml:"max-http-parallel"`
-	P2PPort         uint16 `toml:"p2p-port"`
-	NumWant         uint16 `toml:"num-want"`
-	// hard global connection limit
-	GlobalConnectionLimit uint16 `toml:"global-connections-limit"`
-	// hard global upload slot limit (across all torrents)
-	// 0 means auto (derived from GlobalConnectionLimit).
-	GlobalUploadSlots uint16 `toml:"global-upload-slots"`
-	// Global download speed limit in bytes per second. 0 means unlimited.
-	GlobalDownloadSpeedLimit int64 `toml:"global-download-speed-limit"`
-	// Global upload speed limit in bytes per second. 0 means unlimited.
-	GlobalUploadSpeedLimit int64 `toml:"global-upload-speed-limit"`
-	Fallocate              bool  `toml:"fallocate"`
+	DownloadDir              string `toml:"download-dir"`
+	P2PPort                  string `toml:"p2p-port"`
+	MaxHTTPParallel          int    `toml:"max-http-parallel"`
+	GlobalDownloadSpeedLimit int64  `toml:"global-download-speed-limit"`
+	GlobalUploadSpeedLimit   int64  `toml:"global-upload-speed-limit"`
+	NumWant                  uint16 `toml:"num-want"`
+	GlobalConnectionLimit    uint16 `toml:"global-connections-limit"`
+	GlobalUploadSlots        uint16 `toml:"global-upload-slots"`
+	Fallocate                bool   `toml:"fallocate"`
 }
 
 type Config struct {
 	App Application `toml:"application"`
+}
+
+// ValidateP2PPort checks that s is a valid port ("50047") or port range ("50047-50100").
+func ValidateP2PPort(s string) (uint16, uint16, error) {
+	parts := strings.SplitN(s, "-", 2)
+
+	start, err := strconv.ParseUint(parts[0], 10, 16)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid p2p port %q: %w", s, err)
+	}
+
+	if len(parts) == 1 {
+		return uint16(start), uint16(start), nil
+	}
+
+	end, err := strconv.ParseUint(parts[1], 10, 16)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid p2p port range %q: %w", s, err)
+	}
+
+	if end <= start {
+		return 0, 0, fmt.Errorf("invalid p2p port range %q: end must be > start", s)
+	}
+
+	return uint16(start), uint16(end), nil
 }

--- a/internal/config/script.go
+++ b/internal/config/script.go
@@ -170,14 +170,24 @@ var configFields = map[string]configField{
 	},
 	"application.p2p-port": {
 		setter: func(a *Application, v lua.LValue) error {
-			n, err := toGoUint16(v)
-			if err != nil {
+			s, ok := v.(lua.LString)
+			if !ok {
+				// Also accept a number (backward compat).
+				if n, ok := v.(lua.LNumber); ok {
+					a.P2PPort = strconv.Itoa(int(n))
+					return nil
+				}
+				return fmt.Errorf("expected string or number, got %s", v.Type())
+			}
+			// Validate format: single port or range.
+			raw := string(s)
+			if _, _, err := ValidateP2PPort(raw); err != nil {
 				return err
 			}
-			a.P2PPort = n
+			a.P2PPort = raw
 			return nil
 		},
-		getter: func(a *Application) lua.LValue { return lua.LNumber(a.P2PPort) },
+		getter: func(a *Application) lua.LValue { return lua.LString(a.P2PPort) },
 	},
 	"application.num-want": {
 		setter: func(a *Application, v lua.LValue) error {

--- a/internal/config/script_test.go
+++ b/internal/config/script_test.go
@@ -23,7 +23,7 @@ func TestLoadFromLua_SimpleSet(t *testing.T) {
 
 	cfg, err := LoadFromLua(script)
 	require.NoError(t, err)
-	assert.Equal(t, uint16(12345), cfg.App.P2PPort)
+	assert.Equal(t, "12345", cfg.App.P2PPort)
 	assert.True(t, cfg.App.Fallocate)
 	assert.Equal(t, "/custom/downloads", cfg.App.DownloadDir)
 }

--- a/internal/core/c.go
+++ b/internal/core/c.go
@@ -6,6 +6,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/netip"
@@ -53,17 +54,24 @@ func New(cfg config.Config, sessionPath string, debug bool) *Client {
 	//	only 'prefer'(default) 'prefer-not', 'disable' or 'force' are allowed", cfg.App.Crypto))
 	//}
 
-	conn, err := (&net.ListenConfig{}).ListenPacket(ctx, "udp", fmt.Sprintf(":%d", cfg.App.P2PPort))
+	p2pPort, p2pListener, err := parseAndResolvePort(cfg.App.P2PPort)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to resolve p2p port")
+	}
+
+	conn, err := (&net.ListenConfig{}).ListenPacket(ctx, "udp", fmt.Sprintf(":%d", p2pPort))
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to listen on dht")
 	}
 
-	d := dht.Start(conn, cfg.App.P2PPort)
+	d := dht.Start(conn, p2pPort)
 
 	v4, v6, _ := util.GetIPAddress()
 
 	c := &Client{
 		Config:      cfg,
+		p2pPort:     p2pPort,
+		p2pListener: p2pListener,
 		ctx:         ctx,
 		cancel:      cancel,
 		sem:         semaphore.NewWeighted(int64(cfg.App.GlobalConnectionLimit)),
@@ -125,9 +133,9 @@ type incomingConn struct {
 
 type Client struct {
 	ctx               context.Context
-	uploadLimiter     *ratelimit.Limiter
-	ipv4              atomic.Pointer[netip.Addr]
-	downloadMap       map[metainfo.Hash]*Download
+	p2pListener       net.Listener
+	filePool          *filepool.FilePool
+	downloadLimiter   *ratelimit.Limiter
 	connChan          chan incomingConn
 	sem               *semaphore.Weighted
 	uploadQ           chan uploadTask
@@ -135,20 +143,22 @@ type Client struct {
 	pieceDownloadRate *flowrate.Monitor
 	pieceUploadRate   *flowrate.Monitor
 	dht               *dht.DHT
-	downloadLimiter   *ratelimit.Limiter
+	ipv4              atomic.Pointer[netip.Addr]
 	http              *resty.Client
 	cancel            context.CancelFunc
-	filePool          *filepool.FilePool
+	downloadMap       map[metainfo.Hash]*Download
+	uploadLimiter     *ratelimit.Limiter
 	ipv6              atomic.Pointer[netip.Addr]
-	torrentPath       string
 	resumePath        string
-	downloads         []*Download
-	infoHashes        []metainfo.Hash
-	checkQueue        []metainfo.Hash
+	torrentPath       string
 	randKey           []byte
+	infoHashes        []metainfo.Hash
+	downloads         []*Download
+	checkQueue        []metainfo.Hash
 	Config            config.Config
 	connectionCount   atomic.Uint32
 	m                 sync.RWMutex
+	p2pPort           uint16
 	debug             bool
 }
 
@@ -181,7 +191,7 @@ func (c *Client) PeerPriority(peer netip.AddrPort) uint32 {
 			return bep40.SimplePriority(c.randKey, unsafe.Bytes(peer.String()))
 		}
 
-		return bep40.Priority4(netip.AddrPortFrom(*localV4, c.Config.App.P2PPort), peer)
+		return bep40.Priority4(netip.AddrPortFrom(*localV4, c.p2pPort), peer)
 	}
 
 	if peer.Addr().Is6() {
@@ -190,8 +200,47 @@ func (c *Client) PeerPriority(peer netip.AddrPort) uint32 {
 			return bep40.SimplePriority(c.randKey, unsafe.Bytes(peer.String()))
 		}
 
-		return bep40.Priority6(netip.AddrPortFrom(*localV6, c.Config.App.P2PPort), peer)
+		return bep40.Priority6(netip.AddrPortFrom(*localV6, c.p2pPort), peer)
 	}
 
 	panic(fmt.Sprintf("unexpected addrPort address format %+v", peer))
+}
+
+// parseAndResolvePort parses a P2PPort config value that can be a single port
+// ("50047") or a range ("50047-50100"). It binds a TCP listener and returns
+// both the port and the open listener — no TOCTOU race with a later bind.
+// When a range is given, ports are shuffled randomly and the first available
+// one wins.
+func parseAndResolvePort(s string) (uint16, net.Listener, error) {
+	start, end, err := config.ValidateP2PPort(s)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	if start == end {
+		l, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", fmt.Sprintf(":%d", start))
+		if err != nil {
+			return 0, nil, fmt.Errorf("failed to bind port %d: %w", start, err)
+		}
+		return start, l, nil
+	}
+
+	// Randomly shuffle ports in the range and try to bind TCP.
+	n := int(end - start + 1)
+	ports := make([]uint16, n)
+	for i := range n {
+		ports[i] = start + uint16(i)
+	}
+	rand.Shuffle(len(ports), func(i, j int) { ports[i], ports[j] = ports[j], ports[i] })
+
+	var lastErr error
+	for _, port := range ports {
+		l, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", fmt.Sprintf(":%d", port))
+		if err == nil {
+			return port, l, nil
+		}
+		lastErr = err
+	}
+
+	return 0, nil, fmt.Errorf("no available port in range %d-%d: %w", start, end, lastErr)
 }

--- a/internal/core/c_start.go
+++ b/internal/core/c_start.go
@@ -6,7 +6,6 @@ package core
 import (
 	"fmt"
 	"io/fs"
-	"net"
 	"net/netip"
 	"os"
 	"path/filepath"
@@ -16,7 +15,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/samber/lo"
 	"github.com/trim21/conntrack"
-	"github.com/trim21/errgo"
 
 	"neptune/internal/pkg/global"
 	"neptune/internal/pkg/global/tasks"
@@ -108,18 +106,9 @@ func (c *Client) Start() error {
 }
 
 func (c *Client) startListen() error {
-	var lc = net.ListenConfig{
-		Control:   nil,
-		KeepAlive: time.Minute,
-	}
-
-	l, err := lc.Listen(c.ctx, "tcp", fmt.Sprintf(":%d", c.Config.App.P2PPort))
-	if err != nil {
-		return errgo.Wrap(err, "failed to listen on p2p port")
-	}
-
-	// add x/net/trace only in debug mode
-	l = conntrack.NewListener(l, conntrack.TrackWithTracing(), conntrack.TrackWithName("p2p"))
+	// The listener was already bound during port resolution in New().
+	// Wrap it with conntrack for tracing and use it directly — no rebind.
+	l := conntrack.NewListener(c.p2pListener, conntrack.TrackWithTracing(), conntrack.TrackWithName("p2p"))
 
 	go c.handleConn()
 

--- a/internal/core/d.go
+++ b/internal/core/d.go
@@ -290,7 +290,7 @@ func (c *Client) NewDownload(m *metainfo.MetaInfo, info meta.Info, basePath stri
 		HTTP:            c.http,
 		InfoHash:        info.Hash.AsString(),
 		PeerID:          d.peerID.AsString(),
-		Port:            c.Config.App.P2PPort,
+		Port:            c.p2pPort,
 		Uploaded:        &d.uploaded,
 		UploadedStart:   d.uploadAtStart,
 		Downloaded:      &d.downloaded,

--- a/internal/core/d_download.go
+++ b/internal/core/d_download.go
@@ -66,9 +66,9 @@ func (d *Download) have(index uint32) {
 }
 
 type responseChunk struct {
+	recvAt time.Time
 	res    *proto.ChunkResponse
 	pi     uint32
-	recvAt time.Time
 }
 
 func (r responseChunk) Less(o responseChunk) bool {

--- a/internal/core/p.go
+++ b/internal/core/p.go
@@ -466,7 +466,6 @@ func (p *Peer) checkRequestTimeouts() {
 			}
 		}
 	}
-
 }
 
 func (p *Peer) start(skipHandshake bool) {

--- a/internal/web/e2e_test.go
+++ b/internal/web/e2e_test.go
@@ -101,7 +101,7 @@ func TestE2E(t *testing.T) {
 		App: config.Application{
 			DownloadDir:              downloadDir,
 			MaxHTTPParallel:          10,
-			P2PPort:                  0,
+			P2PPort:                  "0",
 			NumWant:                  50,
 			GlobalConnectionLimit:    10,
 			GlobalUploadSlots:        4,

--- a/main.go
+++ b/main.go
@@ -196,7 +196,7 @@ func setupFlagsAndEnvParser() {
 
 	pflag.String("web", "127.0.0.1:8002", "web interface address")
 	pflag.String("web-secret-token", "", "web interface address secret token")
-	pflag.Uint16("p2p-port", 50047, "p2p listen port")
+	pflag.String("p2p-port", "50047", "p2p listen port or range (e.g. '50047' or '50047-50100')")
 
 	pflag.Bool("log-json", false, "log as json format")
 	pflag.String("log-level", "info", "log level")
@@ -379,7 +379,7 @@ func mustParseConfig(sessionPath string) config.Config {
 		errExit("failed to load config", err)
 	}
 
-	cfg.App.P2PPort = viper.GetUint16("p2p-port")
+	cfg.App.P2PPort = viper.GetString("p2p-port")
 
 	log.Info().Str("path", configPath).Msg("config loaded")
 


### PR DESCRIPTION
## Summary

Change `P2PPort` config field from `uint16` to `string` to support port ranges like `"50047-50100"`. Single port `"50047"` still works as before.

## Why

When running multiple neptune instances or in constrained environments, a single hardcoded port often conflicts. A port range allows neptune to randomly pick an available port at startup.

## Changes

- **config.go**: `P2PPort` → `string`, add `ValidateP2PPort()` to parse `"50047"` or `"50047-50100"`
- **c.go**: `parseAndResolvePort()` binds a TCP listener once during `New()` and stores it — `startListen` reuses it directly, no TOCTOU race
- **c_start.go**: uses `c.p2pListener` instead of calling `Listen` again
- **d.go / c.go (BEP40)**: use resolved `c.p2pPort` (uint16)
- **script.go**: Lua setter accepts both `string` and `number` (backward compat)
- **main.go**: flag changed to `String`

## Usage

```toml
[application]
p2p-port = "50047-50100"
```

```bash
neptune --p2p-port "50047-50100"
```