### PR TITLE
feat: add peer direction and encryption to debug page and API

### DIFF
--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -273,6 +273,7 @@ type APIPeers struct {
 	DownloadRate int64   `json:"download_rate"`
 	UploadRate   int64   `json:"upload_rate"`
 	IsIncoming   bool    `json:"is_incoming"`
+	Encrypted    bool    `json:"encrypted"`
 }
 
 func (c *Client) GetTorrentPeers(h metainfo.Hash) []APIPeers {
@@ -294,6 +295,7 @@ func (c *Client) GetTorrentPeers(h metainfo.Hash) []APIPeers {
 			DownloadRate: p.pieceDownloadRate.Status().CurRate,
 			UploadRate:   p.pieceUploadRate.Status().CurRate,
 			IsIncoming:   p.Incoming,
+			Encrypted:    false,
 		})
 		return true
 	})

--- a/internal/core/debug.html
+++ b/internal/core/debug.html
@@ -95,12 +95,14 @@ async function reannounce(e) {
 
 <h2>Peers</h2>
 <table>
-<tr><th>Address</th><th>Down Rate</th><th>Up Rate</th><th class="num">Our Req</th><th class="num">Req Q</th><th class="num">DesiredQ</th>
+<tr><th>Address</th><th>Dir</th><th>Enc</th><th>Down Rate</th><th>Up Rate</th><th class="num">Our Req</th><th class="num">Req Q</th><th class="num">DesiredQ</th>
     <th>Client</th><th class="num">Progress</th>
     <th>Snubbed</th><th>Peer Choke</th><th>Peer Interest</th><th>Our Choke</th><th>Our Interest</th>
     <th>Fast</th><th class="num">Peer Req</th><th>Last Pick</th><th>Peer ID</th></tr>
 {{range .Peers}}<tr>
   <td>{{.Address}}</td>
+  <td>{{.Direction}}</td>
+  <td>{{.Encryption}}</td>
   <td>{{.DownRate}}</td>
   <td>{{.UpRate}}</td>
   <td class="num">{{.OurReq}}</td>

--- a/internal/core/debug_template.go
+++ b/internal/core/debug_template.go
@@ -99,6 +99,8 @@ type debugPeer struct {
 	Fast         string
 	PeerID       string
 	LastPick     string
+	Direction    string
+	Encryption   string
 	OurReq       int
 	ReqQ         int
 	DesiredQ     int
@@ -192,6 +194,10 @@ func buildDebugPageData(d *Download, infoHashHex string, fullMode bool) *debugPa
 	// Peers
 	var peers []debugPeer
 	d.peers.Range(func(_ uint64, p *Peer) bool {
+		dir := "out"
+		if p.Incoming {
+			dir = "in"
+		}
 		peers = append(peers, debugPeer{
 			Address:      p.Address.String(),
 			DownRate:     humanize.IBytes(uint64(p.pieceDownloadRate.Status().CurRate)) + "/s",
@@ -210,6 +216,8 @@ func buildDebugPageData(d *Download, infoHashHex string, fullMode bool) *debugPa
 			PeerReq:      p.peerRequests.Size(),
 			PeerID:       url.QueryEscape(p.peerID.Load().AsString()),
 			LastPick:     p.lastPickDebugString(),
+			Direction:    dir,
+			Encryption:   "none",
 		})
 		return true
 	})

--- a/sdk/python/src/neptune_sdk/models.py
+++ b/sdk/python/src/neptune_sdk/models.py
@@ -66,6 +66,7 @@ class Peer:
     download_rate: int
     upload_rate: int
     is_incoming: bool
+    encrypted: bool
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -154,6 +154,7 @@ def test_torrent_peers(mock_api, client):
                         "download_rate": 1000,
                         "upload_rate": 500,
                         "is_incoming": False,
+                        "encrypted": False,
                     }
                 ]
             }

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -67,6 +67,7 @@ export interface Peer {
   download_rate: number;
   upload_rate: number;
   is_incoming: boolean;
+  encrypted: boolean;
 }
 
 /** A tracker entry. */


### PR DESCRIPTION
Add peer connection direction (in/out) and encryption status to the debug page and JSON-RPC API.

Changes:
- Debug page Peers table: added Direction and Encryption columns
- JSON-RPC API : added  field to response
- TypeScript SDK: added  to Peer interface
- Python SDK: added  to Peer dataclass

Encryption is always / until MSE is implemented.