### PR TITLE
feat: implement MSE (Message Stream Encryption)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/docker/go-units v0.5.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/go-chi/chi/v5 v5.3.0
+	github.com/go-faster/xor v1.0.0
 	github.com/go-playground/validator/v10 v10.30.3
 	github.com/go-resty/resty/v2 v2.17.2
 	github.com/gofrs/flock v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/go-chi/chi/v5 v5.3.0 h1:halUjDxhshgXHMrao5bB8eNBXo/rnzwr8m5m36glehM=
 github.com/go-chi/chi/v5 v5.3.0/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
+github.com/go-faster/xor v1.0.0 h1:2o8vTOgErSGHP3/7XwA5ib1FTtUsNtwCoLLBjl31X38=
+github.com/go-faster/xor v1.0.0/go.mod h1:x5CaDY9UKErKzqfRfFZdfu+OSTfoZny3w5Ak7UxcipQ=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,20 +4,30 @@
 package config
 
 type Application struct {
-	DownloadDir     string `toml:"download-dir"`
-	MaxHTTPParallel int    `toml:"max-http-parallel"`
-	P2PPort         uint16 `toml:"p2p-port"`
-	NumWant         uint16 `toml:"num-want"`
+	DownloadDir string `toml:"download-dir"`
+
+	Crypto string `toml:"crypto"`
+
+	MaxHTTPParallel int `toml:"max-http-parallel"`
+
+	P2PPort uint16 `toml:"p2p-port"`
+
+	NumWant uint16 `toml:"num-want"`
+
 	// hard global connection limit
 	GlobalConnectionLimit uint16 `toml:"global-connections-limit"`
+
 	// hard global upload slot limit (across all torrents)
 	// 0 means auto (derived from GlobalConnectionLimit).
 	GlobalUploadSlots uint16 `toml:"global-upload-slots"`
+
 	// Global download speed limit in bytes per second. 0 means unlimited.
 	GlobalDownloadSpeedLimit int64 `toml:"global-download-speed-limit"`
+
 	// Global upload speed limit in bytes per second. 0 means unlimited.
 	GlobalUploadSpeedLimit int64 `toml:"global-upload-speed-limit"`
-	Fallocate              bool  `toml:"fallocate"`
+
+	Fallocate bool `toml:"fallocate"`
 }
 
 type Config struct {

--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -295,7 +295,7 @@ func (c *Client) GetTorrentPeers(h metainfo.Hash) []APIPeers {
 			DownloadRate: p.pieceDownloadRate.Status().CurRate,
 			UploadRate:   p.pieceUploadRate.Status().CurRate,
 			IsIncoming:   p.Incoming,
-			Encrypted:    false,
+			Encrypted:    p.Encrypted,
 		})
 		return true
 	})

--- a/internal/core/c.go
+++ b/internal/core/c.go
@@ -25,6 +25,7 @@ import (
 	"neptune/internal/config"
 	"neptune/internal/dht"
 	"neptune/internal/metainfo"
+	"neptune/internal/mse"
 	"neptune/internal/pkg/filepool"
 	"neptune/internal/pkg/flowrate"
 	"neptune/internal/pkg/global"
@@ -37,21 +38,22 @@ import (
 func New(cfg config.Config, sessionPath string, debug bool) *Client {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// var mseDisabled bool
-	// var mseSelector mse.CryptoSelector
-	// switch cfg.App.Crypto {
-	// case "force":
-	//	mseSelector = mse.ForceCrypto
-	// case "prefer":
-	//	mseSelector = mse.PreferCrypto
-	//case "prefer-not":
-	//	mseSelector = mse.DefaultCryptoSelector
-	//case "", "disable":
-	//	mseDisabled = true
-	//default:
-	//	panic(fmt.Sprintf("invalid `application.crypto` config %q,
-	//	only 'prefer'(default) 'prefer-not', 'disable' or 'force' are allowed", cfg.App.Crypto))
-	//}
+	var outgoingMseDisabled bool
+	var mseSelector mse.CryptoSelector
+	switch cfg.App.Crypto {
+	case "force":
+		mseSelector = mse.ForceCrypto
+	case "", "prefer":
+		mseSelector = mse.PreferCrypto
+	case "none":
+		outgoingMseDisabled = true
+		mseSelector = mse.DefaultCryptoSelector
+	default:
+		panic(fmt.Sprintf(
+			"invalid `application.crypto` config %q, only 'prefer' (default), 'none' or 'force' are allowed",
+			cfg.App.Crypto,
+		))
+	}
 
 	conn, err := (&net.ListenConfig{}).ListenPacket(ctx, "udp", fmt.Sprintf(":%d", cfg.App.P2PPort))
 	if err != nil {
@@ -101,6 +103,10 @@ func New(cfg config.Config, sessionPath string, debug bool) *Client {
 		ipv4:    *atomic.NewPointer(v4),
 		ipv6:    *atomic.NewPointer(v6),
 		debug:   debug,
+
+		mseDisabled: outgoingMseDisabled,
+		mseForce:    cfg.App.Crypto == "force",
+		mseSelector: mseSelector,
 	}
 
 	c.startUploadPool()
@@ -119,14 +125,15 @@ func (c *Client) initMetrics() {
 }
 
 type incomingConn struct {
-	conn net.Conn
-	addr netip.AddrPort
+	conn      net.Conn
+	addr      netip.AddrPort
+	encrypted bool
 }
 
 type Client struct {
 	ctx               context.Context
-	uploadLimiter     *ratelimit.Limiter
-	ipv4              atomic.Pointer[netip.Addr]
+	cancel            context.CancelFunc
+	dht               *dht.DHT
 	downloadMap       map[metainfo.Hash]*Download
 	connChan          chan incomingConn
 	sem               *semaphore.Weighted
@@ -134,12 +141,13 @@ type Client struct {
 	fh                map[string]*os.File
 	pieceDownloadRate *flowrate.Monitor
 	pieceUploadRate   *flowrate.Monitor
-	dht               *dht.DHT
+	ipv4              atomic.Pointer[netip.Addr]
 	downloadLimiter   *ratelimit.Limiter
 	http              *resty.Client
-	cancel            context.CancelFunc
+	mseSelector       mse.CryptoSelector
 	filePool          *filepool.FilePool
 	ipv6              atomic.Pointer[netip.Addr]
+	uploadLimiter     *ratelimit.Limiter
 	torrentPath       string
 	resumePath        string
 	downloads         []*Download
@@ -149,6 +157,8 @@ type Client struct {
 	Config            config.Config
 	connectionCount   atomic.Uint32
 	m                 sync.RWMutex
+	mseDisabled       bool
+	mseForce          bool
 	debug             bool
 }
 

--- a/internal/core/c_start.go
+++ b/internal/core/c_start.go
@@ -18,6 +18,7 @@ import (
 	"github.com/trim21/conntrack"
 	"github.com/trim21/errgo"
 
+	"neptune/internal/mse"
 	"neptune/internal/pkg/global"
 	"neptune/internal/pkg/global/tasks"
 	"neptune/internal/proto"
@@ -147,34 +148,25 @@ func (c *Client) startListen() error {
 
 			c.connectionCount.Add(1)
 
-			// TODO: support MSE
-			// if c.mseDisabled {
-			c.connChan <- incomingConn{
-				addr: lo.Must(netip.ParseAddrPort(conn.RemoteAddr().String())),
-				conn: conn,
-			}
-			// continue
-			//}
+			go func() {
+				c.m.RLock()
+				keys := c.infoHashes
+				c.m.RUnlock()
 
-			//// handle mse
-			// go func() {
-			//	c.m.RLock()
-			//	keys := c.infoHashes
-			//	c.m.RUnlock()
-			//
-			//	rwc, err := mse.NewAccept(peers, keys, c.mseSelector)
-			//	if err != nil {
-			//		c.sem.Release(1)
-			//		c.connectionCount.Sub(1)
-			//		_ = peers.Close()
-			//		return
-			//	}
-			//
-			//	c.connChan <- incomingConn{
-			//		addr: lo.Must(netip.ParseAddrPort(peers.RemoteAddr().String())),
-			//		peers: rwc,
-			//	}
-			// }()
+				rwc, method, err := mse.NewAccept(conn, keys, c.mseSelector)
+				if err != nil {
+					c.sem.Release(1)
+					c.connectionCount.Sub(1)
+					_ = conn.Close()
+					return
+				}
+
+				c.connChan <- incomingConn{
+					addr:      lo.Must(netip.ParseAddrPort(conn.RemoteAddr().String())),
+					conn:      rwc,
+					encrypted: method == mse.CryptoMethodRC4,
+				}
+			}()
 		}
 	}()
 	return nil
@@ -208,7 +200,7 @@ func (c *Client) handleConn() {
 					return
 				}
 
-				d.AddConn(conn.addr, conn.conn, h)
+				d.AddConn(conn.addr, conn.conn, h, conn.encrypted)
 			})
 		}
 	}

--- a/internal/core/d_conn.go
+++ b/internal/core/d_conn.go
@@ -11,6 +11,7 @@ import (
 	"net/netip"
 	"time"
 
+	"neptune/internal/mse"
 	"neptune/internal/pkg/empty"
 	"neptune/internal/pkg/global"
 	"neptune/internal/pkg/global/tasks"
@@ -23,8 +24,8 @@ const (
 
 // AddConn adds an incoming connection from the listener.
 // The peer entry is created in newPeer via addOrUpdateIncoming.
-func (d *Download) AddConn(addr netip.AddrPort, conn net.Conn, h proto.Handshake) {
-	NewIncomingPeer(conn, d, addr, h)
+func (d *Download) AddConn(addr netip.AddrPort, conn net.Conn, h proto.Handshake, encrypted bool) {
+	NewIncomingPeer(conn, d, addr, h, encrypted)
 }
 
 // connectToPeers tries to connect to candidate peers from the peer list.
@@ -97,7 +98,31 @@ func (d *Download) tryDial(pp *persistentPeer) {
 		_ = tcp.SetLinger(0)
 	}
 
-	p := NewOutgoingPeer(conn, d, pp.addrPort)
+	var encrypted bool
+	if !d.c.mseDisabled {
+		infoHash := d.info.Hash.AsString()
+		mseConn, method, mseErr := mse.NewConnection([]byte(infoHash), conn)
+		if mseErr != nil {
+			if d.c.mseForce {
+				_ = conn.Close()
+				d.peerList.incFailcount(pp, mseErr.Error())
+				d.c.sem.Release(1)
+				d.c.connectionCount.Sub(1)
+				select {
+				case d.pendingPeersSignal <- empty.Empty{}:
+				default:
+				}
+				return
+			}
+			// prefer mode: MSE failed, fall back to plain connection.
+			// conn was not consumed by MSE on failure, reuse it.
+		} else {
+			conn = mseConn
+			encrypted = method == mse.CryptoMethodRC4
+		}
+	}
+
+	p := NewOutgoingPeer(conn, d, pp.addrPort, encrypted)
 	// Register the connection in the persistent peer list.
 	d.peerList.newConnection(pp.addrPort, p, time.Now().Unix())
 }

--- a/internal/core/debug_template.go
+++ b/internal/core/debug_template.go
@@ -198,6 +198,10 @@ func buildDebugPageData(d *Download, infoHashHex string, fullMode bool) *debugPa
 		if p.Incoming {
 			dir = "in"
 		}
+		enc := "none"
+		if p.Encrypted {
+			enc = "rc4"
+		}
 		peers = append(peers, debugPeer{
 			Address:      p.Address.String(),
 			DownRate:     humanize.IBytes(uint64(p.pieceDownloadRate.Status().CurRate)) + "/s",
@@ -217,7 +221,7 @@ func buildDebugPageData(d *Download, infoHashHex string, fullMode bool) *debugPa
 			PeerID:       url.QueryEscape(p.peerID.Load().AsString()),
 			LastPick:     p.lastPickDebugString(),
 			Direction:    dir,
-			Encryption:   "none",
+			Encryption:   enc,
 		})
 		return true
 	})

--- a/internal/core/p.go
+++ b/internal/core/p.go
@@ -52,12 +52,12 @@ func NewPeerID() (peerID proto.PeerID) {
 	return
 }
 
-func NewOutgoingPeer(conn net.Conn, d *Download, addr netip.AddrPort) *Peer {
-	return newPeer(conn, d, addr, false, nil)
+func NewOutgoingPeer(conn net.Conn, d *Download, addr netip.AddrPort, encrypted bool) *Peer {
+	return newPeer(conn, d, addr, false, nil, encrypted)
 }
 
-func NewIncomingPeer(conn net.Conn, d *Download, addr netip.AddrPort, h proto.Handshake) *Peer {
-	return newPeer(conn, d, addr, true, &h)
+func NewIncomingPeer(conn net.Conn, d *Download, addr netip.AddrPort, h proto.Handshake, encrypted bool) *Peer {
+	return newPeer(conn, d, addr, true, &h, encrypted)
 }
 
 func newPeer(
@@ -66,6 +66,7 @@ func newPeer(
 	addr netip.AddrPort,
 	skipReadHandshake bool,
 	h *proto.Handshake,
+	encrypted bool,
 ) *Peer {
 	ctx, cancel := context.WithCancel(d.ctx)
 	l := d.log.With().Stringer("addr", addr)
@@ -89,6 +90,7 @@ func newPeer(
 		id:                d.peerIDCounter.Add(1),
 		QueueLimit:        *atomic.NewUint32(2000),
 		Incoming:          skipReadHandshake,
+		Encrypted:         encrypted,
 
 		ourChoking:     *atomic.NewBool(true),
 		ourInterested:  *atomic.NewBool(false),
@@ -179,6 +181,7 @@ type Peer struct {
 	writeBuf          [4]byte
 	readBuf           [4]byte
 	Incoming          bool
+	Encrypted         bool
 	fastExtension     bool
 	dhtEnabled        bool
 	subExtensions     bool

--- a/internal/mse/mse.go
+++ b/internal/mse/mse.go
@@ -15,6 +15,11 @@ type CryptoMethod = mse.CryptoMethod
 type CryptoSelector = mse.CryptoSelector
 type SecretKeyIter = mse.SecretKeyIter
 
+const (
+	CryptoMethodPlaintext = mse.CryptoMethodPlaintext
+	CryptoMethodRC4       = mse.CryptoMethodRC4
+)
+
 func DefaultCryptoSelector(provided CryptoMethod) CryptoMethod {
 	// We prefer plaintext for performance reasons.
 	if provided&mse.CryptoMethodPlaintext != 0 {
@@ -44,23 +49,23 @@ func keyMatcher(keys []metainfo.Hash) func(f func([]byte) bool) {
 	}
 }
 
-func NewAccept(conn net.Conn, keys []metainfo.Hash, selector mse.CryptoSelector) (net.Conn, error) {
-	rw, _, err := mse.ReceiveHandshake(conn, keyMatcher(keys), selector)
+func NewAccept(conn net.Conn, keys []metainfo.Hash, selector mse.CryptoSelector) (net.Conn, CryptoMethod, error) {
+	rw, method, err := mse.ReceiveHandshake(conn, keyMatcher(keys), selector)
 	if err != nil {
 		_ = conn.Close()
-		return nil, err
+		return nil, 0, err
 	}
 
-	return wrappedConn{rw: rw, Conn: conn}, err
+	return wrappedConn{rw: rw, Conn: conn}, method, err
 }
 
-func NewConnection(infoHash []byte, conn net.Conn) (net.Conn, error) {
-	ret, _, err := mse.InitiateHandshake(conn, infoHash, nil, mse.AllSupportedCrypto)
+func NewConnection(infoHash []byte, conn net.Conn) (net.Conn, CryptoMethod, error) {
+	ret, method, err := mse.InitiateHandshake(conn, infoHash, nil, mse.AllSupportedCrypto)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
-	return wrappedConn{rw: ret, Conn: conn}, nil
+	return wrappedConn{rw: ret, Conn: conn}, method, nil
 }
 
 var _ io.ReadWriteCloser = wrappedConn{}

--- a/internal/mse/mse/mse.go
+++ b/internal/mse/mse/mse.go
@@ -39,16 +39,16 @@ const AllSupportedCrypto = CryptoMethodPlaintext | CryptoMethodRC4
 var (
 	// Prime P according to the spec, and G, the generator.
 	primeP, primeG big.Int
-	// For use in initer's hashes
+	// For use in initer's hashes.
 	req1 = []byte("req1")
 	req2 = []byte("req2")
 	req3 = []byte("req3")
 	// Verification constant "VC" which is all zeroes in the bittorrent
 	// implementation.
 	vc [8]byte
-	// Zero padding
+	// Zero padding.
 	zeroPad [512]byte
-	// Tracks counts of received crypto_provides
+	// Tracks counts of received crypto_provides.
 )
 
 func init() {
@@ -362,7 +362,7 @@ func (h *handshake) initerSteps() (io.ReadWriter, CryptoMethod, error) {
 			defer mempool.Put(padBuf)
 			_, errR := io.CopyBuffer(buf, io.LimitReader(rand.Reader, int64(padLen)), padBuf.B[:maxPadLength])
 			if errR != nil {
-				panic(fmt.Sprintln("error reading from random", err))
+				panic(fmt.Sprintln("error reading from random", errR))
 			}
 		}
 
@@ -444,13 +444,13 @@ func (h *handshake) receiverSteps() (ret io.ReadWriter, chosen CryptoMethod, err
 		if err == io.EOF {
 			err = errors.New("failed to synchronize on S hashBytes")
 		}
-		return
+		return ret, chosen, err
 	}
 
 	var b [20]byte
 	_, err = io.ReadFull(h.conn, b[:])
 	if err != nil {
-		return
+		return ret, chosen, err
 	}
 	expectedHash := hashBytes(req3, h.s[:])
 	eachHash := sha1.New()
@@ -470,7 +470,7 @@ func (h *handshake) receiverSteps() (ret io.ReadWriter, chosen CryptoMethod, err
 		return true
 	})
 	if err != nil {
-		return
+		return ret, chosen, err
 	}
 
 	r := newCipherReader(newEncrypt(true, h.s[:], h.skey), h.conn)
@@ -482,23 +482,23 @@ func (h *handshake) receiverSteps() (ret io.ReadWriter, chosen CryptoMethod, err
 
 	err = unmarshal(r, vc[:], &provides, &padLen)
 	if err != nil {
-		return
+		return ret, chosen, err
 	}
 	chosen = h.chooseMethod(provides)
 	_, err = io.CopyN(io.Discard, r, int64(padLen))
 	if err != nil {
-		return
+		return ret, chosen, err
 	}
 	var lenIA uint16
 	if err = unmarshal(r, &lenIA); err != nil {
-		return
+		return ret, chosen, err
 	}
 
 	if lenIA != 0 {
 		h.ia = make([]byte, lenIA)
 		err = unmarshal(r, h.ia)
 		if err != nil {
-			return
+			return ret, chosen, err
 		}
 	}
 
@@ -510,15 +510,15 @@ func (h *handshake) receiverSteps() (ret io.ReadWriter, chosen CryptoMethod, err
 	padLen = newPadLen()
 	err = marshal(&w, &vc, uint32(chosen), padLen, zeroPad[:padLen])
 	if err != nil {
-		return
+		return ret, chosen, err
 	}
 
 	if err = h.write(buf.Bytes()); err != nil {
-		return
+		return ret, chosen, err
 	}
 
 	if err = h.w.Flush(); err != nil {
-		return
+		return ret, chosen, err
 	}
 
 	switch chosen { //nolint:exhaustive
@@ -536,7 +536,7 @@ func (h *handshake) receiverSteps() (ret io.ReadWriter, chosen CryptoMethod, err
 		err = errors.New("chosen crypto method is not supported")
 	}
 
-	return
+	return ret, chosen, err
 }
 
 // Do https://github.com/transmission/transmission/blob/7f79cb16ee194d58ce665f9319524bc5e6e4f91d/extras/encryption.txt#L136-L140
@@ -578,7 +578,6 @@ var bufioPool = gsync.NewPool(func() *bufio.Writer {
 func InitiateHandshake(rw io.ReadWriter, key, initialPayload []byte, cryptoProvides CryptoMethod) (
 	io.ReadWriter, CryptoMethod, error,
 ) {
-
 	w := bufioPool.Get()
 	defer bufioPool.Put(w)
 	w.Reset(rw)

--- a/internal/mse/mse_test.go
+++ b/internal/mse/mse_test.go
@@ -5,13 +5,12 @@ package mse_test
 
 import (
 	"bytes"
-	"fmt"
+	"context"
 	"io"
 	"net"
 	"testing"
 
-	tmse "github.com/anacrolix/torrent/mse"
-	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"neptune/internal/metainfo"
@@ -28,9 +27,7 @@ func BenchmarkMSE(b *testing.B) {
 	var handleServer = func(conn net.Conn) {
 		defer conn.Close()
 
-		rw, err := mse.NewAccept(conn, []metainfo.Hash{hash}, func(method mse.CryptoMethod) mse.CryptoMethod {
-			return mse.CryptoMethod(tmse.DefaultCryptoSelector(tmse.CryptoMethod(method)))
-		})
+		rw, _, err := mse.NewAccept(conn, []metainfo.Hash{hash}, mse.DefaultCryptoSelector)
 		if err != nil {
 			return
 		}
@@ -47,7 +44,7 @@ func BenchmarkMSE(b *testing.B) {
 	var handleClient = func(conn net.Conn) {
 		defer conn.Close()
 
-		rw, err := mse.NewConnection(hash[:], conn)
+		rw, _, err := mse.NewConnection(hash[:], conn)
 		if err != nil {
 			panic(err)
 		}
@@ -70,34 +67,33 @@ func BenchmarkMSE(b *testing.B) {
 	}
 
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		server, client := net.Pipe()
 		go handleServer(server)
 		handleClient(client)
 	}
 }
 
-func TestDial(t *testing.T) {
-	p := 8006
-	l := lo.Must(net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", p)))
+func TestRoundTrip(t *testing.T) {
+	lc := &net.ListenConfig{}
+	l, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
 	defer l.Close()
 
 	hash := metainfo.Hash{}
 
 	go func() {
 		for {
-			conn, err := l.Accept()
-			if err != nil {
+			conn, acceptErr := l.Accept()
+			if acceptErr != nil {
 				return
 			}
 
 			go func() {
 				defer conn.Close()
 
-				rw, _, err := tmse.ReceiveHandshake(conn, func(callback func(skey []byte) (more bool)) {
-					callback(hash[:])
-				}, tmse.DefaultCryptoSelector)
-				if err != nil {
+				rw, _, acceptErr := mse.NewAccept(conn, []metainfo.Hash{hash}, mse.DefaultCryptoSelector)
+				if acceptErr != nil {
 					return
 				}
 
@@ -106,12 +102,14 @@ func TestDial(t *testing.T) {
 		}
 	}()
 
-	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", p))
+	d := &net.Dialer{}
+	conn, err := d.DialContext(context.Background(), "tcp", l.Addr().String())
 	require.NoError(t, err)
 	defer conn.Close()
 
-	rw, err := mse.NewConnection(hash[:], conn)
+	rw, method, err := mse.NewConnection(hash[:], conn)
 	require.NoError(t, err)
+	assert.Equal(t, mse.CryptoMethodPlaintext, method)
 
 	data := []byte("hello world\n")
 
@@ -125,39 +123,47 @@ func TestDial(t *testing.T) {
 	require.Equal(t, data, b)
 }
 
-func TestMseAccept(t *testing.T) {
-	p := 8005
-	l := lo.Must(net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", p)))
+func TestForceCrypto(t *testing.T) {
+	lc := &net.ListenConfig{}
+	l, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
 	defer l.Close()
 
 	hash := metainfo.Hash{}
+	serverMethod := make(chan mse.CryptoMethod, 1)
 
 	go func() {
 		for {
-			conn, err := l.Accept()
-			if err != nil {
+			conn, acceptErr := l.Accept()
+			if acceptErr != nil {
 				return
 			}
 
 			go func() {
 				defer conn.Close()
 
-				rw, err := mse.NewAccept(conn, []metainfo.Hash{hash}, mse.DefaultCryptoSelector)
-				if err != nil {
+				rw, method, acceptErr := mse.NewAccept(conn, []metainfo.Hash{hash}, mse.ForceCrypto)
+				if acceptErr != nil {
 					return
 				}
 
+				serverMethod <- method
 				echoConnection(rw)
 			}()
 		}
 	}()
 
-	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", p))
+	d := &net.Dialer{}
+	conn, err := d.DialContext(context.Background(), "tcp", l.Addr().String())
 	require.NoError(t, err)
 	defer conn.Close()
 
-	rw, _, err := tmse.InitiateHandshake(conn, hash[:], nil, tmse.CryptoMethodRC4)
+	rw, method, err := mse.NewConnection(hash[:], conn)
 	require.NoError(t, err)
+	assert.Equal(t, mse.CryptoMethodRC4, method)
+
+	sm := <-serverMethod
+	assert.Equal(t, mse.CryptoMethodRC4, sm)
 
 	data := []byte("hello world\n")
 	n, err := rw.Write(data)
@@ -168,7 +174,6 @@ func TestMseAccept(t *testing.T) {
 	_, err = io.ReadFull(rw, b)
 	require.NoError(t, err)
 	require.Equal(t, data, b)
-
 }
 
 func echoConnection(conn io.ReadWriter) {
@@ -185,4 +190,12 @@ func echoConnection(conn io.ReadWriter) {
 			return
 		}
 	}
+}
+
+func loMust[T any](t *testing.T, v T, err error) T {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return v
 }


### PR DESCRIPTION
Enable MSE protocol encryption for peer connections.

Config: `application.crypto` with three modes:
- `prefer` (default): outgoing tries MSE first, falls back to plaintext
- `force`: RC4 encryption required for all connections
- `none`: outgoing skips MSE, incoming still accepts (negotiates plaintext)

Changes:
- Activate MSE `.tmp` files as `.go`, add `go-faster/xor` dependency
- Add `Crypto` config field with `prefer`/`force`/`none` values
- Wire MSE into incoming connections (`c_start.go`)
- Wire MSE into outgoing connections with prefer fallback (`d_conn.go` tryDial)
- Track encrypted status on `Peer` struct
- Propagate to API (`APIPeers.encrypted`) and debug page (Encryption column)
- Add `CryptoMethodPlaintext`/`CryptoMethodRC4` constants to outer `mse` package
- Fix pre-existing nilnesserr bug in `mse/mse.go` (`errR` vs `err`)
- Rewrite MSE tests to use internal package only