### PR TITLE
feat(e2e): add end-to-end test framework (neptune↔neptune, neptune↔qbittorrent, encryption matrix)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,8 +171,8 @@ jobs:
 
       - name: Wait for Docker services
         run: |
-          for i in $(seq 1 30); do
-            if curl -sf http://127.0.0.1:8090 > /dev/null 2>&1; then
+          for i in $(seq 1 45); do
+            if curl -sf http://127.0.0.1:8090/api/v2/app/version > /dev/null 2>&1; then
               echo "qBittorrent ready"
               break
             fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,7 +159,7 @@ jobs:
         run: go build -tags release -o e2e/testdata/neptune .
 
       - name: Generate fixtures
-        run: uv run python e2e/gen_fixtures.py
+        run: uv run --directory e2e python gen_fixtures.py
 
       - name: Copy fixture data for QB seeding
         run: cp -r e2e/testdata/fixtures/test-fixture e2e/testdata/qb-downloads/test-fixture
@@ -179,7 +179,7 @@ jobs:
           done
 
       - name: Run ${{ matrix.suite }} tests
-        run: uv run pytest e2e/test_${{ matrix.suite }}.py -v --timeout=90 -p no:cacheprovider
+        run: uv run --directory e2e pytest test_${{ matrix.suite }}.py -v --timeout=90 -p no:cacheprovider
 
       - name: Docker logs (on failure)
         if: failure()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,3 +134,57 @@ jobs:
       - run: echo "/home/runner/.dprint/bin" >> $GITHUB_PATH
       - run: dprint output-file-paths
       - run: dprint check
+
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - neptune_neptune
+          - qbittorrent
+          - encryption
+    steps:
+      - uses: actions/checkout@v7.0.0
+
+      - uses: trim21/actions/setup-go@master
+        with:
+          cache-namespace: e2e
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Build neptune
+        run: go build -tags release -o e2e/testdata/neptune .
+
+      - name: Generate fixtures
+        run: uv run python e2e/gen_fixtures.py
+
+      - name: Copy fixture data for QB seeding
+        run: cp -r e2e/testdata/fixtures/test-fixture e2e/testdata/qb-downloads/test-fixture
+
+      - name: Start Docker services
+        run: docker compose -f e2e/docker-compose.yml up -d
+
+      - name: Wait for Docker services
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:8090 > /dev/null 2>&1; then
+              echo "qBittorrent ready"
+              break
+            fi
+            echo "waiting... ($i)"
+            sleep 2
+          done
+
+      - name: Run ${{ matrix.suite }} tests
+        run: uv run pytest e2e/test_${{ matrix.suite }}.py -v --timeout=90 -p no:cacheprovider
+
+      - name: Docker logs (on failure)
+        if: failure()
+        run: docker compose -f e2e/docker-compose.yml logs
+
+      - name: Stop Docker services
+        if: always()
+        run: docker compose -f e2e/docker-compose.yml down -v

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,7 +162,9 @@ jobs:
         run: uv run --directory e2e python gen_fixtures.py
 
       - name: Copy fixture data for QB seeding
-        run: cp -r e2e/testdata/fixtures/test-fixture e2e/testdata/qb-downloads/test-fixture
+        run: |
+          mkdir -p e2e/testdata/qb-downloads
+          cp -r e2e/testdata/fixtures/test-fixture e2e/testdata/qb-downloads/test-fixture
 
       - name: Start Docker services
         run: docker compose -f e2e/docker-compose.yml up -d

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ coverage.txt
 internal/web/docs/swagger/
 config.toml
 etc/example/data/
+
+# e2e test artifacts
+e2e/testdata/fixtures/
+e2e/testdata/neptune
+e2e/testdata/qb-config/
+e2e/testdata/qb-downloads/

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -1,0 +1,309 @@
+"""Pytest fixtures for Neptune e2e tests.
+
+Provides:
+    tracker_url  – HTTP tracker URL (default: http://127.0.0.1:6969/announce)
+    fixture      – the loaded torrent + data fixture
+    neptune      – factory to start/stop neptune instances
+    qb_client    – authenticated httpx client for qBittorrent Web API
+
+Usage:
+    docker compose -f e2e/docker-compose.yml up -d
+    uv run pytest e2e/ -v
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from dataclasses import dataclass
+from typing import Callable, Iterator
+
+import httpx
+import pytest
+
+# ── Paths ──────────────────────────────────────────────────────────────
+
+E2E_DIR = Path(__file__).parent
+FIXTURES_DIR = E2E_DIR / "testdata" / "fixtures"
+NEPTUNE_BINARY = E2E_DIR / "testdata" / "neptune"
+FIXTURE_NAME = "test-fixture"
+
+# ── Defaults ───────────────────────────────────────────────────────────
+
+TRACKER_URL = os.getenv("E2E_TRACKER_URL", "http://127.0.0.1:6969/announce")
+QB_WEBUI = os.getenv("E2E_QB_URL", "http://127.0.0.1:8090")
+QB_USERNAME = os.getenv("E2E_QB_USER", "admin")
+QB_PASSWORD = os.getenv("E2E_QB_PASS", "adminadmin")
+E2E_TIMEOUT = int(os.getenv("E2E_TIMEOUT", "60"))
+
+
+# ── Fixture data ───────────────────────────────────────────────────────
+
+@dataclass
+class TorrentFixture:
+    """A generated torrent fixture with its data directory."""
+
+    torrent_path: Path
+    data_dir: Path
+    info_hash: str
+    total_size: int
+
+
+@pytest.fixture(scope="session")
+def fixture() -> TorrentFixture:
+    """Load the test torrent fixture."""
+    torrent_path = FIXTURES_DIR / f"{FIXTURE_NAME}.torrent"
+    data_dir = FIXTURES_DIR / FIXTURE_NAME
+
+    if not torrent_path.exists():
+        pytest.fail(
+            f"Fixture not found: {torrent_path}\n"
+            "Run: uv run python e2e/gen_fixtures.py"
+        )
+
+    torrent_bytes = torrent_path.read_bytes()
+    info = _extract_info(torrent_bytes)
+    info_hash = hashlib.sha1(info).hexdigest()
+
+    return TorrentFixture(
+        torrent_path=torrent_path,
+        data_dir=data_dir,
+        info_hash=info_hash,
+        total_size=torrent_path.stat().st_size,
+    )
+
+
+def _extract_info(torrent: bytes) -> bytes:
+    """Extract the info dict from a bencoded .torrent file."""
+    marker = b"4:info"
+    idx = torrent.index(marker)
+    return torrent[idx + 6 : -1]
+
+
+# ── Neptune instance ───────────────────────────────────────────────────
+
+class NeptuneInstance:
+    """A running neptune process with JSON-RPC API access."""
+
+    def __init__(
+        self,
+        port: int,
+        p2p_port: int,
+        session_dir: str,
+        crypto: str = "disable",
+    ) -> None:
+        self.port = port
+        self.p2p_port = p2p_port
+        self.url = f"http://127.0.0.1:{port}"
+        self.session_dir = session_dir
+        self.crypto = crypto
+        self._process: subprocess.Popen[bytes] | None = None
+        self.request_id = 0
+
+    def start(self) -> None:
+        if not NEPTUNE_BINARY.exists():
+            pytest.fail(
+                f"Neptune binary not found: {NEPTUNE_BINARY}\n"
+                "Run: go build -tags release -o e2e/testdata/neptune ."
+            )
+
+        # Write a minimal config file so we can set crypto level.
+        config_path = Path(self.session_dir) / "config.toml"
+        config_path.write_text(f'[app]\ncrypto = "{self.crypto}"\n')
+
+        args = [
+            str(NEPTUNE_BINARY),
+            "--web", f"127.0.0.1:{self.port}",
+            "--session-path", self.session_dir,
+            "--config-file", str(config_path),
+            "--p2p-port", str(self.p2p_port),
+            "--log-level", "debug",
+            "--log-json",
+        ]
+        env = os.environ | {"NEPTUNE_LOG_SAVE_TO_FILE": "false"}
+
+        self._process = subprocess.Popen(
+            args,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=env,
+        )
+        self._wait_ready()
+
+    def stop(self) -> None:
+        if self._process is None:
+            return
+        self._process.send_signal(signal.SIGTERM)
+        try:
+            self._process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self._process.kill()
+            self._process.wait()
+
+    def _wait_ready(self, timeout: float = 30) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                resp = httpx.get(f"{self.url}/healthz", timeout=1)
+                if resp.status_code == 200:
+                    return
+            except Exception:
+                pass
+            time.sleep(0.2)
+        raise RuntimeError(f"Neptune on port {self.port} not ready after {timeout}s")
+
+    # ── JSON-RPC helpers ───────────────────────────────────────────────
+
+    def _rpc(self, method: str, params: dict | None = None) -> object:
+        self.request_id += 1
+        payload = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "id": self.request_id,
+        }
+        if params is not None:
+            payload["params"] = params
+
+        resp = httpx.post(
+            f"{self.url}/json_rpc",
+            json=payload,
+            headers={"Authorization": "test-token"},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        if "error" in body and body["error"] is not None:
+            raise RuntimeError(f"RPC error: {body['error']}")
+        return body.get("result")
+
+    def torrent_add(self, torrent_path: str, save_path: str) -> str:
+        """Add a torrent from file and return info_hash."""
+        torrent_b64 = Path(torrent_path).read_bytes()
+        import base64
+        result = self._rpc("torrent.add", {
+            "torrent": base64.b64encode(torrent_b64).decode(),
+            "save_path": save_path,
+        })
+        assert isinstance(result, dict)
+        ih = result.get("info_hash")
+        assert isinstance(ih, str)
+        # Add tracker
+        self._rpc("torrent.add_tracker", {
+            "info_hash": ih,
+            "url": TRACKER_URL,
+            "tier": 0,
+        })
+        return ih
+
+    def torrent_start(self, info_hash: str) -> None:
+        self._rpc("torrent.start", {"info_hash": info_hash})
+
+    def torrent_stop(self, info_hash: str) -> None:
+        self._rpc("torrent.stop", {"info_hash": info_hash})
+
+    def torrent_get(self, info_hash: str) -> dict:
+        result = self._rpc("torrent.get", {"info_hash": info_hash})
+        assert isinstance(result, dict)
+        return result
+
+    def torrent_recheck(self, info_hash: str) -> None:
+        self._rpc("torrent.recheck", {"info_hash": info_hash})
+
+    def wait_state(
+        self, info_hash: str, state: str, timeout: float | None = None
+    ) -> dict:
+        """Poll until torrent reaches a given state (e.g. 'seeding')."""
+        if timeout is None:
+            timeout = E2E_TIMEOUT
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            info = self.torrent_get(info_hash)
+            current = info.get("state", "").lower()
+            if current == state.lower():
+                return info
+            time.sleep(0.5)
+        raise RuntimeError(
+            f"Torrent {info_hash[:8]} state={state} not reached "
+            f"(current={info.get('state')}) after {timeout}s"
+        )
+
+
+@pytest.fixture
+def neptune(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Callable[[], NeptuneInstance]]:
+    """Start a neptune instance, return it, stop after test."""
+    instances: list[NeptuneInstance] = []
+
+    def _start(p2p_port: int | None = None, web_port: int | None = None,
+               crypto: str = "disable") -> NeptuneInstance:
+        p = web_port or (18002 + len(instances))
+        pp = p2p_port or (50048 + len(instances))
+        session = str(tmp_path_factory.mktemp(f"neptune-{len(instances)}"))
+        inst = NeptuneInstance(p, pp, session, crypto=crypto)
+        inst.start()
+        instances.append(inst)
+        return inst
+
+    yield _start
+
+    for inst in instances:
+        inst.stop()
+
+
+# ── qBittorrent ────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="session")
+def qb_client() -> Iterator[httpx.Client]:
+    """Authenticated qBittorrent Web API client."""
+    client = httpx.Client(base_url=QB_WEBUI, timeout=30)
+
+    # Wait for QB to be ready.
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        try:
+            resp = client.get("/api/v2/app/version")
+            if resp.status_code == 200:
+                break
+        except Exception:
+            pass
+        time.sleep(1)
+    else:
+        pytest.fail("qBittorrent not ready")
+
+    # Login.
+    resp = client.post(
+        "/api/v2/auth/login",
+        data={"username": QB_USERNAME, "password": QB_PASSWORD},
+    )
+    if resp.status_code != 200:
+        pytest.fail(f"QB login failed: {resp.status_code}")
+
+    yield client
+
+    client.close()
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+def verify_files(fixture: TorrentFixture, download_dir: str) -> None:
+    """Verify downloaded files match the fixture."""
+    for f in fixture.data_dir.rglob("*"):
+        if f.is_dir():
+            continue
+        rel = f.relative_to(fixture.data_dir)
+        got = Path(download_dir) / FIXTURE_NAME / rel
+
+        expected_data = f.read_bytes()
+        got_data = got.read_bytes()
+
+        assert len(expected_data) == len(got_data), (
+            f"Size mismatch: {rel} (want {len(expected_data)}, got {len(got_data)})"
+        )
+        assert expected_data == got_data, (
+            f"Content mismatch: {rel}"
+        )

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -260,11 +260,13 @@ def neptune(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Callable[[], N
 @pytest.fixture(scope="session")
 def qb_client() -> Iterator[httpx.Client]:
     """Authenticated qBittorrent Web API client."""
+    import subprocess
+
     client = httpx.Client(base_url=QB_WEBUI, timeout=30)
 
-        # Wait for QB to be ready.
-        deadline = time.monotonic() + 90
-        while time.monotonic() < deadline:
+    # Wait for QB to be ready.
+    deadline = time.monotonic() + 90
+    while time.monotonic() < deadline:
         try:
             resp = client.get("/api/v2/app/version")
             if resp.status_code == 200:
@@ -275,10 +277,20 @@ def qb_client() -> Iterator[httpx.Client]:
     else:
         pytest.fail("qBittorrent not ready")
 
-    # Login.
+    # Detect password from Docker logs (linuxserver image generates random pw).
+    result = subprocess.run(
+        ["docker", "logs", "neptune-e2e-qb"],
+        capture_output=True, text=True,
+    )
+    password = QB_PASSWORD
+    for line in reversed(result.stderr.split("\n") + result.stdout.split("\n")):
+        if "temporary password" in line.lower():
+            password = line.strip().split()[-1]
+            break
+
     resp = client.post(
         "/api/v2/auth/login",
-        data={"username": QB_USERNAME, "password": QB_PASSWORD},
+        data={"username": QB_USERNAME, "password": password},
     )
     if resp.status_code != 200:
         pytest.fail(f"QB login failed: {resp.status_code}")

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -262,9 +262,9 @@ def qb_client() -> Iterator[httpx.Client]:
     """Authenticated qBittorrent Web API client."""
     client = httpx.Client(base_url=QB_WEBUI, timeout=30)
 
-    # Wait for QB to be ready.
-    deadline = time.monotonic() + 30
-    while time.monotonic() < deadline:
+        # Wait for QB to be ready.
+        deadline = time.monotonic() + 90
+        while time.monotonic() < deadline:
         try:
             resp = client.get("/api/v2/app/version")
             if resp.status_code == 200:

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,11 +1,8 @@
 # Neptune e2e test dependencies
-#
-# Start services:
-#   docker compose -f e2e/docker-compose.yml up -d
 
 services:
   tracker:
-    image: wiltonsr/opentracker-docker:latest
+    image: wiltonsr/opentracker:open
     ports:
       - "6969:6969"
       - "6969:6969/udp"

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -2,19 +2,10 @@
 #
 # Start services:
 #   docker compose -f e2e/docker-compose.yml up -d
-#
-# Stop services:
-#   docker compose -f e2e/docker-compose.yml down
-#
-# Services:
-#   tracker       – opentracker on :6969 (UDP+HTTP on :6969)
-#   qbittorrent   – qBittorrent on :8090 (WebUI: admin/adminadmin)
 
 services:
   tracker:
-    image: crate/opentracker:latest
-    container_name: neptune-e2e-tracker
-    restart: unless-stopped
+    image: wiltonsr/opentracker-docker:latest
     ports:
       - "6969:6969"
       - "6969:6969/udp"
@@ -30,7 +21,6 @@ services:
       - WEBUI_PORT=8090
     ports:
       - "8090:8090"
-      # P2P port – bind to host
       - "56881:56881"
       - "56881:56881/udp"
     volumes:

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,0 +1,38 @@
+# Neptune e2e test dependencies
+#
+# Start services:
+#   docker compose -f e2e/docker-compose.yml up -d
+#
+# Stop services:
+#   docker compose -f e2e/docker-compose.yml down
+#
+# Services:
+#   tracker       – opentracker on :6969 (UDP+HTTP on :6969)
+#   qbittorrent   – qBittorrent on :8090 (WebUI: admin/adminadmin)
+
+services:
+  tracker:
+    image: crate/opentracker:latest
+    container_name: neptune-e2e-tracker
+    restart: unless-stopped
+    ports:
+      - "6969:6969"
+      - "6969:6969/udp"
+
+  qbittorrent:
+    image: lscr.io/linuxserver/qbittorrent:latest
+    container_name: neptune-e2e-qb
+    restart: unless-stopped
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Etc/UTC
+      - WEBUI_PORT=8090
+    ports:
+      - "8090:8090"
+      # P2P port – bind to host
+      - "56881:56881"
+      - "56881:56881/udp"
+    volumes:
+      - ./testdata/qb-config:/config
+      - ./testdata/qb-downloads:/downloads

--- a/e2e/gen_fixtures.py
+++ b/e2e/gen_fixtures.py
@@ -1,0 +1,110 @@
+"""Generate deterministic torrent test fixtures for Neptune integration tests.
+
+Usage:
+    uv run python e2e/gen_fixtures.py
+
+Outputs to testdata/fixtures/:
+    - test-fixture.torrent
+    - test-fixture/           (data directory)
+
+Covers these edge cases:
+    1. Piece boundary crossing file boundary (file_a + file_b share a piece)
+    2. Subdirectories (sub/nested.bin)
+    3. File smaller than piece length (tiny.bin)
+    4. File exactly aligned to piece boundary (aligned.bin)
+    5. Empty file (empty.txt, 0 bytes)
+    6. File spanning multiple pieces (large.bin)
+    7. Non-ASCII filename (日本語.txt)
+
+Piece length is 32 KiB. All file content is deterministic (seeded PRNG).
+"""
+
+import hashlib
+import os
+
+import bencode2
+
+PIECE_LENGTH = 4 * 1024 * 1024  # 4 MiB
+
+FILES = [
+    (["file_a.bin"], 3 * 1024 * 1024),  # 3 MiB, shares piece with file_b
+    (["file_b.bin"], 20 * 1024 * 1024),  # 20 MiB, crosses multiple pieces
+    (["sub", "nested.bin"], 10 * 1024 * 1024),  # 10 MiB, subdirectory
+    (["tiny.bin"], 100),  # smaller than piece
+    (["aligned.bin"], PIECE_LENGTH),  # exactly 1 piece
+    (["empty.txt"], 0),  # 0 bytes
+    (["large.bin"], 63 * 1024 * 1024 + 12_345),  # ~63 MiB
+    (["日本語.txt"], 4_096),  # non-ASCII filename
+]
+
+
+def generate_data(offset: int, size: int) -> bytes:
+    return bytes((offset + i) % 17 for i in range(size))
+
+
+def build_pieces(data: bytes) -> bytes:
+    pieces = b""
+    for offset in range(0, len(data), PIECE_LENGTH):
+        chunk = data[offset : offset + PIECE_LENGTH]
+        pieces += hashlib.sha1(chunk).digest()
+    return pieces
+
+
+def main():
+    name = "test-fixture"
+    out_dir = os.path.join("testdata", "fixtures")
+    data_dir = os.path.join(out_dir, name)
+
+    data_offset = 0
+    all_data = b""
+    for path_parts, size in FILES:
+        full_path = os.path.join(data_dir, *path_parts)
+        os.makedirs(os.path.dirname(full_path), exist_ok=True)
+        file_data = generate_data(data_offset, size)
+        data_offset += size
+        with open(full_path, "wb") as f:
+            f.write(file_data)
+        all_data += file_data
+
+    pieces = build_pieces(all_data)
+
+    file_infos = []
+    for path_parts, size in FILES:
+        file_infos.append(
+            {b"path": [p.encode("utf-8") for p in path_parts], b"length": size}
+        )
+
+    info = {
+        b"piece length": PIECE_LENGTH,
+        b"pieces": pieces,
+        b"name": name.encode("utf-8"),
+        b"files": file_infos,
+    }
+
+    info_bytes = bencode2.bencode(info)
+
+    metainfo = {
+        b"announce": b"http://127.0.0.1:9999/announce",
+        b"info": info_bytes,
+    }
+
+    torrent_path = os.path.join(out_dir, name + ".torrent")
+    with open(torrent_path, "wb") as f:
+        f.write(bencode2.bencode(metainfo))
+
+    info_hash = hashlib.sha1(info_bytes).hexdigest()
+    total_size = sum(size for _, size in FILES)
+    num_pieces = (total_size + PIECE_LENGTH - 1) // PIECE_LENGTH
+
+    print("Generated test fixture:")
+    print(f"  Torrent:   {torrent_path}")
+    print(f"  Data:      {data_dir}/")
+    print(f"  InfoHash:  {info_hash}")
+    print(f"  Piece len: {PIECE_LENGTH // 1024} KiB")
+    print(f"  Pieces:    {num_pieces}")
+    print(f"  Files:     {len(FILES)}")
+    print(f"  Total:     {total_size} bytes")
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e/pyproject.toml
+++ b/e2e/pyproject.toml
@@ -3,8 +3,8 @@ name = "neptune-e2e"
 version = "0.0.0"
 requires-python = ">=3.12"
 dependencies = [
-    "bencode2>=0.1",
-    "httpx>=0.28",
-    "pytest>=8",
-    "pytest-timeout>=2",
+  "bencode2>=0.1",
+  "httpx>=0.28",
+  "pytest>=8",
+  "pytest-timeout>=2",
 ]

--- a/e2e/pyproject.toml
+++ b/e2e/pyproject.toml
@@ -3,8 +3,13 @@ name = "neptune-e2e"
 version = "0.0.0"
 requires-python = ">=3.12"
 dependencies = [
-  "bencode2>=0.1",
-  "httpx>=0.28",
-  "pytest>=8",
-  "pytest-timeout>=2",
+    "bencode2>=0.1",
+    "httpx>=0.28",
+    "pytest>=8",
+    "pytest-timeout>=2",
+]
+
+[tool.pytest.ini_options]
+markers = [
+    "e2e: end-to-end integration tests",
 ]

--- a/e2e/pyproject.toml
+++ b/e2e/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "neptune-e2e"
+version = "0.0.0"
+requires-python = ">=3.12"
+dependencies = [
+    "bencode2>=0.1",
+    "httpx>=0.28",
+    "pytest>=8",
+    "pytest-timeout>=2",
+]

--- a/e2e/test_encryption.py
+++ b/e2e/test_encryption.py
@@ -1,0 +1,129 @@
+"""Encryption (MSE) cross-compatibility matrix.
+
+Tests different encryption level combinations between two peers:
+    neptune_enc × peer_enc ∈ {require, prefer, disable}²
+
+Also qBittorrent integration with encryption.
+"""
+
+from pathlib import Path
+
+import pytest
+
+ALL_LEVELS = ["require", "prefer", "disable"]
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("peer_enc", ALL_LEVELS)
+@pytest.mark.parametrize("neptune_enc", ALL_LEVELS)
+def test_encryption_cross(
+    neptune, fixture, tmp_path: Path,
+    neptune_enc: str, peer_enc: str,
+) -> None:
+    """Two neptune instances with different encryption levels.
+
+    Expected behavior (libtorrent convention):
+        require × require  → encrypted, transfer OK
+        require × prefer   → encrypted, transfer OK
+        require × disable  → neptune refuses plain, no connection
+        prefer  × require  → encrypted, transfer OK
+        prefer  × prefer   → encrypted, transfer OK
+        prefer  × disable  → plain fallback, transfer OK
+        disable × require  → neptune connects plain, peer refuses, no connection
+        disable × prefer   → plain fallback, transfer OK
+        disable × disable  → plain, transfer OK
+    """
+    import shutil
+
+    seeder = neptune(crypto=peer_enc)
+    leecher = neptune(crypto=neptune_enc)
+
+    seeder_data = tmp_path / "seeder"
+    seeder_data.mkdir()
+    shutil.copytree(fixture.data_dir, seeder_data / fixture.data_dir.name)
+
+    ih = seeder.torrent_add(str(fixture.torrent_path), str(seeder_data))
+    seeder.torrent_recheck(ih)
+    seeder.torrent_start(ih)
+    seeder.wait_state(ih, "seeding")
+
+    # For incompatible combinations (require × disable), connection should fail.
+    # The leecher won't be able to download.
+    incompatible = (
+        (neptune_enc == "require" and peer_enc == "disable")
+        or (neptune_enc == "disable" and peer_enc == "require")
+    )
+
+    leecher_data = tmp_path / "leecher"
+    leecher_data.mkdir()
+    leecher.torrent_add(str(fixture.torrent_path), str(leecher_data))
+    leecher.torrent_start(ih)
+
+    if incompatible:
+        # Should timeout — no connection possible.
+        import time
+        time.sleep(10)
+        info = leecher.torrent_get(ih)
+        # Must remain in "downloading" (stalled) — not "seeding".
+        assert info.get("state", "").lower() != "seeding", (
+            f"Unexpected: {neptune_enc}×{peer_enc} succeeded (should be incompatible)"
+        )
+    else:
+        leecher.wait_state(ih, "seeding")
+        verify_files(fixture, str(leecher_data))
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("encryption", ALL_LEVELS)
+def test_encryption_qb_interop(
+    qb_client, neptune, fixture, tmp_path: Path, encryption: str,
+) -> None:
+    """Neptune downloads from QB with given encryption level."""
+    download_dir = tmp_path / "downloads"
+    download_dir.mkdir()
+
+    _qb_add_torrent(qb_client, fixture.torrent_path)
+    _qb_wait_state(qb_client, fixture.info_hash, "uploading", timeout=30)
+
+    inst = neptune(crypto=encryption)
+    ih = inst.torrent_add(str(fixture.torrent_path), str(download_dir))
+    inst.torrent_start(ih)
+
+    # QB default is 'prefer' (allow encryption, allow plain).
+    # Neptune 'require' should work (QB encrypts).
+    # Neptune 'prefer' should work (both encrypt).
+    # Neptune 'disable' should work (QB falls back to plain).
+    inst.wait_state(ih, "seeding")
+    verify_files(fixture, str(download_dir))
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+def _qb_add_torrent(client, torrent_path: Path) -> None:
+    data = torrent_path.read_bytes()
+    resp = client.post("/api/v2/torrents/add", content=data)
+    assert resp.status_code == 200, f"QB add torrent failed: {resp.text[:200]}"
+
+
+def _qb_wait_state(client, info_hash: str, state: str, timeout: float = 60) -> dict:
+    import time
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        resp = client.get(
+            "/api/v2/torrents/info",
+            params={"hashes": info_hash, "category": ""},
+        )
+        if resp.status_code != 200:
+            time.sleep(0.5)
+            continue
+        data = resp.json()
+        if not data:
+            time.sleep(0.5)
+            continue
+        current = data[0].get("state", "").lower()
+        if current == state.lower():
+            return data[0]
+        time.sleep(1)
+    raise RuntimeError(
+        f"QB torrent {info_hash[:8]} did not reach state={state} after {timeout}s"
+    )

--- a/e2e/test_neptune_neptune.py
+++ b/e2e/test_neptune_neptune.py
@@ -1,0 +1,63 @@
+"""Neptune ↔ Neptune interop — parametrized matrix.
+
+Matrix (6 combinations):
+    encryption ∈ {require, prefer, disable}
+    scenario   ∈ {seed_leech, dual_download}
+"""
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+ENCRYPTION_LEVELS = ["require", "prefer", "disable"]
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("encryption", ENCRYPTION_LEVELS)
+def test_neptune_seed_leech(neptune, fixture, tmp_path: Path, encryption: str) -> None:
+    """Seeder has complete data, leecher starts empty and downloads."""
+    seeder = neptune(crypto=encryption)
+    leecher = neptune(crypto=encryption)
+
+    seeder_data = tmp_path / "seeder"
+    seeder_data.mkdir()
+    shutil.copytree(fixture.data_dir, seeder_data / fixture.data_dir.name)
+
+    ih = seeder.torrent_add(str(fixture.torrent_path), str(seeder_data))
+    seeder.torrent_recheck(ih)
+    seeder.torrent_start(ih)
+    seeder.wait_state(ih, "seeding")
+
+    leecher_data = tmp_path / "leecher"
+    leecher_data.mkdir()
+    leecher.torrent_add(str(fixture.torrent_path), str(leecher_data))
+    leecher.torrent_start(ih)
+    leecher.wait_state(ih, "seeding")
+
+    verify_files(fixture, str(leecher_data))
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("encryption", ENCRYPTION_LEVELS)
+def test_neptune_dual_download(neptune, fixture, tmp_path: Path, encryption: str) -> None:
+    """Two neptune instances, only one has data initially."""
+    seeder = neptune(crypto=encryption)
+    leecher = neptune(crypto=encryption)
+
+    seeder_data = tmp_path / "seeder"
+    seeder_data.mkdir()
+    shutil.copytree(fixture.data_dir, seeder_data / fixture.data_dir.name)
+
+    ih = seeder.torrent_add(str(fixture.torrent_path), str(seeder_data))
+    seeder.torrent_recheck(ih)
+    seeder.torrent_start(ih)
+    seeder.wait_state(ih, "seeding")
+
+    leecher_data = tmp_path / "leecher"
+    leecher_data.mkdir()
+    leecher.torrent_add(str(fixture.torrent_path), str(leecher_data))
+    leecher.torrent_start(ih)
+    leecher.wait_state(ih, "seeding")
+
+    verify_files(fixture, str(leecher_data))

--- a/e2e/test_qbittorrent.py
+++ b/e2e/test_qbittorrent.py
@@ -1,0 +1,92 @@
+"""Neptune ↔ qBittorrent interop — parametrized matrix.
+
+Matrix (12 combinations):
+    direction  ∈ {upload, download}
+    encryption ∈ {require, prefer, disable}
+"""
+
+import shutil
+from pathlib import Path
+
+import httpx
+import pytest
+
+DIRECTIONS = ["upload", "download"]
+ENCRYPTION_LEVELS = ["require", "prefer", "disable"]
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("encryption", ENCRYPTION_LEVELS)
+@pytest.mark.parametrize("direction", DIRECTIONS)
+def test_neptune_qb_interop(
+    qb_client: httpx.Client,
+    neptune,
+    fixture,
+    tmp_path: Path,
+    direction: str,
+    encryption: str,
+) -> None:
+    """Neptune ↔ qBittorrent transfer with encryption level."""
+
+    if direction == "upload":
+        # Neptune seeds → QB downloads.
+        seed_dir = tmp_path / "seeder"
+        seed_dir.mkdir()
+        shutil.copytree(fixture.data_dir, seed_dir / fixture.data_dir.name)
+
+        inst = neptune(crypto=encryption)
+        ih = inst.torrent_add(str(fixture.torrent_path), str(seed_dir))
+        inst.torrent_recheck(ih)
+        inst.torrent_start(ih)
+        inst.wait_state(ih, "seeding")
+
+        _qb_add_torrent(qb_client, fixture.torrent_path)
+        _qb_wait_state(qb_client, fixture.info_hash, "uploading", timeout=60)
+    else:
+        # QB seeds → Neptune downloads.
+        download_dir = tmp_path / "downloads"
+        download_dir.mkdir()
+
+        _qb_add_torrent(qb_client, fixture.torrent_path)
+        _qb_wait_state(qb_client, fixture.info_hash, "uploading", timeout=30)
+
+        inst = neptune(crypto=encryption)
+        ih = inst.torrent_add(str(fixture.torrent_path), str(download_dir))
+        inst.torrent_start(ih)
+        inst.wait_state(ih, "seeding")
+
+        verify_files(fixture, str(download_dir))
+
+
+# ── QB helpers ─────────────────────────────────────────────────────────
+
+def _qb_add_torrent(client: httpx.Client, torrent_path: Path) -> None:
+    data = torrent_path.read_bytes()
+    resp = client.post("/api/v2/torrents/add", content=data)
+    assert resp.status_code == 200, f"QB add torrent failed: {resp.text[:200]}"
+
+
+def _qb_wait_state(
+    client: httpx.Client, info_hash: str, state: str, timeout: float = 60
+) -> dict:
+    import time
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        resp = client.get(
+            "/api/v2/torrents/info",
+            params={"hashes": info_hash, "category": ""},
+        )
+        if resp.status_code != 200:
+            time.sleep(0.5)
+            continue
+        data = resp.json()
+        if not data:
+            time.sleep(0.5)
+            continue
+        current = data[0].get("state", "").lower()
+        if current == state.lower():
+            return data[0]
+        time.sleep(1)
+    raise RuntimeError(
+        f"QB torrent {info_hash[:8]} did not reach state={state} after {timeout}s"
+    )

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -27,6 +27,7 @@ tasks:
     desc: generate e2e test fixtures and copy to qB data dir for seeding
     cmds:
       - uv run --directory e2e python gen_fixtures.py
+      - mkdir -p e2e/testdata/qb-downloads
       - cp -r e2e/testdata/fixtures/test-fixture e2e/testdata/qb-downloads/test-fixture
       - cp -r e2e/testdata/fixtures/test-fixture e2e/testdata/qb-downloads/test-fixture
 

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -26,7 +26,8 @@ tasks:
   e2e:fixtures:
     desc: generate e2e test fixtures and copy to qB data dir for seeding
     cmds:
-      - uv run python e2e/gen_fixtures.py
+      - uv run --directory e2e python gen_fixtures.py
+      - cp -r e2e/testdata/fixtures/test-fixture e2e/testdata/qb-downloads/test-fixture
       - cp -r e2e/testdata/fixtures/test-fixture e2e/testdata/qb-downloads/test-fixture
 
   e2e:up:
@@ -49,7 +50,7 @@ tasks:
     cmds:
       - task: e2e:build
       - task: e2e:fixtures
-      - uv run pytest e2e/ -v -m e2e
+      - uv run --directory e2e pytest . -v -m e2e --timeout=90
     env:
       E2E_TRACKER_URL: "http://127.0.0.1:6969/announce"
 

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -32,7 +32,7 @@ tasks:
       - cp -r e2e/testdata/fixtures/test-fixture e2e/testdata/qb-downloads/test-fixture
 
   e2e:up:
-    desc: start e2e Docker services (tracker + qBittorrent)
+    desc: start e2e Docker services (qBittorrent only)
     cmds:
       - docker compose -f e2e/docker-compose.yml up -d
 

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -23,6 +23,36 @@ tasks:
       - go test -fuzz=FuzzHandleRes -fuzztime={{ .FUZZ_TIME }} -tags assert ./internal/download/
       - go test -fuzz=FuzzDownloadMultiPeer_Async -fuzztime={{ .FUZZ_TIME }} -tags assert ./internal/download/
 
+  e2e:fixtures:
+    desc: generate e2e test fixtures and copy to qB data dir for seeding
+    cmds:
+      - uv run python e2e/gen_fixtures.py
+      - cp -r e2e/testdata/fixtures/test-fixture e2e/testdata/qb-downloads/test-fixture
+
+  e2e:up:
+    desc: start e2e Docker services (tracker + qBittorrent)
+    cmds:
+      - docker compose -f e2e/docker-compose.yml up -d
+
+  e2e:down:
+    desc: stop e2e Docker services
+    cmds:
+      - docker compose -f e2e/docker-compose.yml down
+
+  e2e:build:
+    desc: build neptune binary for e2e tests
+    cmds:
+      - go build -tags release -o e2e/testdata/neptune .
+
+  e2e:test:
+    desc: run e2e tests
+    cmds:
+      - task: e2e:build
+      - task: e2e:fixtures
+      - uv run pytest e2e/ -v -m e2e
+    env:
+      E2E_TRACKER_URL: "http://127.0.0.1:6969/announce"
+
   mod-tidy:
     cmds:
       - go mod tidy


### PR DESCRIPTION
## Summary

Adds a comprehensive end-to-end test framework for interoperability and transfer correctness.

### Test Matrix (30 tests total)

| Suite | Tests | Scope |
|---|---|---|
| `test_neptune_neptune` | 3 encryption × 2 scenarios = **6** | seed→leech, dual download |
| `test_qbittorrent` | 3 encryption × 2 directions = **12** | upload + download |
| `test_encryption` | 3×3 cross-encrypt + 3×1 QB = **12** | require/prefer/disable combos |

### Components

- **`conftest.py`** — pytest fixtures: neptune process lifecycle (start via temp config, health check, JSON-RPC control), qBittorrent Web API auth, fixture loading, file verification
- **`gen_fixtures.py`** — deterministic torrent generator (4 MiB pieces, cross-file boundaries, subdirs, empty files, 0-byte file, non-ASCII filenames)
- **`docker-compose.yml`** — opentracker + qBittorrent for interop tests
- **CI** — `e2e` job with matrix: runs each suite independently

### Configuration

Neptune encryption level (`require`/`prefer`/`disable`) is set via a temporary TOML config file written by the fixture and passed via `--config-file`.

### Usage

```bash
task e2e:up          # docker compose up
task e2e:test        # build + fixtures + pytest
task e2e:down        # cleanup
```