### PR TITLE
fix(sdk): support require(esm) with node-specific imports

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -19,6 +19,7 @@
     ".": {
       "node": {
         "import": "./dist/client.node.js",
+        "require": "./dist/client.node.js",
         "types": "./dist/client.node.d.ts"
       },
       "browser": {


### PR DESCRIPTION
In flood, running dev server doesn't work.

```
❯ pnpm dev
$ concurrently 'panda --watch' 'vite --config vite.config.ts' 'tsx watch server/bin/start.ts'
[1]
[1]   VITE v6.4.3  ready in 252 ms
[1]
[1]   ➜  Local:   http://localhost:4200/
[1]   ➜  Network: http://172.16.26.43:4200/
[1]   ➜  Network: http://100.101.44.29:4200/
[2] node:internal/modules/esm/resolve:315
[2]   return new ERR_PACKAGE_PATH_NOT_EXPORTED(
[2]          ^
[2]
[2] Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /home/slagiewka/code/slagiewka/flood/node_modules/@trim21/neptune/package.json
[2]     at exportsNotFound (node:internal/modules/esm/resolve:315:10)
[2]     at packageExportsResolve (node:internal/modules/esm/resolve:606:13)
[2]     at resolveExports (node:internal/modules/cjs/loader:759:36)
[2]     at Module._findPath (node:internal/modules/cjs/loader:826:31)
[2]     at node:internal/modules/cjs/loader:1562:27
[2]     at nextResolveSimple (/home/slagiewka/code/slagiewka/flood/node_modules/tsx/dist/register-BoI6-WNn.cjs:10:1017)
[2]     at /home/slagiewka/code/slagiewka/flood/node_modules/tsx/dist/register-BoI6-WNn.cjs:9:4613
[2]     at /home/slagiewka/code/slagiewka/flood/node_modules/tsx/dist/register-BoI6-WNn.cjs:9:3894
[2]     at resolveTsPaths (/home/slagiewka/code/slagiewka/flood/node_modules/tsx/dist/register-BoI6-WNn.cjs:10:770)
[2]     at /home/slagiewka/code/slagiewka/flood/node_modules/tsx/dist/register-BoI6-WNn.cjs:10:1171 {
[2]   code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
[2] }
[2]
[2] Node.js v26.5.0
```

I did a quick manual fix inside `node_modules` and it runs then. This makes the `require` path still fall onto the ESM code anyway.