### PR TITLE
refactor(download): dispatch connections via per-download FIFO connect loop

### DIFF
--- a/internal/download/conn.go
+++ b/internal/download/conn.go
@@ -124,9 +124,6 @@ type peerConn struct {
 	encrypted bool
 }
 
-// errConnectionLimit is reported when the global connection slot is exhausted.
-var errConnectionLimit = errors.New("connection limit reached")
-
 // dial establishes a TCP connection to addr, configuring deadline and linger.
 func (d *Download) dial(ctx context.Context, addr netip.AddrPort) (net.Conn, error) {
 	conn, err := global.Dial(ctx, "tcp", addr.String())
@@ -143,29 +140,16 @@ func (d *Download) dial(ctx context.Context, addr netip.AddrPort) (net.Conn, err
 	return conn, nil
 }
 
-// connectPeer establishes a full connection to a peer: TCP dial plus an
-// optional MSE handshake. The caller holds DialSem.
-//
-// The returned peerConn owns a global connection slot; on success the slot
-// ownership transfers with the conn to the registered peer (released by
-// recordDisconnect). On failure the slot is released automatically.
+// connectPeerWithReservedSlot establishes a full connection to a peer: TCP
+// dial plus an optional MSE handshake, using a ConnSem slot already reserved
+// and counted by the caller. It transfers that slot to the caller (and
+// eventually the registered peer) on success, or releases it on every failure
+// path. The caller holds DialSem.
 //
 // In prefer mode a failed MSE handshake closes the polluted connection and
 // retries plaintext on a fresh TCP connection: the old connection's byte
 // stream already contains MSE handshake data, so a plaintext handshake on
 // it can never succeed.
-func (d *Download) connectPeer(ctx context.Context, pp *persistentPeer) (peerConn, error) {
-	// Grab a global connection slot before dialing.
-	if !d.session.ConnSem.TryAcquire(1) {
-		return peerConn{}, errConnectionLimit
-	}
-	d.session.ConnCount.Add(1)
-	return d.connectPeerWithReservedSlot(ctx, pp)
-}
-
-// connectPeerWithReservedSlot establishes a connection using a ConnSem slot
-// already reserved by the caller. It transfers that slot to the peer on
-// success, or releases it on every failure path.
 func (d *Download) connectPeerWithReservedSlot(ctx context.Context, pp *persistentPeer) (peerConn, error) {
 	// Every failure path releases the slot; success transfers ownership.
 	owned := false

--- a/internal/download/conn.go
+++ b/internal/download/conn.go
@@ -82,17 +82,13 @@ func (d *Download) connectLoop() {
 // do not occupy positions in its FIFO wait queue.
 func (d *Download) dispatchConnections() {
 	for {
-		if !d.IsActive() || d.peerCount() >= d.maxConnections() {
-			return
-		}
-		if !d.reserveOutgoingSlot() {
+		if !d.IsActive() || d.occupiedConnectionCount() >= d.maxConnections() {
 			return
 		}
 
 		now := time.Now().Unix()
 		candidates := d.peerList.connectPeers(now, 1)
 		if len(candidates) == 0 {
-			d.releaseOutgoingSlot()
 			return
 		}
 		candidate := candidates[0]
@@ -101,13 +97,11 @@ func (d *Download) dispatchConnections() {
 		// have raced candidate selection.
 		if !d.peerList.canDial(candidate, now) {
 			d.peerList.clearDialing(candidate)
-			d.releaseOutgoingSlot()
 			continue
 		}
 
-		if err := d.session.DialSem.Acquire(d.connectAttemptContext(), 1); err != nil {
+		if err := d.session.DialSem.Acquire(d.ctx, 1); err != nil {
 			d.peerList.clearDialing(candidate)
-			d.releaseOutgoingSlot()
 			return
 		}
 
@@ -196,18 +190,10 @@ func (d *Download) connectPeerWithReservedSlot(ctx context.Context, pp *persiste
 // connection to a candidate peer. DialSem is held while waiting, which bounds
 // the number of ConnSem waiters and preserves FIFO scheduling across downloads.
 func (d *Download) tryDial(pp *persistentPeer) {
-	pendingOwned := true
-	defer func() {
-		if pendingOwned {
-			d.releaseOutgoingSlotAndSignal()
-		}
-	}()
-
 	// ConnSem represents the actual scarce resource. Blocking here rather
 	// than failing fast makes the next released connection slot go to the
 	// longest-waiting dial, instead of only waking its owning download.
-	connectCtx := d.connectAttemptContext()
-	if err := d.session.ConnSem.Acquire(connectCtx, 1); err != nil {
+	if err := d.session.ConnSem.Acquire(d.ctx, 1); err != nil {
 		d.peerList.clearDialing(pp)
 		return
 	}
@@ -219,9 +205,10 @@ func (d *Download) tryDial(pp *persistentPeer) {
 		d.peerList.clearDialing(pp)
 		d.session.ConnSem.Release(1)
 		d.session.ConnCount.Sub(1)
+		d.signalConnect()
 		return
 	}
-	ctx, cancel := context.WithTimeout(connectCtx, peerConnectTimeout)
+	ctx, cancel := context.WithTimeout(d.ctx, peerConnectTimeout)
 	defer cancel()
 
 	d.log.Trace().Msgf("try to connect to peer %s", pp.addrPort)
@@ -229,11 +216,13 @@ func (d *Download) tryDial(pp *persistentPeer) {
 	pc, err := d.connectPeerWithReservedSlot(ctx, pp)
 	if err != nil {
 		d.peerList.incFailcount(pp, err.Error())
+		// The failed dial clears the candidate's dialing flag, freeing this
+		// download's in-flight slot: wake the loop to dispatch the next one.
+		d.signalConnect()
 		return
 	}
 
-	p := newPendingOutgoingPeer(pc.conn, d, pp.addrPort, pc.encrypted)
-	pendingOwned = false
+	p := NewOutgoingPeer(pc.conn, d, pp.addrPort, pc.encrypted)
 	// Register the connection in the persistent peer list.
 	d.peerList.newConnection(pp.addrPort, p, time.Now().Unix())
 }
@@ -322,22 +311,9 @@ func (d *Download) EvictPeers(n int) int {
 
 // peerTurnover disconnects least useful peers to make room for fresh candidates.
 // Mirrors libtorrent's optimistic disconnect (~2% per round).
-// When the download is pending (queued), all peers are disconnected to free
-// global connection slots for active downloads.
 func (d *Download) peerTurnover() {
 	peerCount := d.peers.Size()
 	if peerCount == 0 {
-		return
-	}
-
-	// Pending (queued) downloads don't need any peers — disconnect all to
-	// free global connection slots. Peers will be reconnected when the
-	// download is promoted back to Downloading.
-	if d.HasState(PendingDownloading) {
-		d.peers.Range(func(_ uint64, p Peer) bool {
-			p.Close()
-			return true
-		})
 		return
 	}
 

--- a/internal/download/conn.go
+++ b/internal/download/conn.go
@@ -111,7 +111,10 @@ func (d *Download) dispatchConnections() {
 			return
 		}
 
-		go d.tryDial(candidate)
+		go func() {
+			defer d.session.DialSem.Release(1)
+			d.tryDial(candidate)
+		}()
 	}
 }
 
@@ -209,7 +212,6 @@ func (d *Download) connectPeerWithReservedSlot(ctx context.Context, pp *persiste
 // connection to a candidate peer. DialSem is held while waiting, which bounds
 // the number of ConnSem waiters and preserves FIFO scheduling across downloads.
 func (d *Download) tryDial(pp *persistentPeer) {
-	defer d.session.DialSem.Release(1)
 	pendingOwned := true
 	defer func() {
 		if pendingOwned {

--- a/internal/download/conn.go
+++ b/internal/download/conn.go
@@ -35,13 +35,12 @@ func (d *Download) AddConn(addr netip.AddrPort, conn net.Conn, h proto.Handshake
 		conn.Close()
 		return
 	}
-	if d.peers.Size() >= d.maxConnections() {
+	if !d.peerList.tryOpenIncoming(addr, d.maxConnections()) {
 		d.session.ConnSem.Release(1)
 		d.session.ConnCount.Sub(1)
 		conn.Close()
 		return
 	}
-	d.peerList.incomingConnectionOpened(addr)
 	NewIncomingPeer(conn, d, addr, h, encrypted)
 }
 
@@ -66,7 +65,9 @@ func (d *Download) connectLoop() {
 	defer reconnectTicker.Stop()
 
 	for {
-		d.dispatchConnections()
+		if d.dispatchConnections() {
+			continue
+		}
 
 		select {
 		case <-d.ctx.Done():
@@ -77,39 +78,30 @@ func (d *Download) connectLoop() {
 	}
 }
 
-// dispatchConnections dispatches up to the current per-torrent free capacity.
-// Candidates are selected before waiting on DialSem, so downloads with no work
-// do not occupy positions in its FIFO wait queue.
-func (d *Download) dispatchConnections() {
-	for {
-		if !d.IsActive() || d.occupiedConnectionCount() >= d.maxConnections() {
-			return
-		}
-
-		now := time.Now().Unix()
-		candidates := d.peerList.connectPeers(now, 1)
-		if len(candidates) == 0 {
-			return
-		}
-		candidate := candidates[0]
-
-		// Re-check after peerList unlocks: an incoming connection or ban may
-		// have raced candidate selection.
-		if !d.peerList.canDial(candidate, now) {
-			d.peerList.clearDialing(candidate)
-			continue
-		}
-
-		if err := d.session.DialSem.Acquire(d.ctx, 1); err != nil {
-			d.peerList.clearDialing(candidate)
-			return
-		}
-
-		go func() {
-			defer d.session.DialSem.Release(1)
-			d.tryDial(candidate)
-		}()
+// dispatchConnections executes one fair connection turn. The download joins
+// DialSem before selecting a candidate, re-checks all local state after the
+// wait, and releases the turn after one transport attempt. A download can
+// therefore occupy at most one position in each global FIFO.
+func (d *Download) dispatchConnections() bool {
+	now := time.Now().Unix()
+	if !d.IsActive() || !d.peerList.hasConnectWork(now, d.maxConnections()) {
+		return false
 	}
+	if err := d.session.DialSem.Acquire(d.ctx, 1); err != nil {
+		return false
+	}
+	defer d.session.DialSem.Release(1)
+
+	if !d.IsActive() {
+		return false
+	}
+	candidate := d.peerList.pickConnectCandidate(time.Now().Unix(), d.maxConnections())
+	if candidate == nil {
+		return false
+	}
+
+	d.tryDial(candidate)
+	return true
 }
 
 // peerConn is an established peer transport connection.
@@ -222,28 +214,33 @@ func (d *Download) tryDial(pp *persistentPeer) {
 		return
 	}
 
-	p := NewOutgoingPeer(pc.conn, d, pp.addrPort, pc.encrypted)
-	// Register the connection in the persistent peer list.
-	d.peerList.newConnection(pp.addrPort, p, time.Now().Unix())
+	p := newUnstartedOutgoingPeer(pc.conn, d, pp.addrPort, pc.encrypted)
+	// Attach ownership before starting the handshake goroutine so every close
+	// path can remove exactly this connection from the persistent peer entry.
+	if !d.peerList.newConnection(pp.addrPort, p, time.Now().Unix()) {
+		p.Close()
+		return
+	}
+	p.startAsync(false)
 }
 
 // recordDisconnect is called by Peer.Close() to clean up shared peer tracking.
-// The connectedAddrs/peerList part is skipped if p is not the primary peer
-// for its address (e.g. when a replacement has already arrived).
+// Outgoing peer-list ownership is cleared by identity, while connectedAddrs is
+// removed only when p is still the primary peer for its address.
 func (d *Download) recordDisconnect(p Peer) {
 	if p.Incoming() {
 		d.peerList.incomingConnectionClosed(p.Addr())
 	}
+
+	failed := p.CloseError() != nil &&
+		!errors.Is(p.CloseError(), io.EOF) &&
+		!errors.Is(p.CloseError(), context.Canceled)
+	if !p.Incoming() {
+		d.peerList.connectionClosed(p.Addr(), p, time.Now().Unix(), p.HadTransfer(), failed)
+	}
+
 	if actual, ok := d.connectedAddrs.Load(p.Addr()); ok && actual == p {
 		d.connectedAddrs.Delete(p.Addr())
-
-		failed := p.CloseError() != nil &&
-			!errors.Is(p.CloseError(), io.EOF) &&
-			!errors.Is(p.CloseError(), context.Canceled)
-
-		if !p.Incoming() {
-			d.peerList.connectionClosed(p.Addr(), time.Now().Unix(), p.HadTransfer(), failed)
-		}
 	}
 
 	d.peers.Delete(p.ID())

--- a/internal/download/conn.go
+++ b/internal/download/conn.go
@@ -16,7 +16,6 @@ import (
 	"github.com/trim21/errgo"
 
 	"neptune/internal/mse"
-	"neptune/internal/pkg/empty"
 	"neptune/internal/pkg/global"
 	"neptune/internal/proto"
 )
@@ -45,53 +44,76 @@ func (d *Download) AddConn(addr netip.AddrPort, conn net.Conn, h proto.Handshake
 	NewIncomingPeer(conn, d, addr, h, encrypted)
 }
 
-// connectToPeers tries to connect to candidate peers from the peer list.
-// Mirrors libtorrent's torrent::try_connect_peer loop.
-func (d *Download) connectToPeers(maxSlots int) int {
-	now := time.Now().Unix()
-	connected := 0
+// connectLoop is the per-download connection driver. It dispatches dials for
+// candidate peers until there is nothing left to do, then sleeps until an
+// event (new peers, a closed connection, a state change) wakes it.
+//
+// Fairness across downloads comes from DialSem itself: Acquire is FIFO, so
+// when the global dial slots are exhausted, competing downloads queue up and
+// are served in arrival order — one download whose peers are all slow to
+// time out can no longer starve others out of the slots. The download's own
+// ctx bounds the loop, so closing the download releases everything (no
+// goroutine leak, no dialing flag leak).
+//
+// The periodic ticker mirrors libtorrent's on_tick connection pass: peer
+// candidates become eligible again purely as a function of time (failcount
+// backoff in findConnectCandidates), so time-driven retries need a periodic
+// wakeup, not just events. The interval is long enough that the loop is
+// otherwise event-driven and stays quiet when there is nothing to do.
+func (d *Download) connectLoop() {
+	reconnectTicker := time.NewTicker(30 * time.Second)
+	defer reconnectTicker.Stop()
 
-	for connected < maxSlots {
-		remaining := maxSlots - connected
-		candidates := d.peerList.connectPeers(now, remaining)
-		if len(candidates) == 0 {
-			break
-		}
+	for {
+		d.dispatchConnections()
 
-		semFull := false
-		for _, candidate := range candidates {
-			if semFull {
-				d.peerList.clearDialing(candidate)
-				continue
-			}
-			if _, ok := d.connectedAddrs.Load(candidate.addrPort); ok {
-				d.peerList.clearDialing(candidate)
-				continue
-			}
-			if d.isAddrBanned(candidate.addrPort.Addr()) {
-				d.peerList.clearDialing(candidate)
-				continue
-			}
-			if !d.session.DialSem.TryAcquire(1) {
-				d.peerList.clearDialing(candidate)
-				semFull = true
-				// Continue the inner loop to clearDialing remaining
-				// candidates, then stop: no point retrying until slots free up.
-				continue
-			}
-			go d.tryDial(candidate)
-			connected++
-			if connected >= maxSlots {
-				return connected
-			}
-		}
-
-		if semFull {
-			return connected
+		select {
+		case <-d.ctx.Done():
+			return
+		case <-d.connectSignal:
+		case <-reconnectTicker.C:
 		}
 	}
+}
 
-	return connected
+// dispatchConnections dials candidates one at a time. DialSem slots are held
+// by the async dial goroutines until they finish, so a single download can
+// have multiple dials in flight (up to DialSem capacity) while other
+// downloads' pending Acquire calls still get served between our dials.
+func (d *Download) dispatchConnections() {
+	for {
+		if !d.IsActive() || d.peerCount() >= d.maxConnections() {
+			return
+		}
+
+		// Global connection pool full: stop dispatching. Without this short
+		// circuit, dials would fail immediately with errConnectionLimit and
+		// the loop would spin — each candidate is restored via clearDialing
+		// and immediately re-picked. recordDisconnect wakes the loop when a
+		// slot frees up.
+		if int(d.session.ConnCount.Load()) >= int(d.session.Config.App.GlobalConnectionLimit) {
+			return
+		}
+
+		if err := d.session.DialSem.Acquire(d.ctx, 1); err != nil {
+			return // download closed; DialSem unchanged on ctx cancel
+		}
+
+		// State may have changed while blocked on DialSem; re-check before
+		// committing a dial.
+		if !d.IsActive() || d.peerCount() >= d.maxConnections() {
+			d.session.DialSem.Release(1)
+			return
+		}
+
+		candidates := d.peerList.connectPeers(time.Now().Unix(), 1)
+		if len(candidates) == 0 {
+			d.session.DialSem.Release(1)
+			return // no candidates; re-woken when new peers arrive
+		}
+
+		go d.tryDial(candidates[0])
+	}
 }
 
 // peerConn is an established peer transport connection.
@@ -179,7 +201,8 @@ func (d *Download) connectPeer(ctx context.Context, pp *persistentPeer) (peerCon
 }
 
 // tryDial attempts to establish a connection to a candidate peer.
-// DialSem is held by the caller; it is released on every exit path.
+// DialSem is held by the caller (dispatchConnections); it is released on
+// every exit path so the next dial can start.
 // On success, registers the connection in the peer list.
 // On failure, increments failcount.
 func (d *Download) tryDial(pp *persistentPeer) {
@@ -192,16 +215,17 @@ func (d *Download) tryDial(pp *persistentPeer) {
 
 	pc, err := d.connectPeer(ctx, pp)
 	if err != nil {
-		// A full global connection slot is our own capacity limit, not a
-		// failure of the peer — don't penalize the peer's failcount.
-		if !errors.Is(err, errConnectionLimit) {
-			d.peerList.incFailcount(pp, err.Error())
+		if errors.Is(err, errConnectionLimit) {
+			// The global connection pool was full by the time we dialed (e.g.
+			// an incoming connection raced us for the last slot). This is our
+			// own capacity limit, not a peer failure: restore the candidate
+			// without penalizing its failcount, and rely on the ConnCount
+			// short-circuit in dispatchConnections to stop further attempts
+			// until a connection closes.
+			d.peerList.clearDialing(pp)
+			return
 		}
-		// Wake up connection loop to try next candidate.
-		select {
-		case d.pendingPeersSignal <- empty.Empty{}:
-		default:
-		}
+		d.peerList.incFailcount(pp, err.Error())
 		return
 	}
 
@@ -230,13 +254,9 @@ func (d *Download) recordDisconnect(p Peer) {
 	d.session.ConnSem.Release(1)
 	d.session.ConnCount.Sub(1)
 
-	// Wake up connection loop to fill the freed slot.
-	if d.IsActive() {
-		select {
-		case d.pendingPeersSignal <- empty.Empty{}:
-		default:
-		}
-	}
+	// The freed global connection slot (and possibly a freed per-torrent
+	// slot) lets this download dispatch a new candidate immediately.
+	d.signalConnect()
 
 	// Notify scheduler: blocks freed by abortDownload are now available
 	// for other peers to pick up immediately.

--- a/internal/download/conn.go
+++ b/internal/download/conn.go
@@ -41,6 +41,7 @@ func (d *Download) AddConn(addr netip.AddrPort, conn net.Conn, h proto.Handshake
 		conn.Close()
 		return
 	}
+	d.peerList.incomingConnectionOpened(addr)
 	NewIncomingPeer(conn, d, addr, h, encrypted)
 }
 
@@ -76,43 +77,41 @@ func (d *Download) connectLoop() {
 	}
 }
 
-// dispatchConnections dials candidates one at a time. DialSem slots are held
-// by the async dial goroutines until they finish, so a single download can
-// have multiple dials in flight (up to DialSem capacity) while other
-// downloads' pending Acquire calls still get served between our dials.
+// dispatchConnections dispatches up to the current per-torrent free capacity.
+// Candidates are selected before waiting on DialSem, so downloads with no work
+// do not occupy positions in its FIFO wait queue.
 func (d *Download) dispatchConnections() {
 	for {
 		if !d.IsActive() || d.peerCount() >= d.maxConnections() {
 			return
 		}
-
-		// Global connection pool full: stop dispatching. Without this short
-		// circuit, dials would fail immediately with errConnectionLimit and
-		// the loop would spin — each candidate is restored via clearDialing
-		// and immediately re-picked. recordDisconnect wakes the loop when a
-		// slot frees up.
-		if int(d.session.ConnCount.Load()) >= int(d.session.Config.App.GlobalConnectionLimit) {
+		if !d.reserveOutgoingSlot() {
 			return
 		}
 
-		if err := d.session.DialSem.Acquire(d.ctx, 1); err != nil {
-			return // download closed; DialSem unchanged on ctx cancel
-		}
-
-		// State may have changed while blocked on DialSem; re-check before
-		// committing a dial.
-		if !d.IsActive() || d.peerCount() >= d.maxConnections() {
-			d.session.DialSem.Release(1)
-			return
-		}
-
-		candidates := d.peerList.connectPeers(time.Now().Unix(), 1)
+		now := time.Now().Unix()
+		candidates := d.peerList.connectPeers(now, 1)
 		if len(candidates) == 0 {
-			d.session.DialSem.Release(1)
-			return // no candidates; re-woken when new peers arrive
+			d.releaseOutgoingSlot()
+			return
+		}
+		candidate := candidates[0]
+
+		// Re-check after peerList unlocks: an incoming connection or ban may
+		// have raced candidate selection.
+		if !d.peerList.canDial(candidate, now) {
+			d.peerList.clearDialing(candidate)
+			d.releaseOutgoingSlot()
+			continue
 		}
 
-		go d.tryDial(candidates[0])
+		if err := d.session.DialSem.Acquire(d.connectAttemptContext(), 1); err != nil {
+			d.peerList.clearDialing(candidate)
+			d.releaseOutgoingSlot()
+			return
+		}
+
+		go d.tryDial(candidate)
 	}
 }
 
@@ -158,7 +157,13 @@ func (d *Download) connectPeer(ctx context.Context, pp *persistentPeer) (peerCon
 		return peerConn{}, errConnectionLimit
 	}
 	d.session.ConnCount.Add(1)
+	return d.connectPeerWithReservedSlot(ctx, pp)
+}
 
+// connectPeerWithReservedSlot establishes a connection using a ConnSem slot
+// already reserved by the caller. It transfers that slot to the peer on
+// success, or releases it on every failure path.
+func (d *Download) connectPeerWithReservedSlot(ctx context.Context, pp *persistentPeer) (peerConn, error) {
 	// Every failure path releases the slot; success transfers ownership.
 	owned := false
 	defer func() {
@@ -200,36 +205,49 @@ func (d *Download) connectPeer(ctx context.Context, pp *persistentPeer) (peerCon
 	return peerConn{conn: plainConn}, nil
 }
 
-// tryDial attempts to establish a connection to a candidate peer.
-// DialSem is held by the caller (dispatchConnections); it is released on
-// every exit path so the next dial can start.
-// On success, registers the connection in the peer list.
-// On failure, increments failcount.
+// tryDial waits fairly for a global connection slot, then establishes a
+// connection to a candidate peer. DialSem is held while waiting, which bounds
+// the number of ConnSem waiters and preserves FIFO scheduling across downloads.
 func (d *Download) tryDial(pp *persistentPeer) {
 	defer d.session.DialSem.Release(1)
+	pendingOwned := true
+	defer func() {
+		if pendingOwned {
+			d.releaseOutgoingSlotAndSignal()
+		}
+	}()
 
-	ctx, cancel := context.WithTimeout(d.ctx, peerConnectTimeout)
+	// ConnSem represents the actual scarce resource. Blocking here rather
+	// than failing fast makes the next released connection slot go to the
+	// longest-waiting dial, instead of only waking its owning download.
+	connectCtx := d.connectAttemptContext()
+	if err := d.session.ConnSem.Acquire(connectCtx, 1); err != nil {
+		d.peerList.clearDialing(pp)
+		return
+	}
+	d.session.ConnCount.Add(1)
+
+	// The download state or candidate may have changed while waiting for the
+	// global slot. Do not start a stale dial, and return ownership immediately.
+	if !d.IsActive() || !d.peerList.canDial(pp, time.Now().Unix()) {
+		d.peerList.clearDialing(pp)
+		d.session.ConnSem.Release(1)
+		d.session.ConnCount.Sub(1)
+		return
+	}
+	ctx, cancel := context.WithTimeout(connectCtx, peerConnectTimeout)
 	defer cancel()
 
 	d.log.Trace().Msgf("try to connect to peer %s", pp.addrPort)
 
-	pc, err := d.connectPeer(ctx, pp)
+	pc, err := d.connectPeerWithReservedSlot(ctx, pp)
 	if err != nil {
-		if errors.Is(err, errConnectionLimit) {
-			// The global connection pool was full by the time we dialed (e.g.
-			// an incoming connection raced us for the last slot). This is our
-			// own capacity limit, not a peer failure: restore the candidate
-			// without penalizing its failcount, and rely on the ConnCount
-			// short-circuit in dispatchConnections to stop further attempts
-			// until a connection closes.
-			d.peerList.clearDialing(pp)
-			return
-		}
 		d.peerList.incFailcount(pp, err.Error())
 		return
 	}
 
-	p := NewOutgoingPeer(pc.conn, d, pp.addrPort, pc.encrypted)
+	p := newPendingOutgoingPeer(pc.conn, d, pp.addrPort, pc.encrypted)
+	pendingOwned = false
 	// Register the connection in the persistent peer list.
 	d.peerList.newConnection(pp.addrPort, p, time.Now().Unix())
 }
@@ -238,6 +256,9 @@ func (d *Download) tryDial(pp *persistentPeer) {
 // The connectedAddrs/peerList part is skipped if p is not the primary peer
 // for its address (e.g. when a replacement has already arrived).
 func (d *Download) recordDisconnect(p Peer) {
+	if p.Incoming() {
+		d.peerList.incomingConnectionClosed(p.Addr())
+	}
 	if actual, ok := d.connectedAddrs.Load(p.Addr()); ok && actual == p {
 		d.connectedAddrs.Delete(p.Addr())
 
@@ -366,7 +387,9 @@ func (d *Download) isAddrBanned(addr netip.Addr) bool {
 
 // banAddr bans an address from connecting to this torrent for addrBanDuration.
 func (d *Download) banAddr(addr netip.Addr) {
+	expires := time.Now().Add(addrBanDuration)
 	d.bannedAddrsMu.Lock()
-	d.bannedAddrs[addr] = time.Now().Add(addrBanDuration)
+	d.bannedAddrs[addr] = expires
 	d.bannedAddrsMu.Unlock()
+	d.peerList.banAddr(addr, expires)
 }

--- a/internal/download/conn_mse_test.go
+++ b/internal/download/conn_mse_test.go
@@ -72,10 +72,18 @@ func TestConnectPeerFallbackToPlaintext(t *testing.T) {
 	defer cancel()
 
 	pp := &persistentPeer{addrPort: addr}
-	pc, err := d.connectPeer(ctx, pp)
+	// Reserve a global connection slot the way tryDial does before dialing.
+	require.True(t, d.session.ConnSem.TryAcquire(1))
+	d.session.ConnCount.Add(1)
+	pc, err := d.connectPeerWithReservedSlot(ctx, pp)
 	require.NoError(t, err)
 	require.False(t, pc.encrypted, "fallback connection must be plaintext")
-	defer pc.conn.Close()
+	defer func() {
+		pc.conn.Close()
+		// Success transfers slot ownership to the caller; release it here.
+		d.session.ConnSem.Release(1)
+		d.session.ConnCount.Sub(1)
+	}()
 
 	// Plaintext handshake on the fresh connection (normally done by the peer).
 	require.NoError(t, proto.SendHandshake(pc.conn, d.info.Hash, testOutgoingPeerID, d.private))
@@ -122,7 +130,9 @@ func TestConnectPeerMSEForceNoFallback(t *testing.T) {
 	defer cancel()
 
 	pp := &persistentPeer{addrPort: addr}
-	pc, err := d.connectPeer(ctx, pp)
+	require.True(t, d.session.ConnSem.TryAcquire(1))
+	d.session.ConnCount.Add(1)
+	pc, err := d.connectPeerWithReservedSlot(ctx, pp)
 	require.Error(t, err, "force mode must fail on MSE handshake error")
 	require.Nil(t, pc.conn)
 
@@ -133,36 +143,7 @@ func TestConnectPeerMSEForceNoFallback(t *testing.T) {
 	_, err = ln.Accept()
 	require.Error(t, err, "force mode must not attempt a plaintext fallback connection")
 
-	// The failed attempt must have released the connection slot.
+	// The failed attempt must have released the reserved connection slot.
 	require.True(t, d.session.ConnSem.TryAcquire(200), "failed connect must release the connection slot")
-}
-
-// TestConnectPeerReturnsErrConnectionLimit verifies that a full global
-// connection slot fails fast with errConnectionLimit, without dialing or
-// establishing any connection. tryDial skips the peer's failcount for this
-// error because it is our own capacity limit, not a peer failure.
-func TestConnectPeerReturnsErrConnectionLimit(t *testing.T) {
-	var lc net.ListenConfig
-	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	defer ln.Close()
-
-	addr := ln.Addr().(*net.TCPAddr).AddrPort()
-
-	d := newTestDownload(t, 1, 4, piece_store.NewMemStore)
-	// Occupy the full connection semaphore.
-	require.True(t, d.session.ConnSem.TryAcquire(200))
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-
-	pp := &persistentPeer{addrPort: addr}
-	pc, err := d.connectPeer(ctx, pp)
-	require.ErrorIs(t, err, errConnectionLimit)
-	require.Nil(t, pc.conn)
-
-	// No connection should have been dialed.
-	_ = ln.(*net.TCPListener).SetDeadline(time.Now().Add(100 * time.Millisecond))
-	_, err = ln.Accept()
-	require.Error(t, err, "no connection should be dialed when the slot is full")
+	require.Zero(t, d.session.ConnCount.Load(), "failed connect must restore the connection counter")
 }

--- a/internal/download/connect_test.go
+++ b/internal/download/connect_test.go
@@ -77,10 +77,8 @@ func TestDispatchConnectionsAtConnectionLimit(t *testing.T) {
 	sess.TorrentConnLimit.Store(1)
 	d := newConnectDownload(t, sess)
 
-	// Occupy the single per-torrent slot with a mock peer.
-	m := newMockPeer()
-	m.addr = netip.MustParseAddrPort("10.0.0.1:6881")
-	d.peers.Store(1, m)
+	// Occupy the single per-torrent slot with an incoming connection.
+	d.peerList.incomingConnectionOpened(netip.MustParseAddrPort("10.0.0.1:6881"))
 
 	addr := netip.MustParseAddrPort("10.0.0.2:6881")
 	d.peerList.addPeer(addr, tracker.PeerSourceTracker)
@@ -113,6 +111,38 @@ func TestDispatchConnectionsNoCandidates(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("dispatch blocked on DialSem without a candidate")
+	}
+}
+
+func TestDispatchSelectsCandidateAfterDialTurn(t *testing.T) {
+	sess := newConnectSession(t, 1)
+	require.True(t, sess.DialSem.TryAcquire(1))
+	blockGlobalConnectionSlot(t, sess)
+	d := newConnectDownload(t, sess)
+	addr := netip.MustParseAddrPort("10.0.0.14:6881")
+	d.peerList.addPeer(addr, tracker.PeerSourceTracker)
+
+	done := make(chan struct{})
+	go func() {
+		d.dispatchConnections()
+		close(done)
+	}()
+
+	require.Never(t, func() bool {
+		return candidateDialing(d, addr)
+	}, 100*time.Millisecond, 5*time.Millisecond, "candidate must not be selected before the download acquires DialSem")
+
+	sess.DialSem.Release(1)
+	require.Eventually(t, func() bool {
+		return candidateDialing(d, addr)
+	}, time.Second, 10*time.Millisecond)
+
+	d.cancel()
+	sess.ConnSem.Release(1)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("dispatch did not exit after cancellation")
 	}
 }
 
@@ -150,6 +180,84 @@ func TestDispatchConnectionsSkipsConnectedAddress(t *testing.T) {
 	d.peerList.mu.Unlock()
 	require.True(t, sess.DialSem.TryAcquire(4), "connected peers must not take a dial slot")
 	sess.DialSem.Release(4)
+}
+
+func TestOutgoingHandshakeFailureReleasesPeerListSlot(t *testing.T) {
+	sess := newConnectSession(t, 4)
+	sess.TorrentConnLimit.Store(1)
+	d := newConnectDownload(t, sess)
+	defer d.cancel()
+
+	addr := netip.MustParseAddrPort("10.0.0.11:6881")
+	d.peerList.addPeer(addr, tracker.PeerSourceTracker)
+	require.True(t, sess.ConnSem.TryAcquire(1))
+	sess.ConnCount.Add(1)
+
+	local, remote := net.Pipe()
+	defer remote.Close()
+	p := newUnstartedOutgoingPeer(local, d, addr, false)
+	require.True(t, d.peerList.newConnection(addr, p, time.Now().Unix()))
+	p.startAsync(false)
+
+	remoteDone := make(chan struct{})
+	go func() {
+		_, _ = proto.ReadHandshake(remote)
+		_ = remote.Close()
+		close(remoteDone)
+	}()
+
+	require.Eventually(t, func() bool {
+		d.peerList.mu.Lock()
+		defer d.peerList.mu.Unlock()
+		idx, found := d.peerList.findPeer(addr)
+		return found && d.peerList.peers[idx].connection == nil
+	}, time.Second, 10*time.Millisecond)
+	<-remoteDone
+	require.Zero(t, d.occupiedConnectionCount())
+	require.True(t, sess.ConnSem.TryAcquire(200), "failed handshake must release the global connection slot")
+	sess.ConnSem.Release(200)
+}
+
+func TestAddConnReservesOutgoingLane(t *testing.T) {
+	sess := newConnectSession(t, 4)
+	sess.TorrentConnLimit.Store(2)
+	d := newConnectDownload(t, sess)
+	defer d.cancel()
+
+	firstLocal, firstRemote := net.Pipe()
+	defer firstRemote.Close()
+	require.True(t, sess.ConnSem.TryAcquire(1))
+	sess.ConnCount.Add(1)
+	d.AddConn(
+		netip.MustParseAddrPort("10.0.0.12:6881"),
+		firstLocal,
+		proto.Handshake{InfoHash: d.info.Hash},
+		false,
+	)
+	require.Equal(t, 1, d.occupiedConnectionCount())
+
+	secondLocal, secondRemote := net.Pipe()
+	defer secondRemote.Close()
+	require.True(t, sess.ConnSem.TryAcquire(1))
+	sess.ConnCount.Add(1)
+	d.AddConn(
+		netip.MustParseAddrPort("10.0.0.13:6881"),
+		secondLocal,
+		proto.Handshake{InfoHash: d.info.Hash},
+		false,
+	)
+	require.Equal(t, 1, d.occupiedConnectionCount())
+	_, err := secondRemote.Read(make([]byte, 1))
+	require.Error(t, err, "incoming connection must not consume the reserved outgoing lane")
+
+	_, err = proto.ReadHandshake(firstRemote)
+	require.NoError(t, err)
+	require.NoError(t, firstRemote.Close())
+	require.Eventually(t, func() bool {
+		return d.occupiedConnectionCount() == 0 && d.peers.Size() == 0
+	}, time.Second, 10*time.Millisecond)
+	require.True(t, sess.ConnSem.TryAcquire(200), "all incoming connection slots must be released")
+	sess.ConnSem.Release(200)
 }
 
 // ── integration (requires network) ───────────────────────────────────
@@ -211,7 +319,7 @@ func TestDispatchConnectionsSkipsBannedCandidateAndDialsNext(t *testing.T) {
 	d.peerList.addPeer(banned, tracker.PeerSourceTracker)
 	d.banAddr(banned.Addr())
 
-	d.dispatchConnections()
+	go d.dispatchConnections()
 
 	require.Eventually(t, func() bool { return candidateDialing(d, valid) }, time.Second, 10*time.Millisecond)
 	require.False(t, candidateDialing(d, banned))
@@ -232,7 +340,7 @@ func TestStopAbandonsWaitingDial(t *testing.T) {
 	addr := netip.MustParseAddrPort("10.0.0.8:6881")
 	d.peerList.addPeer(addr, tracker.PeerSourceTracker)
 
-	d.dispatchConnections()
+	go d.dispatchConnections()
 	require.Eventually(t, func() bool { return candidateDialing(d, addr) }, time.Second, 10*time.Millisecond)
 
 	require.NoError(t, d.Stop())
@@ -244,10 +352,10 @@ func TestStopAbandonsWaitingDial(t *testing.T) {
 	sess.DialSem.Release(4)
 }
 
-// TestDispatchConnectionsCountsPendingOutgoingSlots verifies the per-torrent
-// in-flight accounting: while one candidate occupies the only slot, a second
-// dispatch pass must not start another dial.
-func TestDispatchConnectionsCountsPendingOutgoingSlots(t *testing.T) {
+// TestDispatchConnectionsCountsDialingOutgoingSlot verifies the per-torrent
+// accounting: while one candidate occupies the only slot, a second dispatch
+// pass must not start another dial.
+func TestDispatchConnectionsCountsDialingOutgoingSlot(t *testing.T) {
 	sess := newConnectSession(t, 4)
 	blockGlobalConnectionSlot(t, sess)
 	d := newConnectDownload(t, sess)
@@ -255,7 +363,7 @@ func TestDispatchConnectionsCountsPendingOutgoingSlots(t *testing.T) {
 	d.peerList.addPeer(netip.MustParseAddrPort("10.0.0.9:6881"), tracker.PeerSourceTracker)
 	d.peerList.addPeer(netip.MustParseAddrPort("10.0.0.10:6881"), tracker.PeerSourcePEX)
 
-	d.dispatchConnections()
+	go d.dispatchConnections()
 	require.Eventually(t, func() bool { return dialingCandidateCount(d) == 1 }, time.Second, 10*time.Millisecond)
 	d.dispatchConnections()
 

--- a/internal/download/connect_test.go
+++ b/internal/download/connect_test.go
@@ -217,11 +217,15 @@ func TestDispatchConnectionsSkipsBannedCandidateAndDialsNext(t *testing.T) {
 	require.False(t, candidateDialing(d, banned))
 
 	d.cancel()
-	require.Eventually(t, func() bool { return d.pendingOutgoing.Load() == 0 }, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool { return dialingCandidateCount(d) == 0 }, time.Second, 10*time.Millisecond)
 	sess.ConnSem.Release(1)
 }
 
-func TestStopCancelsWaitingConnectionAttempt(t *testing.T) {
+// TestStopAbandonsWaitingDial verifies that a dial waiting on the global
+// connection slot is abandoned once the download stops: it acquires the slot
+// when one is released, fails the IsActive re-check, and releases the slot
+// without dialing.
+func TestStopAbandonsWaitingDial(t *testing.T) {
 	sess := newConnectSession(t, 4)
 	blockGlobalConnectionSlot(t, sess)
 	d := newConnectDownload(t, sess)
@@ -232,14 +236,17 @@ func TestStopCancelsWaitingConnectionAttempt(t *testing.T) {
 	require.Eventually(t, func() bool { return candidateDialing(d, addr) }, time.Second, 10*time.Millisecond)
 
 	require.NoError(t, d.Stop())
-	require.Eventually(t, func() bool {
-		return !candidateDialing(d, addr) && d.pendingOutgoing.Load() == 0
-	}, time.Second, 10*time.Millisecond)
+	// Stop does not cancel the wait; the next released slot lets the dial
+	// observe the inactive state and give up.
+	sess.ConnSem.Release(1)
+	require.Eventually(t, func() bool { return dialingCandidateCount(d) == 0 }, time.Second, 10*time.Millisecond)
 	require.True(t, sess.DialSem.TryAcquire(4), "stopped download must release dial slots")
 	sess.DialSem.Release(4)
-	sess.ConnSem.Release(1)
 }
 
+// TestDispatchConnectionsCountsPendingOutgoingSlots verifies the per-torrent
+// in-flight accounting: while one candidate occupies the only slot, a second
+// dispatch pass must not start another dial.
 func TestDispatchConnectionsCountsPendingOutgoingSlots(t *testing.T) {
 	sess := newConnectSession(t, 4)
 	blockGlobalConnectionSlot(t, sess)
@@ -249,14 +256,13 @@ func TestDispatchConnectionsCountsPendingOutgoingSlots(t *testing.T) {
 	d.peerList.addPeer(netip.MustParseAddrPort("10.0.0.10:6881"), tracker.PeerSourcePEX)
 
 	d.dispatchConnections()
-	require.Eventually(t, func() bool { return d.pendingOutgoing.Load() == 1 }, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool { return dialingCandidateCount(d) == 1 }, time.Second, 10*time.Millisecond)
 	d.dispatchConnections()
 
-	require.Equal(t, int32(1), d.pendingOutgoing.Load())
-	require.Equal(t, 1, dialingCandidateCount(d))
+	require.Equal(t, 1, dialingCandidateCount(d), "second dispatch must not exceed the per-torrent limit")
 
 	d.cancel()
-	require.Eventually(t, func() bool { return d.pendingOutgoing.Load() == 0 }, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool { return dialingCandidateCount(d) == 0 }, time.Second, 10*time.Millisecond)
 	sess.ConnSem.Release(1)
 }
 

--- a/internal/download/connect_test.go
+++ b/internal/download/connect_test.go
@@ -1,0 +1,249 @@
+// Copyright 2026 trim21 <trim21.me@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+//go:build !release
+
+package download
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
+
+	"neptune/internal/client/tracker"
+	"neptune/internal/config"
+	"neptune/internal/piece_store"
+	"neptune/internal/proto"
+	"neptune/internal/session"
+)
+
+// ── dispatch logic (no network) ──────────────────────────────────────
+
+// newConnectSession builds a minimal session with the semaphores the
+// connection loop needs.
+func newConnectSession(t *testing.T, dialSlots int64) *session.Session {
+	t.Helper()
+	sess := &session.Session{
+		ConnSem: semaphore.NewWeighted(200),
+		DialSem: semaphore.NewWeighted(dialSlots),
+		Config: config.Config{App: config.Application{
+			GlobalConnectionLimit: 200,
+		}},
+	}
+	sess.TorrentConnLimit.Store(50)
+	sess.ConnCount.Store(0)
+	return sess
+}
+
+func newConnectDownload(t *testing.T, sess *session.Session) *Download {
+	t.Helper()
+	d := newTestDownload(t, 1, 4, piece_store.NewMemStore)
+	d.session = sess
+	d.connectSignal = make(chan struct{}, 1)
+	d.peersCh = make(chan []tracker.DiscoveredPeer, 1)
+	return d
+}
+
+// TestDispatchConnectionsNonActiveState verifies the early return: downloads
+// that are not Downloading/Seeding never dispatch a dial.
+func TestDispatchConnectionsNonActiveState(t *testing.T) {
+	sess := newConnectSession(t, 4)
+	d := newConnectDownload(t, sess)
+	d.peerList.addPeer(netip.MustParseAddrPort("10.0.0.3:6881"), tracker.PeerSourceTracker)
+
+	for _, state := range []State{Stopped, PendingDownloading, Checking, Moving, Error} {
+		d.state.Store(uint32(state))
+		d.dispatchConnections()
+
+		d.peerList.mu.Lock()
+		idx, found := d.peerList.findPeer(netip.MustParseAddrPort("10.0.0.3:6881"))
+		require.True(t, found, "state %s", state)
+		require.Zero(t, d.peerList.peers[idx].failcount, "state %s must not dial", state)
+		require.False(t, d.peerList.peers[idx].dialing, "state %s must not dial", state)
+		d.peerList.mu.Unlock()
+	}
+}
+
+// TestDispatchConnectionsAtConnectionLimit verifies that a download at its
+// per-torrent connection limit stops dispatching: candidates stay untouched.
+func TestDispatchConnectionsAtConnectionLimit(t *testing.T) {
+	sess := newConnectSession(t, 4)
+	sess.TorrentConnLimit.Store(1)
+	d := newConnectDownload(t, sess)
+
+	// Occupy the single per-torrent slot with a mock peer.
+	m := newMockPeer()
+	m.addr = netip.MustParseAddrPort("10.0.0.1:6881")
+	d.peers.Store(1, m)
+
+	addr := netip.MustParseAddrPort("10.0.0.2:6881")
+	d.peerList.addPeer(addr, tracker.PeerSourceTracker)
+
+	d.dispatchConnections()
+
+	d.peerList.mu.Lock()
+	idx, found := d.peerList.findPeer(addr)
+	require.True(t, found)
+	require.Zero(t, d.peerList.peers[idx].failcount)
+	require.False(t, d.peerList.peers[idx].dialing)
+	d.peerList.mu.Unlock()
+}
+
+// TestDispatchConnectionsNoCandidates verifies the loop stops when the peer
+// list has no connectable candidate.
+func TestDispatchConnectionsNoCandidates(t *testing.T) {
+	sess := newConnectSession(t, 4)
+	d := newConnectDownload(t, sess)
+
+	d.dispatchConnections() // must return without blocking
+}
+
+// TestDispatchConnectionsConnSemFull verifies that when the global connection
+// pool is exhausted the loop stops instead of dispatching doomed dials.
+func TestDispatchConnectionsConnSemFull(t *testing.T) {
+	sess := newConnectSession(t, 4)
+	// Occupy the whole global connection pool.
+	require.True(t, sess.ConnSem.TryAcquire(200))
+	sess.ConnCount.Store(200)
+
+	d := newConnectDownload(t, sess)
+	addr := netip.MustParseAddrPort("10.0.0.4:6881")
+	d.peerList.addPeer(addr, tracker.PeerSourceTracker)
+
+	d.dispatchConnections()
+
+	d.peerList.mu.Lock()
+	idx, found := d.peerList.findPeer(addr)
+	require.True(t, found)
+	require.Zero(t, d.peerList.peers[idx].failcount)
+	require.False(t, d.peerList.peers[idx].dialing)
+	d.peerList.mu.Unlock()
+}
+
+// ── integration (requires network) ───────────────────────────────────
+
+// unreachableAddr returns a local address that refuses connections, so a dial
+// fails immediately instead of hanging for the full timeout.
+func unreachableAddr(t *testing.T) netip.AddrPort {
+	t.Helper()
+	var lc net.ListenConfig
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().(*net.TCPAddr).AddrPort()
+	require.NoError(t, ln.Close())
+	return addr
+}
+
+func candidateFailed(d *Download, addr netip.AddrPort) bool {
+	d.peerList.mu.Lock()
+	defer d.peerList.mu.Unlock()
+	idx, found := d.peerList.findPeer(addr)
+	return found && d.peerList.peers[idx].failcount > 0
+}
+
+// TestConnectLoopDispatchesDial verifies the full path: a candidate added to
+// the peer list plus a wakeup signal makes the connection loop dial it, and
+// the dial failure is recorded in the peer's failcount.
+func TestConnectLoopDispatchesDial(t *testing.T) {
+	sess := newConnectSession(t, 4)
+	d := newConnectDownload(t, sess)
+
+	go d.connectLoop()
+
+	addr := unreachableAddr(t)
+	d.peerList.addPeer(addr, tracker.PeerSourceTracker)
+	d.signalConnect()
+
+	require.Eventually(t, func() bool { return candidateFailed(d, addr) }, 5*time.Second, 10*time.Millisecond)
+}
+
+// TestConnectLoopFairnessAcrossDownloads verifies that with a single dial
+// slot, two downloads both get to dial — the FIFO DialSem cannot starve one
+// download.
+func TestConnectLoopFairnessAcrossDownloads(t *testing.T) {
+	sess := newConnectSession(t, 1) // one dial slot in total
+	d1 := newConnectDownload(t, sess)
+	d2 := newConnectDownload(t, sess)
+
+	go d1.connectLoop()
+	go d2.connectLoop()
+
+	addr1 := unreachableAddr(t)
+	addr2 := unreachableAddr(t)
+	d1.peerList.addPeer(addr1, tracker.PeerSourceTracker)
+	d2.peerList.addPeer(addr2, tracker.PeerSourceTracker)
+	d1.signalConnect()
+	d2.signalConnect()
+
+	require.Eventually(t, func() bool { return candidateFailed(d1, addr1) }, 5*time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool { return candidateFailed(d2, addr2) }, 5*time.Second, 10*time.Millisecond)
+}
+
+// TestPeerIntakeWakesConnectLoop verifies the decoupled intake path: peers
+// arriving on peersCh are added to the peer list and wake the connection
+// loop, which then dials them.
+func TestPeerIntakeWakesConnectLoop(t *testing.T) {
+	sess := newConnectSession(t, 4)
+	d := newConnectDownload(t, sess)
+
+	go d.connectLoop()
+	go d.startPeerIntake()
+
+	addr := unreachableAddr(t)
+	d.peersCh <- []tracker.DiscoveredPeer{{AddrPort: addr, Source: tracker.PeerSourceTracker}}
+
+	require.Eventually(t, func() bool { return candidateFailed(d, addr) }, 5*time.Second, 10*time.Millisecond)
+}
+
+// TestConnectLoopExitsOnClose verifies that closing the download tears down a
+// registered peer connection and releases every DialSem/ConnSem slot.
+func TestConnectLoopExitsOnClose(t *testing.T) {
+	sess := newConnectSession(t, 4)
+	d := newConnectDownload(t, sess)
+	go d.connectLoop()
+
+	var lc net.ListenConfig
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	// Complete the BitTorrent handshake so the peer registers, then park the
+	// connection idle (the peer's read loop blocks until the download closes).
+	handshakeErr := make(chan error, 1)
+	go func() {
+		c, aErr := ln.Accept()
+		if aErr != nil {
+			handshakeErr <- aErr
+			return
+		}
+		h, hErr := proto.ReadHandshake(c)
+		if hErr != nil {
+			handshakeErr <- hErr
+			return
+		}
+		handshakeErr <- proto.SendHandshake(c, h.InfoHash, testOutgoingPeerID, false)
+		_, _ = io.Copy(io.Discard, c) // holds the connection until closed
+	}()
+
+	addr := ln.Addr().(*net.TCPAddr).AddrPort()
+	d.peerList.addPeer(addr, tracker.PeerSourceTracker)
+	d.signalConnect()
+
+	// The dial succeeds and the peer registers after the handshake.
+	require.Eventually(t, func() bool { return d.peers.Size() > 0 }, 5*time.Second, 10*time.Millisecond)
+	require.NoError(t, <-handshakeErr)
+
+	// Closing the download force-closes the connection and releases every slot.
+	d.Close()
+	require.Eventually(t, func() bool { return d.peers.Size() == 0 }, 5*time.Second, 10*time.Millisecond)
+	require.True(t, sess.DialSem.TryAcquire(4), "DialSem slots must be released after close")
+	sess.DialSem.Release(4)
+	require.True(t, sess.ConnSem.TryAcquire(200), "ConnSem slots must be released after close")
+	sess.ConnSem.Release(200)
+}

--- a/internal/download/connect_test.go
+++ b/internal/download/connect_test.go
@@ -100,30 +100,56 @@ func TestDispatchConnectionsAtConnectionLimit(t *testing.T) {
 func TestDispatchConnectionsNoCandidates(t *testing.T) {
 	sess := newConnectSession(t, 4)
 	d := newConnectDownload(t, sess)
+	require.True(t, sess.DialSem.TryAcquire(4))
+	defer sess.DialSem.Release(4)
 
-	d.dispatchConnections() // must return without blocking
+	done := make(chan struct{})
+	go func() {
+		d.dispatchConnections()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("dispatch blocked on DialSem without a candidate")
+	}
 }
 
-// TestDispatchConnectionsConnSemFull verifies that when the global connection
-// pool is exhausted the loop stops instead of dispatching doomed dials.
-func TestDispatchConnectionsConnSemFull(t *testing.T) {
+func TestDispatchConnectionsSkipsBannedPeer(t *testing.T) {
 	sess := newConnectSession(t, 4)
-	// Occupy the whole global connection pool.
-	require.True(t, sess.ConnSem.TryAcquire(200))
-	sess.ConnCount.Store(200)
-
 	d := newConnectDownload(t, sess)
 	addr := netip.MustParseAddrPort("10.0.0.4:6881")
 	d.peerList.addPeer(addr, tracker.PeerSourceTracker)
+	d.banAddr(addr.Addr())
 
 	d.dispatchConnections()
 
 	d.peerList.mu.Lock()
 	idx, found := d.peerList.findPeer(addr)
 	require.True(t, found)
-	require.Zero(t, d.peerList.peers[idx].failcount)
 	require.False(t, d.peerList.peers[idx].dialing)
 	d.peerList.mu.Unlock()
+	require.True(t, sess.DialSem.TryAcquire(4), "banned peers must not take a dial slot")
+	sess.DialSem.Release(4)
+}
+
+func TestDispatchConnectionsSkipsConnectedAddress(t *testing.T) {
+	sess := newConnectSession(t, 4)
+	d := newConnectDownload(t, sess)
+	addr := netip.MustParseAddrPort("10.0.0.5:6881")
+	d.peerList.addPeer(addr, tracker.PeerSourceTracker)
+	d.peerList.incomingConnectionOpened(addr)
+
+	d.dispatchConnections()
+
+	d.peerList.mu.Lock()
+	idx, found := d.peerList.findPeer(addr)
+	require.True(t, found)
+	require.False(t, d.peerList.peers[idx].dialing)
+	d.peerList.mu.Unlock()
+	require.True(t, sess.DialSem.TryAcquire(4), "connected peers must not take a dial slot")
+	sess.DialSem.Release(4)
 }
 
 // ── integration (requires network) ───────────────────────────────────
@@ -145,6 +171,93 @@ func candidateFailed(d *Download, addr netip.AddrPort) bool {
 	defer d.peerList.mu.Unlock()
 	idx, found := d.peerList.findPeer(addr)
 	return found && d.peerList.peers[idx].failcount > 0
+}
+
+func candidateDialing(d *Download, addr netip.AddrPort) bool {
+	d.peerList.mu.Lock()
+	defer d.peerList.mu.Unlock()
+	idx, found := d.peerList.findPeer(addr)
+	return found && d.peerList.peers[idx].dialing
+}
+
+func dialingCandidateCount(d *Download) int {
+	d.peerList.mu.Lock()
+	defer d.peerList.mu.Unlock()
+	count := 0
+	for _, peer := range d.peerList.peers {
+		if peer.dialing {
+			count++
+		}
+	}
+	return count
+}
+
+func blockGlobalConnectionSlot(t *testing.T, sess *session.Session) {
+	t.Helper()
+	sess.ConnSem = semaphore.NewWeighted(1)
+	sess.Config.App.GlobalConnectionLimit = 1
+	require.True(t, sess.ConnSem.TryAcquire(1))
+}
+
+func TestDispatchConnectionsSkipsBannedCandidateAndDialsNext(t *testing.T) {
+	sess := newConnectSession(t, 4)
+	blockGlobalConnectionSlot(t, sess)
+	d := newConnectDownload(t, sess)
+	d.session.TorrentConnLimit.Store(1)
+
+	banned := netip.MustParseAddrPort("10.0.0.6:6881")
+	valid := netip.MustParseAddrPort("10.0.0.7:6881")
+	d.peerList.addPeer(valid, tracker.PeerSourcePEX)
+	d.peerList.addPeer(banned, tracker.PeerSourceTracker)
+	d.banAddr(banned.Addr())
+
+	d.dispatchConnections()
+
+	require.Eventually(t, func() bool { return candidateDialing(d, valid) }, time.Second, 10*time.Millisecond)
+	require.False(t, candidateDialing(d, banned))
+
+	d.cancel()
+	require.Eventually(t, func() bool { return d.pendingOutgoing.Load() == 0 }, time.Second, 10*time.Millisecond)
+	sess.ConnSem.Release(1)
+}
+
+func TestStopCancelsWaitingConnectionAttempt(t *testing.T) {
+	sess := newConnectSession(t, 4)
+	blockGlobalConnectionSlot(t, sess)
+	d := newConnectDownload(t, sess)
+	addr := netip.MustParseAddrPort("10.0.0.8:6881")
+	d.peerList.addPeer(addr, tracker.PeerSourceTracker)
+
+	d.dispatchConnections()
+	require.Eventually(t, func() bool { return candidateDialing(d, addr) }, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, d.Stop())
+	require.Eventually(t, func() bool {
+		return !candidateDialing(d, addr) && d.pendingOutgoing.Load() == 0
+	}, time.Second, 10*time.Millisecond)
+	require.True(t, sess.DialSem.TryAcquire(4), "stopped download must release dial slots")
+	sess.DialSem.Release(4)
+	sess.ConnSem.Release(1)
+}
+
+func TestDispatchConnectionsCountsPendingOutgoingSlots(t *testing.T) {
+	sess := newConnectSession(t, 4)
+	blockGlobalConnectionSlot(t, sess)
+	d := newConnectDownload(t, sess)
+	d.session.TorrentConnLimit.Store(1)
+	d.peerList.addPeer(netip.MustParseAddrPort("10.0.0.9:6881"), tracker.PeerSourceTracker)
+	d.peerList.addPeer(netip.MustParseAddrPort("10.0.0.10:6881"), tracker.PeerSourcePEX)
+
+	d.dispatchConnections()
+	require.Eventually(t, func() bool { return d.pendingOutgoing.Load() == 1 }, time.Second, 10*time.Millisecond)
+	d.dispatchConnections()
+
+	require.Equal(t, int32(1), d.pendingOutgoing.Load())
+	require.Equal(t, 1, dialingCandidateCount(d))
+
+	d.cancel()
+	require.Eventually(t, func() bool { return d.pendingOutgoing.Load() == 0 }, time.Second, 10*time.Millisecond)
+	sess.ConnSem.Release(1)
 }
 
 // TestConnectLoopDispatchesDial verifies the full path: a candidate added to
@@ -183,6 +296,41 @@ func TestConnectLoopFairnessAcrossDownloads(t *testing.T) {
 
 	require.Eventually(t, func() bool { return candidateFailed(d1, addr1) }, 5*time.Second, 10*time.Millisecond)
 	require.Eventually(t, func() bool { return candidateFailed(d2, addr2) }, 5*time.Second, 10*time.Millisecond)
+}
+
+// TestConnectLoopWaitsForGlobalConnectionSlot verifies that downloads wait on
+// ConnSem itself when the global pool is full. Releasing a slot then serves
+// both queued downloads without relying on their periodic retry ticks.
+func TestConnectLoopWaitsForGlobalConnectionSlot(t *testing.T) {
+	sess := newConnectSession(t, 2)
+	sess.ConnSem = semaphore.NewWeighted(1)
+	sess.Config.App.GlobalConnectionLimit = 1
+	require.True(t, sess.ConnSem.TryAcquire(1))
+	sess.ConnCount.Store(1)
+
+	d1 := newConnectDownload(t, sess)
+	d2 := newConnectDownload(t, sess)
+	defer d1.cancel()
+	defer d2.cancel()
+	go d1.connectLoop()
+	go d2.connectLoop()
+
+	addr1 := unreachableAddr(t)
+	addr2 := unreachableAddr(t)
+	d1.peerList.addPeer(addr1, tracker.PeerSourceTracker)
+	d2.peerList.addPeer(addr2, tracker.PeerSourceTracker)
+	d1.signalConnect()
+	d2.signalConnect()
+
+	require.Eventually(t, func() bool {
+		return candidateDialing(d1, addr1) && candidateDialing(d2, addr2)
+	}, time.Second, 10*time.Millisecond)
+
+	sess.ConnCount.Sub(1)
+	sess.ConnSem.Release(1)
+
+	require.Eventually(t, func() bool { return candidateFailed(d1, addr1) }, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool { return candidateFailed(d2, addr2) }, time.Second, 10*time.Millisecond)
 }
 
 // TestPeerIntakeWakesConnectLoop verifies the decoupled intake path: peers

--- a/internal/download/d.go
+++ b/internal/download/d.go
@@ -180,11 +180,11 @@ type Download struct {
 	bannedAddrs            map[netip.Addr]time.Time         // Never nil.
 	stateCond              *gsync.Cond                      // Never nil.
 	peerList               *peerList                        // Never nil.
+	connectSignal          chan struct{}                    // Never nil in real downloads.
 	downloadLimiter        *ratelimit.Limiter               // Never nil.
 	err                    atomic.Pointer[error]            // nil unless download enters Error state
 	cancel                 context.CancelFunc               // Never nil after New().
 	scheduleResponseSignal chan empty.Empty                 // Never nil.
-	pendingPeersSignal     chan empty.Empty                 // Never nil.
 	tracker                *tracker.Trackers                // Never nil.
 	completedBm            *bm.Bitmap                       // Never nil.
 	missingBm              *bm.LockFreeBitmap               // Never nil.
@@ -278,6 +278,20 @@ func (d *Download) IsAlive() bool {
 // IsActiveDownloading returns true when the download is in Downloading state (not PendingDownloading, not Seeding).
 func (d *Download) IsActiveDownloading() bool {
 	return d.GetState() == Downloading
+}
+
+// signalConnect wakes the per-download connection loop so it dispatches
+// another candidate. Any event that may free up a connection opportunity
+// (new peers, a closed connection, a state change) calls this. No-op for
+// downloads constructed without a connectSignal (unit tests).
+func (d *Download) signalConnect() {
+	if d.connectSignal == nil {
+		return
+	}
+	select {
+	case d.connectSignal <- struct{}{}:
+	default:
+	}
 }
 
 // QueueWeight returns the queue priority weight (higher = higher priority).

--- a/internal/download/d.go
+++ b/internal/download/d.go
@@ -348,7 +348,19 @@ func (d *Download) reserveOutgoingSlot() bool {
 }
 
 func (d *Download) releaseOutgoingSlot() {
-	d.pendingOutgoing.Sub(1)
+	for {
+		pending := d.pendingOutgoing.Load()
+		if pending <= 0 {
+			// reserve/release 配平被破坏：release 比 reserve 多。不把计数
+			// 静默搞负（负值会让 reserveOutgoingSlot 的容量检查失效），
+			// 记录上下文后放弃这次释放。
+			d.log.Error().Msg("releaseOutgoingSlot: outgoing slot underflow (release without reserve)")
+			return
+		}
+		if d.pendingOutgoing.CompareAndSwap(pending, pending-1) {
+			return
+		}
+	}
 }
 
 func (d *Download) releaseOutgoingSlotAndSignal() {

--- a/internal/download/d.go
+++ b/internal/download/d.go
@@ -301,31 +301,10 @@ func (d *Download) signalConnect() {
 	}
 }
 
-// occupiedConnectionCount returns the number of per-torrent connection slots
-// currently occupied: registered peers (including incoming) plus outbound
-// connections still in flight — candidate selected, dialing, or handshake
-// pending registration. It is derived from peerList state on every call
-// instead of being maintained as a counter, so no reserve/release pairing is
-// needed: the peerList state transitions (dialing → connection → registered)
-// make the count continuous by construction.
+// occupiedConnectionCount includes incoming connections and every outbound
+// connection from candidate selection through peer shutdown.
 func (d *Download) occupiedConnectionCount() int {
-	d.peerList.mu.Lock()
-	defer d.peerList.mu.Unlock()
-	inFlight := 0
-	for _, pp := range d.peerList.peers {
-		if pp.dialing {
-			inFlight++
-			continue
-		}
-		if pp.connection != nil {
-			// Dial succeeded; the peer is not registered in d.peers until its
-			// handshake completes (or it fails and closes).
-			if _, ok := d.peers.Load(pp.connection.ID()); !ok {
-				inFlight++
-			}
-		}
-	}
-	return d.peers.Size() + inFlight
+	return d.peerList.connectionCount()
 }
 
 // QueueWeight returns the queue priority weight (higher = higher priority).

--- a/internal/download/d.go
+++ b/internal/download/d.go
@@ -122,12 +122,11 @@ func (d *Download) transition(to State) (stateTransition, error) {
 func (d *Download) commitStateTransition(from, to State) {
 	d.state.Store(uint32(to))
 
-	fromActive := from == Downloading || from == Seeding
-	toActive := to == Downloading || to == Seeding
-	if fromActive && !toActive {
-		d.cancelConnectAttempts()
-	} else if !fromActive && toActive {
-		d.resetConnectAttempts()
+	if (from != Downloading && from != Seeding) && (to == Downloading || to == Seeding) {
+		// Wake the connect loop so a resumed download does not have to wait
+		// for the next peer-intake event or periodic tick. Peers disconnect
+		// themselves via the keepalive check once the download turns inactive.
+		d.signalConnect()
 	}
 
 	fromAcceptsResponses := from == Downloading || from == PendingDownloading
@@ -189,8 +188,6 @@ type Download struct {
 	stateCond              *gsync.Cond                      // Never nil.
 	peerList               *peerList                        // Never nil.
 	connectSignal          chan struct{}                    // Never nil in real downloads.
-	connectCtx             context.Context                  // Canceled whenever the download becomes inactive.
-	connectCancel          context.CancelFunc               // Never nil in real downloads.
 	downloadLimiter        *ratelimit.Limiter               // Never nil.
 	err                    atomic.Pointer[error]            // nil unless download enters Error state
 	cancel                 context.CancelFunc               // Never nil after New().
@@ -216,7 +213,6 @@ type Download struct {
 	wastedStale            atomic.Int64
 	peerSeeds              atomic.Int64
 	peerIDCounter          atomic.Uint64
-	pendingOutgoing        atomic.Int32
 	uploadAtStart          int64
 	// completed is the amount of data for wanted pieces that have passed
 	// hash verification. Used for UI progress display and tracker 'left'
@@ -233,7 +229,6 @@ type Download struct {
 	queueWeight        atomic.Int64
 	completedOnce      atomic.Bool
 	moveCancelMu       sync.RWMutex
-	connectCtxMu       sync.RWMutex
 	transitionMu       sync.Mutex
 	bannedAddrsMu      sync.Mutex
 	corruptedPiecesMu  sync.Mutex
@@ -306,66 +301,31 @@ func (d *Download) signalConnect() {
 	}
 }
 
-func (d *Download) connectAttemptContext() context.Context {
-	d.connectCtxMu.RLock()
-	ctx := d.connectCtx
-	d.connectCtxMu.RUnlock()
-	if ctx != nil {
-		return ctx
-	}
-	return d.ctx
-}
-
-func (d *Download) cancelConnectAttempts() {
-	d.connectCtxMu.Lock()
-	if d.connectCancel != nil {
-		d.connectCancel()
-	}
-	d.connectCtxMu.Unlock()
-}
-
-func (d *Download) resetConnectAttempts() {
-	d.connectCtxMu.Lock()
-	if d.connectCancel != nil {
-		d.connectCancel()
-	}
-	d.connectCtx, d.connectCancel = context.WithCancel(d.ctx)
-	d.connectCtxMu.Unlock()
-}
-
-// reserveOutgoingSlot accounts for an outbound connection from candidate
-// selection until its BitTorrent handshake either registers a peer or fails.
-func (d *Download) reserveOutgoingSlot() bool {
-	for {
-		pending := d.pendingOutgoing.Load()
-		if d.peerCount()+int(pending) >= d.maxConnections() {
-			return false
+// occupiedConnectionCount returns the number of per-torrent connection slots
+// currently occupied: registered peers (including incoming) plus outbound
+// connections still in flight — candidate selected, dialing, or handshake
+// pending registration. It is derived from peerList state on every call
+// instead of being maintained as a counter, so no reserve/release pairing is
+// needed: the peerList state transitions (dialing → connection → registered)
+// make the count continuous by construction.
+func (d *Download) occupiedConnectionCount() int {
+	d.peerList.mu.Lock()
+	defer d.peerList.mu.Unlock()
+	inFlight := 0
+	for _, pp := range d.peerList.peers {
+		if pp.dialing {
+			inFlight++
+			continue
 		}
-		if d.pendingOutgoing.CompareAndSwap(pending, pending+1) {
-			return true
+		if pp.connection != nil {
+			// Dial succeeded; the peer is not registered in d.peers until its
+			// handshake completes (or it fails and closes).
+			if _, ok := d.peers.Load(pp.connection.ID()); !ok {
+				inFlight++
+			}
 		}
 	}
-}
-
-func (d *Download) releaseOutgoingSlot() {
-	for {
-		pending := d.pendingOutgoing.Load()
-		if pending <= 0 {
-			// reserve/release 配平被破坏：release 比 reserve 多。不把计数
-			// 静默搞负（负值会让 reserveOutgoingSlot 的容量检查失效），
-			// 记录上下文后放弃这次释放。
-			d.log.Error().Msg("releaseOutgoingSlot: outgoing slot underflow (release without reserve)")
-			return
-		}
-		if d.pendingOutgoing.CompareAndSwap(pending, pending-1) {
-			return
-		}
-	}
-}
-
-func (d *Download) releaseOutgoingSlotAndSignal() {
-	d.releaseOutgoingSlot()
-	d.signalConnect()
+	return d.peers.Size() + inFlight
 }
 
 // QueueWeight returns the queue priority weight (higher = higher priority).

--- a/internal/download/d.go
+++ b/internal/download/d.go
@@ -122,6 +122,14 @@ func (d *Download) transition(to State) (stateTransition, error) {
 func (d *Download) commitStateTransition(from, to State) {
 	d.state.Store(uint32(to))
 
+	fromActive := from == Downloading || from == Seeding
+	toActive := to == Downloading || to == Seeding
+	if fromActive && !toActive {
+		d.cancelConnectAttempts()
+	} else if !fromActive && toActive {
+		d.resetConnectAttempts()
+	}
+
 	fromAcceptsResponses := from == Downloading || from == PendingDownloading
 	toAcceptsResponses := to == Downloading || to == PendingDownloading
 	if fromAcceptsResponses && !toAcceptsResponses {
@@ -181,6 +189,8 @@ type Download struct {
 	stateCond              *gsync.Cond                      // Never nil.
 	peerList               *peerList                        // Never nil.
 	connectSignal          chan struct{}                    // Never nil in real downloads.
+	connectCtx             context.Context                  // Canceled whenever the download becomes inactive.
+	connectCancel          context.CancelFunc               // Never nil in real downloads.
 	downloadLimiter        *ratelimit.Limiter               // Never nil.
 	err                    atomic.Pointer[error]            // nil unless download enters Error state
 	cancel                 context.CancelFunc               // Never nil after New().
@@ -206,6 +216,7 @@ type Download struct {
 	wastedStale            atomic.Int64
 	peerSeeds              atomic.Int64
 	peerIDCounter          atomic.Uint64
+	pendingOutgoing        atomic.Int32
 	uploadAtStart          int64
 	// completed is the amount of data for wanted pieces that have passed
 	// hash verification. Used for UI progress display and tracker 'left'
@@ -222,6 +233,7 @@ type Download struct {
 	queueWeight        atomic.Int64
 	completedOnce      atomic.Bool
 	moveCancelMu       sync.RWMutex
+	connectCtxMu       sync.RWMutex
 	transitionMu       sync.Mutex
 	bannedAddrsMu      sync.Mutex
 	corruptedPiecesMu  sync.Mutex
@@ -292,6 +304,56 @@ func (d *Download) signalConnect() {
 	case d.connectSignal <- struct{}{}:
 	default:
 	}
+}
+
+func (d *Download) connectAttemptContext() context.Context {
+	d.connectCtxMu.RLock()
+	ctx := d.connectCtx
+	d.connectCtxMu.RUnlock()
+	if ctx != nil {
+		return ctx
+	}
+	return d.ctx
+}
+
+func (d *Download) cancelConnectAttempts() {
+	d.connectCtxMu.Lock()
+	if d.connectCancel != nil {
+		d.connectCancel()
+	}
+	d.connectCtxMu.Unlock()
+}
+
+func (d *Download) resetConnectAttempts() {
+	d.connectCtxMu.Lock()
+	if d.connectCancel != nil {
+		d.connectCancel()
+	}
+	d.connectCtx, d.connectCancel = context.WithCancel(d.ctx)
+	d.connectCtxMu.Unlock()
+}
+
+// reserveOutgoingSlot accounts for an outbound connection from candidate
+// selection until its BitTorrent handshake either registers a peer or fails.
+func (d *Download) reserveOutgoingSlot() bool {
+	for {
+		pending := d.pendingOutgoing.Load()
+		if d.peerCount()+int(pending) >= d.maxConnections() {
+			return false
+		}
+		if d.pendingOutgoing.CompareAndSwap(pending, pending+1) {
+			return true
+		}
+	}
+}
+
+func (d *Download) releaseOutgoingSlot() {
+	d.pendingOutgoing.Sub(1)
+}
+
+func (d *Download) releaseOutgoingSlotAndSignal() {
+	d.releaseOutgoingSlot()
+	d.signalConnect()
 }
 
 // QueueWeight returns the queue priority weight (higher = higher priority).

--- a/internal/download/debug.html
+++ b/internal/download/debug.html
@@ -188,11 +188,11 @@ async function reannounce(e) {
 <h2>Pending Peers</h2>
 <div class="table-responsive">
 <table class="table table-sm table-dark table-striped">
-<thead><tr><th>Address</th><th class="num">Fail</th><th>Last Seen</th><th>Last Error</th><th>HadTrans</th><th>Conn</th></tr></thead>
+<thead><tr><th>Address</th><th class="num">Fail</th><th>Last Seen</th><th>Last Error</th><th>HadTrans</th><th>Conn</th><th>Dial</th></tr></thead>
 <tbody>
 {{range .PendingPeers}}<tr>
   <td>{{.Address}}</td><td class="num">{{.Failcount}}</td><td>{{.LastSeen}}</td>
-  <td class="text-break">{{.LastError}}</td><td>{{.HadTrans}}</td><td>{{.Connectable}}</td>
+  <td class="text-break">{{.LastError}}</td><td>{{.HadTrans}}</td><td>{{.Connectable}}</td><td>{{.Dialing}}</td>
 </tr>
 {{end}}</tbody>
 </table>

--- a/internal/download/debug_template.go
+++ b/internal/download/debug_template.go
@@ -71,6 +71,7 @@ type debugPendingPeer struct {
 	Failcount   uint8  `json:"failcount"`
 	HadTrans    bool   `json:"had_trans"`
 	Connectable bool   `json:"connectable"`
+	Dialing     bool   `json:"dialing"`
 }
 
 type debugFailingPiece struct {
@@ -389,6 +390,7 @@ func BuildDebugPageData(d *Download, infoHashHex string, fullMode bool) *debugPa
 				LastError:   pp.lastErr,
 				HadTrans:    pp.hadTrans,
 				Connectable: pp.connectable,
+				Dialing:     pp.dialing,
 			})
 		}
 	}

--- a/internal/download/handle_res_test.go
+++ b/internal/download/handle_res_test.go
@@ -61,14 +61,17 @@ func newTestDownload(t testing.TB, numPieces uint32, blocksPerPiece uint32, newS
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
+	connectCtx, connectCancel := context.WithCancel(ctx)
 
 	completedBm := bm.New(info.NumPieces)
 	normalChunkLen := info.BlocksPerPiece()
 	stateCond := gsync.NewCond(&sync.RWMutex{})
 
 	d := &Download{
-		ctx:          ctx,
-		bitfieldSize: (info.NumPieces + 7) / 8,
+		ctx:           ctx,
+		connectCtx:    connectCtx,
+		connectCancel: connectCancel,
+		bitfieldSize:  (info.NumPieces + 7) / 8,
 		session: &session.Session{
 			ConnSem:           semaphore.NewWeighted(200),
 			DownloadLimiter:   ratelimit.New(0),

--- a/internal/download/handle_res_test.go
+++ b/internal/download/handle_res_test.go
@@ -61,17 +61,14 @@ func newTestDownload(t testing.TB, numPieces uint32, blocksPerPiece uint32, newS
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	connectCtx, connectCancel := context.WithCancel(ctx)
 
 	completedBm := bm.New(info.NumPieces)
 	normalChunkLen := info.BlocksPerPiece()
 	stateCond := gsync.NewCond(&sync.RWMutex{})
 
 	d := &Download{
-		ctx:           ctx,
-		connectCtx:    connectCtx,
-		connectCancel: connectCancel,
-		bitfieldSize:  (info.NumPieces + 7) / 8,
+		ctx:          ctx,
+		bitfieldSize: (info.NumPieces + 7) / 8,
 		session: &session.Session{
 			ConnSem:           semaphore.NewWeighted(200),
 			DownloadLimiter:   ratelimit.New(0),

--- a/internal/download/handle_res_test.go
+++ b/internal/download/handle_res_test.go
@@ -94,7 +94,6 @@ func newTestDownload(t testing.TB, numPieces uint32, blocksPerPiece uint32, newS
 		bannedAddrs:            make(map[netip.Addr]time.Time),
 		tracker:                tracker.New(ctx, tracker.Config{}),
 		scheduleResponseSignal: make(chan empty.Empty, 1),
-		pendingPeersSignal:     make(chan empty.Empty, 1),
 	}
 	wantedBm := bm.New(info.NumPieces)
 	wantedBm.Fill()

--- a/internal/download/loop.go
+++ b/internal/download/loop.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"neptune/internal/client/tracker"
-	"neptune/internal/pkg/empty"
 )
 
 func (d *Download) Start() error {
@@ -29,6 +28,8 @@ func (d *Download) Start() error {
 
 	d.stateCond.Broadcast()
 	d.tracker.Resume()
+	// A restarted download may have accumulated candidates while stopped.
+	d.signalConnect()
 	return nil
 }
 
@@ -75,12 +76,9 @@ func (d *Download) PromoteFromQueued() {
 	d.stateCond.Broadcast()
 	d.notifyPeersToRequest()
 
-	// Also wake the connection loop so a promoted download does not have to wait
-	// for the next periodic connection tick.
-	select {
-	case d.pendingPeersSignal <- empty.Empty{}:
-	default:
-	}
+	// Also wake the connection scheduler so a promoted download does not have
+	// to wait for the next peer-intake event.
+	d.signalConnect()
 }
 
 func (d *Download) AsyncCheck() error {
@@ -122,11 +120,13 @@ func (d *Download) wait(state State) bool {
 func (d *Download) startBackground() {
 	d.log.Trace().Msg("start goroutine")
 
+	d.goBackground(d.connectLoop)
 	d.goBackground(d.backgroundResHandler)
 	d.goBackground(d.backgroundReqHandler)
+	d.startPeerIntake()
 
-	// Connection + peer intake loop: handles incoming peers from all sources
-	// (tracker, PEX) and periodic connect / turnover.
+	// Background housekeeping loop: unchoke recalculation, optimistic unchoke
+	// and peer turnover. Peer connection dispatch runs in its own connectLoop.
 	d.goBackground(func() {
 		defer d.log.Info().Msg("main connection loop: exiting")
 		unchokeTicker := time.NewTicker(UnchokeInterval)
@@ -134,9 +134,6 @@ func (d *Download) startBackground() {
 
 		optimisticTicker := time.NewTicker(30 * time.Second)
 		defer optimisticTicker.Stop()
-
-		connectTicker := time.NewTicker(30 * time.Second)
-		defer connectTicker.Stop()
 
 		turnoverTicker := time.NewTicker(5 * time.Minute)
 		defer turnoverTicker.Stop()
@@ -150,44 +147,33 @@ func (d *Download) startBackground() {
 			case <-unchokeTicker.C:
 				d.recalculateUnchokeSlots()
 				d.recalcPeerCounts()
-				continue
 			case <-optimisticTicker.C:
 				if d.IsActiveDownloading() {
 					d.optimisticUnchoke()
 				}
-				continue
-
-			case peers := <-d.peersCh:
-				for _, p := range peers {
-					d.peerList.addPeer(p.AddrPort, p.Source, true)
-				}
-
-			case <-d.pendingPeersSignal:
-			case <-connectTicker.C:
 			case <-turnoverTicker.C:
 				d.peerTurnover()
-				continue
 			}
+		}
+	})
+}
 
-			if !d.IsActive() {
-				continue
+// startPeerIntake consumes discovered peers (tracker announce, PEX) and adds
+// them to the peer list, then wakes the connection loop. Running in its own
+// goroutine decouples peer injection from connection dispatch: a loop blocked
+// on DialSem can never block tracker announces.
+func (d *Download) startPeerIntake() {
+	d.goBackground(func() {
+		for {
+			select {
+			case <-d.ctx.Done():
+				return
+			case peers := <-d.peersCh:
+				for _, p := range peers {
+					d.peerList.addPeer(p.AddrPort, p.Source)
+				}
+				d.signalConnect()
 			}
-
-			desired := d.maxConnections()
-			current := d.peerCount()
-			maxSlots := desired - current
-			if maxSlots <= 0 {
-				continue
-			}
-
-			// Serialize connect attempts across downloads to prevent
-			// connection storms (mirrors libtorrent's round-robin
-			// m_next_connect_torrent at the session level).
-			if !d.session.Connecting.CompareAndSwap(false, true) {
-				continue
-			}
-			d.connectToPeers(maxSlots)
-			d.session.Connecting.Store(false)
 		}
 	})
 }

--- a/internal/download/new.go
+++ b/internal/download/new.go
@@ -119,10 +119,6 @@ func newDownload(
 	init InitState,
 ) (*Download, error) {
 	ctx, cancel := context.WithCancel(context.Background())
-	connectCtx, connectCancel := context.WithCancel(ctx)
-	if init.State != Downloading && init.State != Seeding {
-		connectCancel()
-	}
 
 	if tags == nil {
 		tags = []string{}
@@ -141,10 +137,8 @@ func newDownload(
 	store := piece_store.NewFileStore(info, basePath, sess.FilePool, sess.IOContext, selectedFilesSet, sess.Config.App.Fallocate)
 
 	d := &Download{
-		ctx:           ctx,
-		cancel:        cancel,
-		connectCtx:    connectCtx,
-		connectCancel: connectCancel,
+		ctx:    ctx,
+		cancel: cancel,
 
 		info:    info,
 		session: sess,

--- a/internal/download/new.go
+++ b/internal/download/new.go
@@ -181,7 +181,7 @@ func newDownload(
 		bitfieldSize: (info.NumPieces + 7) / 8,
 
 		scheduleResponseSignal: make(chan empty.Empty, 1),
-		pendingPeersSignal:     make(chan empty.Empty, 1),
+		connectSignal:          make(chan struct{}, 1),
 
 		downloadLimiter: ratelimit.New(0),
 		uploadLimiter:   ratelimit.New(0),

--- a/internal/download/new.go
+++ b/internal/download/new.go
@@ -119,6 +119,10 @@ func newDownload(
 	init InitState,
 ) (*Download, error) {
 	ctx, cancel := context.WithCancel(context.Background())
+	connectCtx, connectCancel := context.WithCancel(ctx)
+	if init.State != Downloading && init.State != Seeding {
+		connectCancel()
+	}
 
 	if tags == nil {
 		tags = []string{}
@@ -137,8 +141,10 @@ func newDownload(
 	store := piece_store.NewFileStore(info, basePath, sess.FilePool, sess.IOContext, selectedFilesSet, sess.Config.App.Fallocate)
 
 	d := &Download{
-		ctx:    ctx,
-		cancel: cancel,
+		ctx:           ctx,
+		cancel:        cancel,
+		connectCtx:    connectCtx,
+		connectCancel: connectCancel,
 
 		info:    info,
 		session: sess,

--- a/internal/download/p.go
+++ b/internal/download/p.go
@@ -142,17 +142,11 @@ func NewPeerID() (peerID proto.PeerID) {
 }
 
 func NewOutgoingPeer(conn net.Conn, d *Download, addr netip.AddrPort, encrypted bool) Peer {
-	return newPeer(conn, d, addr, false, nil, encrypted, false)
+	return newPeer(conn, d, addr, false, nil, encrypted)
 }
 
 func NewIncomingPeer(conn net.Conn, d *Download, addr netip.AddrPort, h proto.Handshake, encrypted bool) Peer {
-	return newPeer(conn, d, addr, true, &h, encrypted, false)
-}
-
-// newPendingOutgoingPeer transfers an already-reserved outbound connection
-// slot to the peer handshake lifecycle.
-func newPendingOutgoingPeer(conn net.Conn, d *Download, addr netip.AddrPort, encrypted bool) Peer {
-	return newPeer(conn, d, addr, false, nil, encrypted, true)
+	return newPeer(conn, d, addr, true, &h, encrypted)
 }
 
 func newPeer(
@@ -162,7 +156,6 @@ func newPeer(
 	skipReadHandshake bool,
 	h *proto.Handshake,
 	encrypted bool,
-	pendingOutgoing bool,
 ) Peer {
 	ctx, cancel := context.WithCancel(d.ctx)
 	l := d.log.With().Stringer("addr", addr)
@@ -189,7 +182,6 @@ func newPeer(
 		queueLimit:        *atomic.NewUint32(2000),
 		incoming:          skipReadHandshake,
 		encrypted:         encrypted,
-		pendingOutgoing:   pendingOutgoing,
 
 		ourChoking:     *atomic.NewBool(true),
 		ourInterested:  *atomic.NewBool(false),
@@ -302,7 +294,6 @@ type peerImpl struct {
 	readBuf                [4]byte
 	writeBuf               [4]byte
 	incoming               bool
-	pendingOutgoing        bool
 	encrypted              bool
 	fastExtension          bool
 	dhtEnabled             bool
@@ -749,10 +740,7 @@ func (p *peerImpl) checkRequestTimeouts() {
 
 func (p *peerImpl) start(skipHandshake bool) {
 	p.log.Trace().Msg("start")
-	defer func() {
-		p.releasePendingOutgoing()
-		p.Close()
-	}()
+	defer p.Close()
 
 	_ = p.Conn.SetWriteDeadline(time.Now().Add(time.Second * 30))
 	if err := proto.SendHandshake(p.Conn, p.d.info.Hash, NewPeerID(), p.d.private); err != nil {
@@ -814,6 +802,14 @@ func (p *peerImpl) start(skipHandshake bool) {
 			case <-p.ctx.Done():
 				return
 			case <-timer.C:
+				if !p.d.IsActive() {
+					// The download is not transferring (Stopped, queued,
+					// checking...): the connection only holds a global slot
+					// and keeps alive for nothing. Close it; the connect loop
+					// re-dials when the download becomes active again.
+					p.log.Debug().Msg("peer: download inactive, closing connection")
+					return
+				}
 				if time.Now().Unix()-p.lastSend.Load() >= 60 {
 					p.sendEventX(Event{keepAlive: true})
 				}
@@ -823,7 +819,6 @@ func (p *peerImpl) start(skipHandshake bool) {
 
 	// Register in peers map by unique ID (never collides).
 	p.d.peers.Store(p.id, p)
-	p.releasePendingOutgoing()
 
 	// Address dedup: ensure only one peer per address.
 	actual, loaded := p.d.connectedAddrs.LoadOrStore(p.Address, p)
@@ -1058,14 +1053,6 @@ func (p *peerImpl) start(skipHandshake bool) {
 			}
 		}
 	}
-}
-
-func (p *peerImpl) releasePendingOutgoing() {
-	if !p.pendingOutgoing {
-		return
-	}
-	p.pendingOutgoing = false
-	p.d.releaseOutgoingSlotAndSignal()
 }
 
 func (p *peerImpl) sendInitPayload() {

--- a/internal/download/p.go
+++ b/internal/download/p.go
@@ -142,11 +142,17 @@ func NewPeerID() (peerID proto.PeerID) {
 }
 
 func NewOutgoingPeer(conn net.Conn, d *Download, addr netip.AddrPort, encrypted bool) Peer {
-	return newPeer(conn, d, addr, false, nil, encrypted)
+	return newPeer(conn, d, addr, false, nil, encrypted, false)
 }
 
 func NewIncomingPeer(conn net.Conn, d *Download, addr netip.AddrPort, h proto.Handshake, encrypted bool) Peer {
-	return newPeer(conn, d, addr, true, &h, encrypted)
+	return newPeer(conn, d, addr, true, &h, encrypted, false)
+}
+
+// newPendingOutgoingPeer transfers an already-reserved outbound connection
+// slot to the peer handshake lifecycle.
+func newPendingOutgoingPeer(conn net.Conn, d *Download, addr netip.AddrPort, encrypted bool) Peer {
+	return newPeer(conn, d, addr, false, nil, encrypted, true)
 }
 
 func newPeer(
@@ -156,6 +162,7 @@ func newPeer(
 	skipReadHandshake bool,
 	h *proto.Handshake,
 	encrypted bool,
+	pendingOutgoing bool,
 ) Peer {
 	ctx, cancel := context.WithCancel(d.ctx)
 	l := d.log.With().Stringer("addr", addr)
@@ -182,6 +189,7 @@ func newPeer(
 		queueLimit:        *atomic.NewUint32(2000),
 		incoming:          skipReadHandshake,
 		encrypted:         encrypted,
+		pendingOutgoing:   pendingOutgoing,
 
 		ourChoking:     *atomic.NewBool(true),
 		ourInterested:  *atomic.NewBool(false),
@@ -294,6 +302,7 @@ type peerImpl struct {
 	readBuf                [4]byte
 	writeBuf               [4]byte
 	incoming               bool
+	pendingOutgoing        bool
 	encrypted              bool
 	fastExtension          bool
 	dhtEnabled             bool
@@ -740,7 +749,10 @@ func (p *peerImpl) checkRequestTimeouts() {
 
 func (p *peerImpl) start(skipHandshake bool) {
 	p.log.Trace().Msg("start")
-	defer p.Close()
+	defer func() {
+		p.releasePendingOutgoing()
+		p.Close()
+	}()
 
 	_ = p.Conn.SetWriteDeadline(time.Now().Add(time.Second * 30))
 	if err := proto.SendHandshake(p.Conn, p.d.info.Hash, NewPeerID(), p.d.private); err != nil {
@@ -811,6 +823,7 @@ func (p *peerImpl) start(skipHandshake bool) {
 
 	// Register in peers map by unique ID (never collides).
 	p.d.peers.Store(p.id, p)
+	p.releasePendingOutgoing()
 
 	// Address dedup: ensure only one peer per address.
 	actual, loaded := p.d.connectedAddrs.LoadOrStore(p.Address, p)
@@ -1045,6 +1058,14 @@ func (p *peerImpl) start(skipHandshake bool) {
 			}
 		}
 	}
+}
+
+func (p *peerImpl) releasePendingOutgoing() {
+	if !p.pendingOutgoing {
+		return
+	}
+	p.pendingOutgoing = false
+	p.d.releaseOutgoingSlotAndSignal()
 }
 
 func (p *peerImpl) sendInitPayload() {

--- a/internal/download/p.go
+++ b/internal/download/p.go
@@ -142,11 +142,19 @@ func NewPeerID() (peerID proto.PeerID) {
 }
 
 func NewOutgoingPeer(conn net.Conn, d *Download, addr netip.AddrPort, encrypted bool) Peer {
-	return newPeer(conn, d, addr, false, nil, encrypted)
+	p := newPeer(conn, d, addr, false, nil, encrypted)
+	p.startAsync(false)
+	return p
 }
 
 func NewIncomingPeer(conn net.Conn, d *Download, addr netip.AddrPort, h proto.Handshake, encrypted bool) Peer {
-	return newPeer(conn, d, addr, true, &h, encrypted)
+	p := newPeer(conn, d, addr, true, &h, encrypted)
+	p.startAsync(true)
+	return p
+}
+
+func newUnstartedOutgoingPeer(conn net.Conn, d *Download, addr netip.AddrPort, encrypted bool) *peerImpl {
+	return newPeer(conn, d, addr, false, nil, encrypted)
 }
 
 func newPeer(
@@ -156,7 +164,7 @@ func newPeer(
 	skipReadHandshake bool,
 	h *proto.Handshake,
 	encrypted bool,
-) Peer {
+) *peerImpl {
 	ctx, cancel := context.WithCancel(d.ctx)
 	l := d.log.With().Stringer("addr", addr)
 	var ua string
@@ -226,9 +234,12 @@ func newPeer(
 		p.peerID.Store(&h.PeerID)
 	}
 
+	return p
+}
+
+func (p *peerImpl) startAsync(skipReadHandshake bool) {
 	go p.scheduleRequests()
 	go p.start(skipReadHandshake)
-	return p
 }
 
 var ErrPeerSendInvalidData = errors.New("addrPort send invalid data")
@@ -818,6 +829,9 @@ func (p *peerImpl) start(skipHandshake bool) {
 	}()
 
 	// Register in peers map by unique ID (never collides).
+	if p.closed.Load() {
+		return
+	}
 	p.d.peers.Store(p.id, p)
 
 	// Address dedup: ensure only one peer per address.

--- a/internal/download/peer_list.go
+++ b/internal/download/peer_list.go
@@ -267,7 +267,7 @@ func (pl *peerList) newConnection(addr netip.AddrPort, conn Peer, sessionTime in
 // connectionClosed is called when a peer connection closes.
 // Mirrors libtorrent's peer_list::connection_closed().
 // Does NOT touch candidateCache.
-func (pl *peerList) connectionClosed(addr netip.AddrPort, sessionTime int64, hadTrans bool, failed bool) {
+func (pl *peerList) connectionClosed(addr netip.AddrPort, conn Peer, sessionTime int64, hadTrans bool, failed bool) {
 	pl.mu.Lock()
 	defer pl.mu.Unlock()
 
@@ -277,6 +277,9 @@ func (pl *peerList) connectionClosed(addr netip.AddrPort, sessionTime int64, had
 	}
 
 	pp := pl.peers[idx]
+	if pp.connection != conn {
+		return
+	}
 	pp.connection = nil
 	pp.hadTrans = pp.hadTrans || hadTrans
 
@@ -366,16 +369,9 @@ func (pl *peerList) findConnectCandidates(sessionTime int64) {
 	}
 }
 
-// connectPeers returns up to n best currently allowed connect candidates in a
-// single locked call.
-// Mirrors libtorrent's connect_one_peer logic:
-// 1. Clean cache (remove non-candidates)
-// 2. Refill if empty via findConnectCandidates
-// 3. Pop from front.
-func (pl *peerList) connectPeers(sessionTime int64, n int) []*persistentPeer {
-	pl.mu.Lock()
-	defer pl.mu.Unlock()
-
+// prepareCandidateCacheLocked removes stale entries and refills an empty
+// candidate cache. Caller must hold pl.mu.
+func (pl *peerList) prepareCandidateCacheLocked(sessionTime int64) bool {
 	// Clean cache: remove entries that are no longer connect candidates.
 	cleaned := pl.candidateCache[:0]
 	for _, entry := range pl.candidateCache {
@@ -387,22 +383,58 @@ func (pl *peerList) connectPeers(sessionTime int64, n int) []*persistentPeer {
 
 	if len(pl.candidateCache) == 0 {
 		pl.findConnectCandidates(sessionTime)
-		if len(pl.candidateCache) == 0 {
-			return nil
+	}
+	return len(pl.candidateCache) > 0
+}
+
+// hasConnectWork avoids joining the global DialSem FIFO when this download has
+// no immediately eligible work. Selection and capacity are checked again after
+// acquisition.
+func (pl *peerList) hasConnectWork(sessionTime int64, maxConnections int) bool {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+
+	incoming, outgoing := pl.connectionCountsLocked()
+	return incoming+outgoing < maxConnections && pl.prepareCandidateCacheLocked(sessionTime)
+}
+
+// pickConnectCandidate atomically re-checks per-download capacity and marks
+// one candidate dialing after this download has acquired its global dial turn.
+func (pl *peerList) pickConnectCandidate(sessionTime int64, maxConnections int) *persistentPeer {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+
+	incoming, outgoing := pl.connectionCountsLocked()
+	if incoming+outgoing >= maxConnections || !pl.prepareCandidateCacheLocked(sessionTime) {
+		return nil
+	}
+
+	pp := pl.candidateCache[0].p
+	remaining := copy(pl.candidateCache, pl.candidateCache[1:])
+	pl.candidateCache = pl.candidateCache[:remaining]
+	pp.dialing = true
+	return pp
+}
+
+// connectionCountsLocked derives connection capacity from peer-list-owned
+// lifecycle state. Caller must hold pl.mu.
+func (pl *peerList) connectionCountsLocked() (incoming, outgoing int) {
+	for _, count := range pl.incomingConnections {
+		incoming += int(count)
+	}
+	for _, pp := range pl.peers {
+		if pp.dialing || pp.connection != nil {
+			outgoing++
 		}
 	}
+	return incoming, outgoing
+}
 
-	result := make([]*persistentPeer, 0, min(n, len(pl.candidateCache)))
-	for len(result) < n && len(pl.candidateCache) > 0 {
-		pp := pl.candidateCache[0].p
-		// Shift left to preserve backing array capacity.
-		remaining := copy(pl.candidateCache, pl.candidateCache[1:])
-		pl.candidateCache = pl.candidateCache[:remaining]
-		pp.dialing = true
-		result = append(result, pp)
-	}
-
-	return result
+func (pl *peerList) connectionCount() int {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+	incoming, outgoing := pl.connectionCountsLocked()
+	return incoming + outgoing
 }
 
 // isConnectCandidateLocked applies peer-list-owned availability state in
@@ -458,6 +490,27 @@ func (pl *peerList) incomingConnectionOpened(addr netip.AddrPort) {
 	pl.mu.Lock()
 	pl.incomingConnections[addr]++
 	pl.mu.Unlock()
+}
+
+// tryOpenIncoming atomically admits an incoming connection. Downloads with a
+// limit of at least two always keep one lane available for outgoing dialing,
+// preventing incoming peers from filling every per-download slot.
+func (pl *peerList) tryOpenIncoming(addr netip.AddrPort, maxConnections int) bool {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+
+	if maxConnections <= 0 {
+		return false
+	}
+	incoming, outgoing := pl.connectionCountsLocked()
+	if incoming+outgoing >= maxConnections {
+		return false
+	}
+	if maxConnections > 1 && outgoing == 0 && incoming >= maxConnections-1 {
+		return false
+	}
+	pl.incomingConnections[addr]++
+	return true
 }
 
 func (pl *peerList) incomingConnectionClosed(addr netip.AddrPort) {

--- a/internal/download/peer_list.go
+++ b/internal/download/peer_list.go
@@ -145,14 +145,14 @@ func (pl *peerList) insertCandidateCacheLocked(pp *persistentPeer) {
 
 // addPeer adds or updates a peer.
 // Mirrors libtorrent's peer_list::add_peer().
-func (pl *peerList) addPeer(addr netip.AddrPort, source tracker.PeerSource, connectable bool) {
+func (pl *peerList) addPeer(addr netip.AddrPort, source tracker.PeerSource) {
 	pl.mu.Lock()
 	defer pl.mu.Unlock()
 
 	idx, found := pl.findPeer(addr)
 	if found {
 		p := pl.peers[idx]
-		pl.updatePeerLocked(p, source, connectable)
+		pl.updatePeerLocked(p, source)
 		return
 	}
 
@@ -160,7 +160,7 @@ func (pl *peerList) addPeer(addr netip.AddrPort, source tracker.PeerSource, conn
 		addrPort:         addr,
 		source:           source,
 		cachedSourceRank: tracker.SourceRank(source),
-		connectable:      connectable,
+		connectable:      true,
 		lastSeen:         0,
 		priority:         pl.d.session.PeerPriority(addr),
 	}
@@ -175,14 +175,12 @@ func (pl *peerList) addPeer(addr netip.AddrPort, source tracker.PeerSource, conn
 
 // updatePeerLocked updates an existing peer's metadata. Caller holds pl.mu.
 // Mirrors libtorrent's peer_list::update_peer().
-func (pl *peerList) updatePeerLocked(p *persistentPeer, source tracker.PeerSource, connectable bool) {
+func (pl *peerList) updatePeerLocked(p *persistentPeer, source tracker.PeerSource) {
 	wasConnCand := p.isConnectCandidate(pl.finished, pl.maxFailcount)
 
 	p.source |= source
 	p.cachedSourceRank = tracker.SourceRank(p.source)
-	if connectable {
-		p.connectable = true
-	}
+	p.connectable = true
 
 	if source&tracker.PeerSourceTracker != 0 {
 		p.failcount = 0

--- a/internal/download/peer_list.go
+++ b/internal/download/peer_list.go
@@ -94,6 +94,8 @@ type peerList struct {
 	d                    *Download
 	candidateCache       []candidateEntry // sorted cache of top candidates (max 10)
 	peers                []*persistentPeer
+	bannedAddrs          map[netip.Addr]int64
+	incomingConnections  map[netip.AddrPort]uint32
 	numConnectCandidates int
 	roundRobin           int
 	maxFailcount         int
@@ -106,10 +108,12 @@ const candidateCount = 50
 
 func newPeerList(d *Download) *peerList {
 	return &peerList{
-		d:                d,
-		candidateCache:   make([]candidateEntry, 0, candidateCount),
-		maxFailcount:     10,
-		minReconnectTime: 60,
+		d:                   d,
+		candidateCache:      make([]candidateEntry, 0, candidateCount),
+		bannedAddrs:         make(map[netip.Addr]int64),
+		incomingConnections: make(map[netip.AddrPort]uint32),
+		maxFailcount:        10,
+		minReconnectTime:    60,
 	}
 }
 
@@ -319,7 +323,7 @@ func (pl *peerList) findConnectCandidates(sessionTime int64) {
 		pp := pl.peers[pl.roundRobin]
 		pl.roundRobin++
 
-		if !pp.isConnectCandidate(pl.finished, pl.maxFailcount) {
+		if !pl.isConnectCandidateLocked(pp, sessionTime) {
 			continue
 		}
 
@@ -362,7 +366,8 @@ func (pl *peerList) findConnectCandidates(sessionTime int64) {
 	}
 }
 
-// connectPeers returns up to n best connect candidates in a single locked call.
+// connectPeers returns up to n best currently allowed connect candidates in a
+// single locked call.
 // Mirrors libtorrent's connect_one_peer logic:
 // 1. Clean cache (remove non-candidates)
 // 2. Refill if empty via findConnectCandidates
@@ -374,7 +379,7 @@ func (pl *peerList) connectPeers(sessionTime int64, n int) []*persistentPeer {
 	// Clean cache: remove entries that are no longer connect candidates.
 	cleaned := pl.candidateCache[:0]
 	for _, entry := range pl.candidateCache {
-		if entry.p.isConnectCandidate(pl.finished, pl.maxFailcount) {
+		if pl.isConnectCandidateLocked(entry.p, sessionTime) {
 			cleaned = append(cleaned, entry)
 		}
 	}
@@ -398,6 +403,71 @@ func (pl *peerList) connectPeers(sessionTime int64, n int) []*persistentPeer {
 	}
 
 	return result
+}
+
+// isConnectCandidateLocked applies peer-list-owned availability state in
+// addition to persistent peer metadata. Caller holds pl.mu.
+func (pl *peerList) isConnectCandidateLocked(pp *persistentPeer, sessionTime int64) bool {
+	if !pp.isConnectCandidate(pl.finished, pl.maxFailcount) {
+		return false
+	}
+	if pl.incomingConnections[pp.addrPort] > 0 {
+		return false
+	}
+	return !pl.isAddrBannedLocked(pp.addrPort.Addr(), sessionTime)
+}
+
+func (pl *peerList) isAddrBannedLocked(addr netip.Addr, sessionTime int64) bool {
+	expires, ok := pl.bannedAddrs[addr]
+	if !ok {
+		return false
+	}
+	if sessionTime >= expires {
+		delete(pl.bannedAddrs, addr)
+		return false
+	}
+	return true
+}
+
+// canDial reports whether an already-selected candidate is still eligible to
+// start a transport connection. The dialing flag is intentionally ignored.
+func (pl *peerList) canDial(pp *persistentPeer, sessionTime int64) bool {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+	if pp.connection != nil || !pp.connectable {
+		return false
+	}
+	if pl.incomingConnections[pp.addrPort] > 0 {
+		return false
+	}
+	return !pl.isAddrBannedLocked(pp.addrPort.Addr(), sessionTime)
+}
+
+// banAddr prevents outbound dials to addr until expires. Download owns the
+// policy decision; peerList owns the candidate availability state.
+func (pl *peerList) banAddr(addr netip.Addr, expires time.Time) {
+	pl.mu.Lock()
+	pl.bannedAddrs[addr] = expires.Unix()
+	pl.mu.Unlock()
+}
+
+// incomingConnectionOpened prevents an existing or later-discovered
+// candidate from being dialed while an inbound connection for that address is
+// alive. The counter handles overlapping inbound handshakes.
+func (pl *peerList) incomingConnectionOpened(addr netip.AddrPort) {
+	pl.mu.Lock()
+	pl.incomingConnections[addr]++
+	pl.mu.Unlock()
+}
+
+func (pl *peerList) incomingConnectionClosed(addr netip.AddrPort) {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+	if pl.incomingConnections[addr] <= 1 {
+		delete(pl.incomingConnections, addr)
+		return
+	}
+	pl.incomingConnections[addr]--
 }
 
 // clearDialing clears the dialing flag for a peer. Called when a candidate is

--- a/internal/download/peer_list.go
+++ b/internal/download/peer_list.go
@@ -92,10 +92,10 @@ func comparePeer(lhs, rhs *persistentPeer) bool {
 // findConnectCandidates when empty.
 type peerList struct {
 	d                    *Download
-	candidateCache       []candidateEntry // sorted cache of top candidates (max 10)
-	peers                []*persistentPeer
 	bannedAddrs          map[netip.Addr]int64
 	incomingConnections  map[netip.AddrPort]uint32
+	candidateCache       []candidateEntry
+	peers                []*persistentPeer
 	numConnectCandidates int
 	roundRobin           int
 	maxFailcount         int

--- a/internal/download/peer_list.go
+++ b/internal/download/peer_list.go
@@ -94,7 +94,7 @@ type peerList struct {
 	d                    *Download
 	bannedAddrs          map[netip.Addr]int64
 	incomingConnections  map[netip.AddrPort]uint32
-	candidateCache       []candidateEntry
+	candidateCache       []candidateEntry // sorted cache of top candidates (max 10)
 	peers                []*persistentPeer
 	numConnectCandidates int
 	roundRobin           int

--- a/internal/download/turnover_test.go
+++ b/internal/download/turnover_test.go
@@ -37,7 +37,7 @@ func addConnectedPeer(d *Download, id uint64, p *mockPeer) *mockPeer {
 }
 
 func addCandidate(d *Download) {
-	d.peerList.addPeer(netip.MustParseAddrPort("10.0.0.1:6881"), tracker.PeerSourceTracker, true)
+	d.peerList.addPeer(netip.MustParseAddrPort("10.0.0.1:6881"), tracker.PeerSourceTracker)
 }
 
 func countClosed(peers ...*mockPeer) int {
@@ -148,7 +148,7 @@ func TestEvictPeersLimitedByCandidates(t *testing.T) {
 
 	// Only 2 candidates available.
 	addCandidate(d)
-	d.peerList.addPeer(netip.MustParseAddrPort("10.0.0.2:6881"), tracker.PeerSourceTracker, true)
+	d.peerList.addPeer(netip.MustParseAddrPort("10.0.0.2:6881"), tracker.PeerSourceTracker)
 
 	var peers = make([]*mockPeer, 0, 4)
 	for i := range uint64(4) {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -61,7 +61,6 @@ type Session struct {
 	randKey                    []byte
 	Config                     config.Config
 	RecheckOnComplete          atomic.Bool
-	Connecting                 atomic.Bool
 	DownloadSlots              atomic.Uint32
 	TorrentConnLimit           atomic.Uint32
 	SlowDownloadSpeedThreshold atomic.Int64


### PR DESCRIPTION
## Problem

Some downloads were starved of outgoing connections: candidate peers stayed `last_seen: never` while a single aggressive download consumed all dial slots.

Root cause: the global `DialSem.TryAcquire` is non-blocking (no FIFO fairness) and slot releases did not notify waiters, so a download whose peers time out slowly kept grabbing every slot on each 30s retry tick, and the retry interval meant others never got a chance.

## Solution

Replace the old loop (per-download `connectToPeers` + global `Connecting` lock + 30s ticker) with a per-download `connectLoop` that blocks on a **FIFO** `DialSem.Acquire`. FIFO fairness means no download can starve others out of the dial slots.

- **`connectLoop`**: `DialSem.Acquire` + event wakeups (`signalConnect`) plus a 30s periodic pass, mirroring libtorrent's `on_tick` connection attempt. Failcount-based backoff in `findConnectCandidates` makes peers re-eligible purely as a function of time, so time-driven retries need a periodic wakeup, not just events.
- **`dispatchConnections`**: short-circuits when the global connection pool is full (`ConnCount`), otherwise dials would fail immediately with `errConnectionLimit` and the loop would spin; dispatches one candidate per pass.
- **`tryDial`**: on `errConnectionLimit` restores the candidate without penalizing failcount (`clearDialing`), covering the race where an incoming connection takes the last slot.
- **`startPeerIntake`**: consumes `peersCh` in its own goroutine and wakes the connect loop, decoupling tracker announces from connection dispatch (a loop blocked on `DialSem` can no longer block tracker announces).
- Drop `session.Connecting`; `addPeer` drops its always-`true` `connectable` parameter.

## Tests

New `connect_test.go`: dispatch behavior (inactive state, connection cap, no candidates, ConnSem full), FIFO fairness across downloads with a single dial slot, peer-intake wakeup, and close/teardown with no slot leaks. `go test -tags assert ./internal/...`, `go build -tags assert ./...`, and `task lint` all pass.