### PR TITLE
refactor(download): consolidate peer lifecycle into peerList registry

### DIFF
--- a/internal/download/conn.go
+++ b/internal/download/conn.go
@@ -224,8 +224,9 @@ func (d *Download) tryDial(pp *persistentPeer) {
 }
 
 // recordDisconnect is called by Peer.Close() to clean up shared peer tracking.
-// Outgoing peer-list ownership is cleared by identity, while connectedAddrs is
-// removed only when p is still the primary peer for its address.
+// Outgoing peer-list ownership is cleared by identity, while the active
+// address entry is removed only when p is still the primary peer for its
+// address (see peerList.Unregister).
 func (d *Download) recordDisconnect(p Peer) {
 	if p.Incoming() {
 		d.peerList.incomingConnectionClosed(p.Addr())
@@ -238,11 +239,8 @@ func (d *Download) recordDisconnect(p Peer) {
 		d.peerList.connectionClosed(p.Addr(), p, time.Now().Unix(), p.HadTransfer(), failed)
 	}
 
-	if actual, ok := d.connectedAddrs.Load(p.Addr()); ok && actual == p {
-		d.connectedAddrs.Delete(p.Addr())
-	}
+	d.peerList.Unregister(p)
 
-	d.peers.Delete(p.ID())
 	d.session.ConnSem.Release(1)
 	d.session.ConnCount.Sub(1)
 
@@ -273,7 +271,7 @@ func (d *Download) EvictPeers(n int) int {
 		score int64
 	}
 	var scored []scoredPeer
-	d.peers.Range(func(_ uint64, p Peer) bool {
+	d.peerList.Range(func(_ uint64, p Peer) bool {
 		if !p.Closed() {
 			scored = append(scored, scoredPeer{
 				p:     p,
@@ -308,7 +306,7 @@ func (d *Download) EvictPeers(n int) int {
 // peerTurnover disconnects least useful peers to make room for fresh candidates.
 // Mirrors libtorrent's optimistic disconnect (~2% per round).
 func (d *Download) peerTurnover() {
-	peerCount := d.peers.Size()
+	peerCount := d.peerList.Size()
 	if peerCount == 0 {
 		return
 	}
@@ -329,25 +327,10 @@ func (d *Download) peerTurnover() {
 
 // isAddrBanned checks whether an address is currently banned for this torrent.
 func (d *Download) isAddrBanned(addr netip.Addr) bool {
-	d.bannedAddrsMu.Lock()
-	defer d.bannedAddrsMu.Unlock()
-
-	expires, ok := d.bannedAddrs[addr]
-	if !ok {
-		return false
-	}
-	if time.Now().After(expires) {
-		delete(d.bannedAddrs, addr)
-		return false
-	}
-	return true
+	return d.peerList.isAddrBanned(addr)
 }
 
 // banAddr bans an address from connecting to this torrent for addrBanDuration.
 func (d *Download) banAddr(addr netip.Addr) {
-	expires := time.Now().Add(addrBanDuration)
-	d.bannedAddrsMu.Lock()
-	d.bannedAddrs[addr] = expires
-	d.bannedAddrsMu.Unlock()
-	d.peerList.banAddr(addr, expires)
+	d.peerList.banAddr(addr, time.Now().Add(addrBanDuration))
 }

--- a/internal/download/connect_test.go
+++ b/internal/download/connect_test.go
@@ -347,7 +347,11 @@ func TestStopAbandonsWaitingDial(t *testing.T) {
 	// observe the inactive state and give up.
 	sess.ConnSem.Release(1)
 	require.Eventually(t, func() bool { return dialingCandidateCount(d) == 0 }, time.Second, 10*time.Millisecond)
-	require.True(t, sess.DialSem.TryAcquire(4), "stopped download must release dial slots")
+	// DialSem is released by dispatchConnections when tryDial returns. The
+	// dialing flag is cleared slightly earlier, so wait for the semaphore
+	// itself instead of inferring its release from the candidate state.
+	require.Eventually(t, func() bool { return sess.DialSem.TryAcquire(4) }, time.Second, 10*time.Millisecond,
+		"stopped download must release dial slots")
 	sess.DialSem.Release(4)
 }
 

--- a/internal/download/connect_test.go
+++ b/internal/download/connect_test.go
@@ -253,7 +253,7 @@ func TestAddConnReservesOutgoingLane(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, firstRemote.Close())
 	require.Eventually(t, func() bool {
-		return d.occupiedConnectionCount() == 0 && d.peers.Size() == 0
+		return d.occupiedConnectionCount() == 0 && d.peerList.Size() == 0
 	}, time.Second, 10*time.Millisecond)
 	require.True(t, sess.ConnSem.TryAcquire(200), "all incoming connection slots must be released")
 	sess.ConnSem.Release(200)
@@ -497,12 +497,12 @@ func TestConnectLoopExitsOnClose(t *testing.T) {
 	d.signalConnect()
 
 	// The dial succeeds and the peer registers after the handshake.
-	require.Eventually(t, func() bool { return d.peers.Size() > 0 }, 5*time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool { return d.peerList.Size() > 0 }, 5*time.Second, 10*time.Millisecond)
 	require.NoError(t, <-handshakeErr)
 
 	// Closing the download force-closes the connection and releases every slot.
 	d.Close()
-	require.Eventually(t, func() bool { return d.peers.Size() == 0 }, 5*time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool { return d.peerList.Size() == 0 }, 5*time.Second, 10*time.Millisecond)
 	require.True(t, sess.DialSem.TryAcquire(4), "DialSem slots must be released after close")
 	sess.DialSem.Release(4)
 	require.True(t, sess.ConnSem.TryAcquire(200), "ConnSem slots must be released after close")

--- a/internal/download/corrupt_recovery_test.go
+++ b/internal/download/corrupt_recovery_test.go
@@ -8,12 +8,10 @@ package download
 import (
 	"context"
 	"crypto/sha1"
-	"net/netip"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/semaphore"
 
@@ -96,8 +94,6 @@ func newTestEnv(t *testing.T, numPieces, blocksPerPiece uint32, failPieces []uin
 		pieceUploadRate:   flowrate.New(time.Second, 5*time.Second),
 		uploadLimiter:     ratelimit.New(0),
 		downloadLimiter:   ratelimit.New(0),
-		peers:             xsync.NewMap[uint64, Peer](),
-		connectedAddrs:    xsync.NewMap[netip.AddrPort, Peer](),
 		stateCond:         stateCond,
 		private:           false,
 		corruptedPieces:   make(map[uint32]int),

--- a/internal/download/d.go
+++ b/internal/download/d.go
@@ -7,12 +7,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/netip"
 	"strconv"
 	"sync"
 	"time"
 
-	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/rs/zerolog"
 	"go.uber.org/atomic"
 
@@ -138,10 +136,10 @@ func (d *Download) commitStateTransition(from, to State) {
 }
 
 func (d *Download) clearPeerDownloadRequests() {
-	if d.peers == nil {
+	if d.peerList == nil {
 		return
 	}
-	d.peers.Range(func(_ uint64, p Peer) bool {
+	d.peerList.Range(func(_ uint64, p Peer) bool {
 		p.ClearDownloadRequests()
 		return true
 	})
@@ -173,32 +171,29 @@ type Download struct {
 	log                    zerolog.Logger
 	AddAt                  time.Time
 	ctx                    context.Context
-	store                  piece_store.PieceStore           // Never nil.
-	connectedAddrs         *xsync.Map[netip.AddrPort, Peer] // Never nil.
-	picker                 atomic.Pointer[PiecePicker]      // nil during initial checking or when the download is complete
-	session                *session.Session                 // Never nil.
-	pieceDownloadRate      *flowrate.Monitor                // Never nil.
-	ioDownloadRate         *flowrate.Monitor                // Never nil.
-	pieceUploadRate        *flowrate.Monitor                // Never nil.
-	resChan                chan chunkSubmit                 // Never nil.
-	uploadLimiter          *ratelimit.Limiter               // Never nil.
-	peersCh                chan []tracker.DiscoveredPeer    // Never nil.
-	peers                  *xsync.Map[uint64, Peer]         // Never nil.
-	bannedAddrs            map[netip.Addr]time.Time         // Never nil.
-	stateCond              *gsync.Cond                      // Never nil.
-	peerList               *peerList                        // Never nil.
-	connectSignal          chan struct{}                    // Never nil in real downloads.
-	downloadLimiter        *ratelimit.Limiter               // Never nil.
-	err                    atomic.Pointer[error]            // nil unless download enters Error state
-	cancel                 context.CancelFunc               // Never nil after New().
-	scheduleResponseSignal chan empty.Empty                 // Never nil.
-	tracker                *tracker.Trackers                // Never nil.
-	completedBm            *bm.Bitmap                       // Never nil.
-	missingBm              *bm.LockFreeBitmap               // Never nil.
-	wantedBm               *bm.Bitmap                       // Never nil.
-	selectedFilesSet       *bm.Bitmap                       // Never nil.
-	corruptedPieces        map[uint32]int                   // Never nil.
-	moveCancel             context.CancelFunc               // nil unless a move operation is in progress
+	store                  piece_store.PieceStore        // Never nil.
+	picker                 atomic.Pointer[PiecePicker]   // nil during initial checking or when the download is complete
+	session                *session.Session              // Never nil.
+	pieceDownloadRate      *flowrate.Monitor             // Never nil.
+	ioDownloadRate         *flowrate.Monitor             // Never nil.
+	pieceUploadRate        *flowrate.Monitor             // Never nil.
+	resChan                chan chunkSubmit              // Never nil.
+	uploadLimiter          *ratelimit.Limiter            // Never nil.
+	peersCh                chan []tracker.DiscoveredPeer // Never nil.
+	peerList               *peerList                     // Never nil.
+	stateCond              *gsync.Cond                   // Never nil.
+	connectSignal          chan struct{}                 // Never nil in real downloads.
+	downloadLimiter        *ratelimit.Limiter            // Never nil.
+	err                    atomic.Pointer[error]         // nil unless download enters Error state
+	cancel                 context.CancelFunc            // Never nil after New().
+	scheduleResponseSignal chan empty.Empty              // Never nil.
+	tracker                *tracker.Trackers             // Never nil.
+	completedBm            *bm.Bitmap                    // Never nil.
+	missingBm              *bm.LockFreeBitmap            // Never nil.
+	wantedBm               *bm.Bitmap                    // Never nil.
+	selectedFilesSet       *bm.Bitmap                    // Never nil.
+	corruptedPieces        map[uint32]int                // Never nil.
+	moveCancel             context.CancelFunc            // nil unless a move operation is in progress
 	s                      downloadState
 	info                   meta.Info
 	backgroundWg           sync.WaitGroup
@@ -212,7 +207,6 @@ type Download struct {
 	uploaded               atomic.Int64
 	wastedStale            atomic.Int64
 	peerSeeds              atomic.Int64
-	peerIDCounter          atomic.Uint64
 	uploadAtStart          int64
 	// completed is the amount of data for wanted pieces that have passed
 	// hash verification. Used for UI progress display and tracker 'left'
@@ -230,7 +224,6 @@ type Download struct {
 	completedOnce      atomic.Bool
 	moveCancelMu       sync.RWMutex
 	transitionMu       sync.Mutex
-	bannedAddrsMu      sync.Mutex
 	corruptedPiecesMu  sync.Mutex
 	normalChunkLen     uint32
 	bitfieldSize       uint32
@@ -436,7 +429,7 @@ func (d *Download) peerSeedLeecherCounts() (seeds, leechers int) {
 // recalcPeerCounts iterates all connected peers and refreshes the cached seed/leecher counters.
 func (d *Download) recalcPeerCounts() {
 	var seeds, leechers int64
-	d.peers.Range(func(_ uint64, p Peer) bool {
+	d.peerList.Range(func(_ uint64, p Peer) bool {
 		if p.IsSeed() {
 			seeds++
 		} else {

--- a/internal/download/debug_template.go
+++ b/internal/download/debug_template.go
@@ -221,7 +221,7 @@ func BuildDebugPageData(d *Download, infoHashHex string, fullMode bool) *debugPa
 
 	// Peers
 	var peers []debugPeer
-	d.peers.Range(func(_ uint64, p Peer) bool {
+	d.peerList.Range(func(_ uint64, p Peer) bool {
 		dir := "out"
 		if p.Incoming() {
 			dir = "in"
@@ -264,7 +264,7 @@ func BuildDebugPageData(d *Download, infoHashHex string, fullMode bool) *debugPa
 	// Peer rate & total vs download
 	var peerTotalCurRate int64
 	var peerTotalBytes int64
-	d.peers.Range(func(_ uint64, p Peer) bool {
+	d.peerList.Range(func(_ uint64, p Peer) bool {
 		peerTotalCurRate += p.DownloadRate()
 		peerTotalBytes += p.DownloadTotal()
 		return true

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -39,7 +39,7 @@ func (d *Download) notifyPeersToRequest() {
 	if !d.IsActiveDownloading() {
 		return
 	}
-	d.peers.Range(func(_ uint64, p Peer) bool {
+	d.peerList.Range(func(_ uint64, p Peer) bool {
 		if p.Closed() {
 			return true
 		}
@@ -52,7 +52,7 @@ func (d *Download) notifyPeersToRequest() {
 
 func (d *Download) have(index uint32) {
 	tasks.SubmitNet(func() {
-		d.peers.Range(func(_ uint64, p Peer) bool {
+		d.peerList.Range(func(_ uint64, p Peer) bool {
 			p.Have(index)
 			return true
 		})
@@ -553,7 +553,7 @@ func (d *Download) penalizePiecePeers(pieceIndex uint32, passed bool, pc *peerCo
 	}
 
 	for peerID := range contributors {
-		p, ok := d.peers.Load(peerID)
+		p, ok := d.peerList.Load(peerID)
 		if !ok {
 			continue
 		}
@@ -603,7 +603,7 @@ func (d *Download) gradualUnblockPiece(pieceIndex uint32) {
 		oldestTime time.Time
 	)
 
-	d.peers.Range(func(_ uint64, p Peer) bool {
+	d.peerList.Range(func(_ uint64, p Peer) bool {
 		if p.Closed() {
 			return true
 		}
@@ -663,7 +663,7 @@ func (d *Download) finalizeDownloadCompletion() {
 	d.pieceDownloadRate.Reset()
 	d.fireCompletedHook()
 
-	d.peers.Range(func(_ uint64, p Peer) bool {
+	d.peerList.Range(func(_ uint64, p Peer) bool {
 		if uint32(p.PeerBitmap().Count()) == d.info.NumPieces {
 			p.Close()
 		}

--- a/internal/download/download_async_test.go
+++ b/internal/download/download_async_test.go
@@ -30,7 +30,7 @@ func asyncHelper(d *Download) func() {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				d.peers.Range(func(_ uint64, p Peer) bool {
+				d.peerList.Range(func(_ uint64, p Peer) bool {
 					if !p.Closed() {
 						p.(*mockPeer).requestABlock()
 					}
@@ -107,7 +107,7 @@ func TestAsyncDownload_FullPeer(t *testing.T) {
 
 			for i := range numPeers {
 				p := fullPeer(d, numPieces, uint64(i+1))
-				d.peers.Store(p.ID(), p)
+				d.peerList.activeByID.Store(p.ID(), p)
 				for pi := range numPieces {
 					d.picker.Load().IncRefcount(pi)
 				}
@@ -149,7 +149,7 @@ func TestAsyncDownload_CorruptRecovery(t *testing.T) {
 			// Peer 1: first download attempt. Will get blocked for pieces
 			// that fail hash due to FailNPieceStore.
 			p1 := fullPeer(d, numPieces, 1)
-			d.peers.Store(p1.ID(), p1)
+			d.peerList.activeByID.Store(p1.ID(), p1)
 			for pi := range numPieces {
 				d.picker.Load().IncRefcount(pi)
 			}
@@ -163,7 +163,7 @@ func TestAsyncDownload_CorruptRecovery(t *testing.T) {
 			}
 
 			p2 := fullPeer(d, numPieces, 2)
-			d.peers.Store(p2.ID(), p2)
+			d.peerList.activeByID.Store(p2.ID(), p2)
 			for pi := range numPieces {
 				d.picker.Load().IncRefcount(pi)
 			}
@@ -192,7 +192,7 @@ func TestAsyncDownload_ParoleBan(t *testing.T) {
 	defer cancel()
 
 	p1 := fullPeer(d, numPieces, 1)
-	d.peers.Store(p1.ID(), p1)
+	d.peerList.activeByID.Store(p1.ID(), p1)
 	for pi := range numPieces {
 		d.picker.Load().IncRefcount(pi)
 	}

--- a/internal/download/download_multi_test.go
+++ b/internal/download/download_multi_test.go
@@ -71,7 +71,7 @@ func FuzzDownloadMultiPeer_Async(f *testing.F) {
 		combined := bm.New(numPieces)
 		for i := range numPeers {
 			p := asyncPeer(d, numPieces, seed+uint64(i))
-			d.peers.Store(p.ID(), p)
+			d.peerList.activeByID.Store(p.ID(), p)
 			t.Cleanup(p.Close)
 			p.bitmap.Range(func(pi uint32) {
 				d.picker.Load().IncRefcount(pi)
@@ -99,7 +99,7 @@ func FuzzDownloadMultiPeer_Async(f *testing.F) {
 				peersAlive := 0
 				peersUnchoked := 0
 				peersInterested := 0
-				d.peers.Range(func(_ uint64, p Peer) bool {
+				d.peerList.Range(func(_ uint64, p Peer) bool {
 					if !p.Closed() {
 						hasCapable = true
 						peersAlive++
@@ -127,7 +127,7 @@ func FuzzDownloadMultiPeer_Async(f *testing.F) {
 				}
 
 				// Call requestABlock for all open peers.
-				d.peers.Range(func(_ uint64, p Peer) bool {
+				d.peerList.Range(func(_ uint64, p Peer) bool {
 					if p.Closed() {
 						return true
 					}
@@ -137,7 +137,7 @@ func FuzzDownloadMultiPeer_Async(f *testing.F) {
 
 				// Random events.
 				if rng.IntN(20) == 0 {
-					d.peers.Range(func(_ uint64, p Peer) bool {
+					d.peerList.Range(func(_ uint64, p Peer) bool {
 						if rng.IntN(3) == 0 {
 							if p.IsOurChoking() {
 								p.SendUnchoke()
@@ -150,7 +150,7 @@ func FuzzDownloadMultiPeer_Async(f *testing.F) {
 				}
 				if rng.IntN(30) == 0 {
 					var toClose []Peer
-					d.peers.Range(func(_ uint64, p Peer) bool {
+					d.peerList.Range(func(_ uint64, p Peer) bool {
 						if rng.IntN(3) == 0 {
 							toClose = append(toClose, p)
 						}
@@ -159,7 +159,7 @@ func FuzzDownloadMultiPeer_Async(f *testing.F) {
 					for _, p := range toClose {
 						// Don't close a peer if it would make any non-completed
 						// piece unavailable among remaining peers.
-						if d.peers.Size() <= 1 {
+						if d.peerList.Size() <= 1 {
 							break
 						}
 						safeToClose := true
@@ -168,7 +168,7 @@ func FuzzDownloadMultiPeer_Async(f *testing.F) {
 								return
 							}
 							hasOther := false
-							d.peers.Range(func(_ uint64, other Peer) bool {
+							d.peerList.Range(func(_ uint64, other Peer) bool {
 								if other.ID() != p.ID() && !other.Closed() && other.PeerBitmap().Contains(pi) {
 									hasOther = true
 									return false

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -73,7 +73,7 @@ func TestRequestABlock_UnchokedPeerEnqueuesBlocks(t *testing.T) {
 func TestPromoteFromQueuedSchedulesExistingPeers(t *testing.T) {
 	d, p := newRequestABlockFixture(t, 5)
 	d.state.Store(uint32(PendingDownloading))
-	d.peers.Store(p.ID(), p)
+	d.peerList.activeByID.Store(p.ID(), p)
 
 	p.requestABlock()
 	require.Empty(t, p.requestsSent, "queued download must not request blocks")

--- a/internal/download/file_priority.go
+++ b/internal/download/file_priority.go
@@ -87,7 +87,7 @@ func (d *Download) resetReSelectedPieces(fileIDs []int) {
 
 // CloseAllPeers closes all peer connections for this download.
 func (d *Download) CloseAllPeers() {
-	d.peers.Range(func(_ uint64, p Peer) bool {
+	d.peerList.Range(func(_ uint64, p Peer) bool {
 		p.Close()
 		return true
 	})

--- a/internal/download/fuzz_full_download_test.go
+++ b/internal/download/fuzz_full_download_test.go
@@ -151,8 +151,8 @@ func wireDownloadState(d *Download, numPieces uint32) string {
 	picker := d.picker.Load()
 	if picker == nil {
 		return fmt.Sprintf("state=%s complete=%d/%d missing=%v peers=%d picker=released",
-			d.GetState(), d.completedBm.Count(), numPieces, missing, d.peers.Size())
+			d.GetState(), d.completedBm.Count(), numPieces, missing, d.peerList.Size())
 	}
 	return fmt.Sprintf("state=%s complete=%d/%d missing=%v peers=%d\n%s",
-		d.GetState(), d.completedBm.Count(), numPieces, missing, d.peers.Size(), picker.DebugDump())
+		d.GetState(), d.completedBm.Count(), numPieces, missing, d.peerList.Size(), picker.DebugDump())
 }

--- a/internal/download/handle_res_test.go
+++ b/internal/download/handle_res_test.go
@@ -10,14 +10,12 @@ import (
 	"crypto/sha1"
 	"fmt"
 	"math/rand/v2"
-	"net/netip"
 	"slices"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sync/semaphore"
@@ -86,12 +84,9 @@ func newTestDownload(t testing.TB, numPieces uint32, blocksPerPiece uint32, newS
 		pieceUploadRate:        flowrate.New(time.Second, 5*time.Second),
 		uploadLimiter:          ratelimit.New(0),
 		downloadLimiter:        ratelimit.New(0),
-		peers:                  xsync.NewMap[uint64, Peer](),
-		connectedAddrs:         xsync.NewMap[netip.AddrPort, Peer](),
 		stateCond:              stateCond,
 		private:                false,
 		corruptedPieces:        make(map[uint32]int),
-		bannedAddrs:            make(map[netip.Addr]time.Time),
 		tracker:                tracker.New(ctx, tracker.Config{}),
 		scheduleResponseSignal: make(chan empty.Empty, 1),
 	}

--- a/internal/download/info.go
+++ b/internal/download/info.go
@@ -74,7 +74,7 @@ func (d *Download) Info(keys []string) TorrentInfo {
 		DownloadTotal:        d.downloaded.Load(),
 		UploadRate:           d.pieceUploadRate.Status().CurRate,
 		UploadTotal:          d.uploaded.Load(),
-		ConnectionCount:      d.peers.Size(),
+		ConnectionCount:      d.peerList.Size(),
 		BytesCompleted:       d.completed.Load(),
 		TotalLength:          d.info.TotalLength,
 		SelectedSize:         d.SelectedSize(),
@@ -139,8 +139,8 @@ type PeerInfo struct {
 
 // PeerInfos returns a snapshot of all connected peers.
 func (d *Download) PeerInfos() []PeerInfo {
-	results := make([]PeerInfo, 0, d.peers.Size())
-	d.peers.Range(func(_ uint64, p Peer) bool {
+	results := make([]PeerInfo, 0, d.peerList.Size())
+	d.peerList.Range(func(_ uint64, p Peer) bool {
 		results = append(results, PeerInfo{
 			Address:      p.Addr().String(),
 			Client:       p.UserAgent(),

--- a/internal/download/loop.go
+++ b/internal/download/loop.go
@@ -186,7 +186,7 @@ func (d *Download) goBackground(fn func()) {
 
 func (d *Download) optimisticUnchoke() {
 	var peers []Peer
-	d.peers.Range(func(_ uint64, p Peer) bool {
+	d.peerList.Range(func(_ uint64, p Peer) bool {
 		if !p.Closed() && !p.IsSnubbed() {
 			peers = append(peers, p)
 		}
@@ -240,5 +240,5 @@ func (d *Download) maxConnections() int {
 
 // peerCount returns the number of currently connected peers.
 func (d *Download) peerCount() int {
-	return d.peers.Size()
+	return d.peerList.Size()
 }

--- a/internal/download/methods.go
+++ b/internal/download/methods.go
@@ -79,7 +79,7 @@ func (d *Download) Cancel() {
 }
 
 // PeerCount returns the number of currently connected peers.
-func (d *Download) PeerCount() int { return d.peers.Size() }
+func (d *Download) PeerCount() int { return d.peerList.Size() }
 
 // BackgroundWgWait waits for all background goroutines to finish.
 func (d *Download) BackgroundWgWait() {

--- a/internal/download/new.go
+++ b/internal/download/new.go
@@ -7,10 +7,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/netip"
 	"time"
 
-	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/rs/zerolog/log"
 	"go.uber.org/atomic"
 
@@ -168,11 +166,7 @@ func newDownload(
 		ioDownloadRate:    flowrate.New(time.Second, 5*time.Second),
 		pieceUploadRate:   flowrate.New(time.Second, 5*time.Second),
 
-		peers:           xsync.NewMap[uint64, Peer](),
-		connectedAddrs:  xsync.NewMap[netip.AddrPort, Peer](),
-		peerList:        newPeerList(nil), // d set below
 		corruptedPieces: make(map[uint32]int),
-		bannedAddrs:     make(map[netip.Addr]time.Time),
 
 		store: store,
 
@@ -188,6 +182,8 @@ func newDownload(
 
 		peersCh: make(chan []tracker.DiscoveredPeer, 1),
 	}
+
+	d.peerList = newPeerList(d)
 
 	d.completedBm = completedBm
 	d.wantedBm = bm.New(info.NumPieces)
@@ -236,8 +232,6 @@ func newDownload(
 		cancel()
 		return nil, err
 	}
-
-	d.peerList.d = d
 
 	d.tracker = tracker.New(d.ctx, tracker.Config{
 		Key:             trackerKey,

--- a/internal/download/p.go
+++ b/internal/download/p.go
@@ -178,7 +178,7 @@ func newPeer(
 		pieceDownloadRate: flowrate.New(time.Second, 5*time.Second),
 		Address:           addr,
 		connectedAt:       time.Now(),
-		id:                d.peerIDCounter.Add(1),
+		id:                d.peerList.AllocID(),
 		queueLimit:        *atomic.NewUint32(2000),
 		incoming:          skipReadHandshake,
 		encrypted:         encrypted,
@@ -818,19 +818,15 @@ func (p *peerImpl) start(skipHandshake bool) {
 		}
 	}()
 
-	// Register in peers map by unique ID (never collides).
+	// Register in the peer list by unique ID and address. Address dedup
+	// ensures only one connection per address; a loser of that race is
+	// closed by defer and cleaned up via Unregister (which only removes
+	// the by-ID entry it actually owns).
 	if p.closed.Load() {
 		return
 	}
-	p.d.peers.Store(p.id, p)
-
-	// Address dedup: ensure only one peer per address.
-	actual, loaded := p.d.connectedAddrs.LoadOrStore(p.Address, p)
-	if loaded {
-		// Another peer already owns this address. We lost the race.
-		// defer close() handles cleanup; it will see we are not in connectedAddrs
-		// and skip shared-state cleanup.
-		p.log.Trace().Uint64("existing_peer_id", actual.ID()).Msg("duplicate connection, closing")
+	if !p.d.peerList.Register(p) {
+		p.log.Trace().Msg("duplicate connection, closing")
 		return
 	}
 

--- a/internal/download/peer_list.go
+++ b/internal/download/peer_list.go
@@ -10,6 +10,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/puzpuzpuz/xsync/v4"
+	"go.uber.org/atomic"
+
 	"neptune/internal/client/tracker"
 )
 
@@ -25,14 +28,13 @@ type persistentPeer struct {
 	failcount        uint8
 	source           tracker.PeerSource
 	connectable      bool
-	seed             bool
 	hadTrans         bool
 	dialing          bool
 }
 
 // isConnectCandidate returns true if this peer is eligible for connection.
 // Mirrors libtorrent's is_connect_candidate().
-func (p *persistentPeer) isConnectCandidate(finished bool, maxFailcount int) bool {
+func (p *persistentPeer) isConnectCandidate(maxFailcount int) bool {
 	if p.connection != nil {
 		return false
 	}
@@ -40,9 +42,6 @@ func (p *persistentPeer) isConnectCandidate(finished bool, maxFailcount int) boo
 		return false
 	}
 	if !p.connectable {
-		return false
-	}
-	if p.seed && finished {
 		return false
 	}
 	if int(p.failcount) >= maxFailcount {
@@ -84,24 +83,29 @@ func comparePeer(lhs, rhs *persistentPeer) bool {
 	return false
 }
 
-// peerList mirrors libtorrent's peer_list — persistent storage of all known
-// peers with a pre-computed connect candidate cache.
+// peerList owns all peer state for a torrent: the persistent peer metadata
+// with a pre-computed connect candidate cache, plus the registry of active
+// connections. Download delegates every peer lifecycle operation here, so a
+// connection is recorded (and cleaned up) in exactly one place.
 //
-// Peers are stored sorted by address for O(log n) lookup. Candidates are kept
-// in a small sorted vector (max 10) that is lazily populated by
-// findConnectCandidates when empty.
+// Persistent peers are stored sorted by address for O(log n) lookup. Candidates
+// are kept in a small sorted vector (max 10) that is lazily populated by
+// findConnectCandidates when empty. Active connections are keyed both by
+// unique peer ID and by address (address dedup rejects duplicate connections).
 type peerList struct {
+	activeByID           *xsync.Map[uint64, Peer]
+	activeByAddr         *xsync.Map[netip.AddrPort, Peer]
 	d                    *Download
 	bannedAddrs          map[netip.Addr]int64
 	incomingConnections  map[netip.AddrPort]uint32
-	candidateCache       []candidateEntry // sorted cache of top candidates (max 10)
 	peers                []*persistentPeer
+	candidateCache       []candidateEntry
+	idCounter            atomic.Uint64
 	numConnectCandidates int
 	roundRobin           int
 	maxFailcount         int
 	minReconnectTime     int64
 	mu                   sync.Mutex
-	finished             bool
 }
 
 const candidateCount = 50
@@ -109,12 +113,63 @@ const candidateCount = 50
 func newPeerList(d *Download) *peerList {
 	return &peerList{
 		d:                   d,
+		activeByID:          xsync.NewMap[uint64, Peer](),
+		activeByAddr:        xsync.NewMap[netip.AddrPort, Peer](),
 		candidateCache:      make([]candidateEntry, 0, candidateCount),
 		bannedAddrs:         make(map[netip.Addr]int64),
 		incomingConnections: make(map[netip.AddrPort]uint32),
 		maxFailcount:        10,
 		minReconnectTime:    60,
 	}
+}
+
+// ── Active connection registry ────────────────────────────────────────
+
+// AllocID returns a unique peer ID for a new connection.
+func (pl *peerList) AllocID() uint64 {
+	return pl.idCounter.Add(1)
+}
+
+// Register records an active connection under both its unique ID and its
+// address. Returns false when another active connection already owns the
+// address — the caller must close the new connection; its by-ID entry is
+// removed by the subsequent Unregister.
+func (pl *peerList) Register(p Peer) bool {
+	pl.activeByID.Store(p.ID(), p)
+	_, loaded := pl.activeByAddr.LoadOrStore(p.Addr(), p)
+	return !loaded
+}
+
+// Unregister removes a connection from the active registry. Only the peer
+// that actually owns its address entry is removed from the address map, so a
+// peer that lost the duplicate-connection race only clears its by-ID entry.
+func (pl *peerList) Unregister(p Peer) {
+	if actual, ok := pl.activeByAddr.Load(p.Addr()); ok && actual == p {
+		pl.activeByAddr.Delete(p.Addr())
+	}
+	pl.activeByID.Delete(p.ID())
+}
+
+// Range iterates active connections by peer ID.
+func (pl *peerList) Range(fn func(uint64, Peer) bool) {
+	pl.activeByID.Range(fn)
+}
+
+// Load returns the active connection with the given peer ID.
+func (pl *peerList) Load(id uint64) (Peer, bool) {
+	return pl.activeByID.Load(id)
+}
+
+// Size returns the number of active connections.
+func (pl *peerList) Size() int {
+	return pl.activeByID.Size()
+}
+
+// isAddrBanned checks whether addr is currently banned for this torrent.
+func (pl *peerList) isAddrBanned(addr netip.Addr) bool {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+	return pl.isAddrBannedLocked(addr, time.Now().Unix())
 }
 
 // insertCandidateCacheLocked inserts a peer into the sorted candidate cache
@@ -171,7 +226,7 @@ func (pl *peerList) addPeer(addr netip.AddrPort, source tracker.PeerSource) {
 
 	pl.peers = slices.Insert(pl.peers, idx, p)
 
-	if p.isConnectCandidate(pl.finished, pl.maxFailcount) {
+	if p.isConnectCandidate(pl.maxFailcount) {
 		pl.numConnectCandidates++
 		pl.insertCandidateCacheLocked(p)
 	}
@@ -180,7 +235,7 @@ func (pl *peerList) addPeer(addr netip.AddrPort, source tracker.PeerSource) {
 // updatePeerLocked updates an existing peer's metadata. Caller holds pl.mu.
 // Mirrors libtorrent's peer_list::update_peer().
 func (pl *peerList) updatePeerLocked(p *persistentPeer, source tracker.PeerSource) {
-	wasConnCand := p.isConnectCandidate(pl.finished, pl.maxFailcount)
+	wasConnCand := p.isConnectCandidate(pl.maxFailcount)
 
 	p.source |= source
 	p.cachedSourceRank = tracker.SourceRank(p.source)
@@ -190,7 +245,7 @@ func (pl *peerList) updatePeerLocked(p *persistentPeer, source tracker.PeerSourc
 		p.failcount = 0
 	}
 
-	isConnCand := p.isConnectCandidate(pl.finished, pl.maxFailcount)
+	isConnCand := p.isConnectCandidate(pl.maxFailcount)
 	if wasConnCand && !isConnCand {
 		pl.numConnectCandidates--
 	} else if !wasConnCand && isConnCand {
@@ -250,7 +305,7 @@ func (pl *peerList) newConnection(addr netip.AddrPort, conn Peer, sessionTime in
 		return false
 	}
 
-	wasConnCand := pp.isConnectCandidate(pl.finished, pl.maxFailcount)
+	wasConnCand := pp.isConnectCandidate(pl.maxFailcount)
 
 	pp.dialing = false
 	pp.connection = conn
@@ -298,7 +353,7 @@ func (pl *peerList) connectionClosed(addr netip.AddrPort, conn Peer, sessionTime
 		}
 	}
 
-	if pp.isConnectCandidate(pl.finished, pl.maxFailcount) {
+	if pp.isConnectCandidate(pl.maxFailcount) {
 		pl.numConnectCandidates++
 		pl.insertCandidateCacheLocked(pp)
 	}
@@ -440,7 +495,7 @@ func (pl *peerList) connectionCount() int {
 // isConnectCandidateLocked applies peer-list-owned availability state in
 // addition to persistent peer metadata. Caller holds pl.mu.
 func (pl *peerList) isConnectCandidateLocked(pp *persistentPeer, sessionTime int64) bool {
-	if !pp.isConnectCandidate(pl.finished, pl.maxFailcount) {
+	if !pp.isConnectCandidate(pl.maxFailcount) {
 		return false
 	}
 	if pl.incomingConnections[pp.addrPort] > 0 {
@@ -543,32 +598,10 @@ func (pl *peerList) incFailcount(p *persistentPeer, errStr string) {
 		return
 	}
 
-	wasConnCand := p.isConnectCandidate(pl.finished, pl.maxFailcount)
+	wasConnCand := p.isConnectCandidate(pl.maxFailcount)
 	p.failcount++
-	if wasConnCand && !p.isConnectCandidate(pl.finished, pl.maxFailcount) {
+	if wasConnCand && !p.isConnectCandidate(pl.maxFailcount) {
 		pl.numConnectCandidates--
-	}
-}
-
-// setFinished updates the finished flag and recalculates candidates.
-func (pl *peerList) setFinished(v bool) {
-	pl.mu.Lock()
-	defer pl.mu.Unlock()
-
-	if pl.finished == v {
-		return
-	}
-	pl.finished = v
-
-	// Invalidate cache since candidate eligibility may change.
-	pl.candidateCache = pl.candidateCache[:0]
-
-	// recalculate candidates
-	pl.numConnectCandidates = 0
-	for _, p := range pl.peers {
-		if p.isConnectCandidate(pl.finished, pl.maxFailcount) {
-			pl.numConnectCandidates++
-		}
 	}
 }
 
@@ -594,9 +627,9 @@ func (pl *peerList) updateConnectable(addr netip.AddrPort, connectable bool) {
 		return
 	}
 
-	wasConnCand := p.isConnectCandidate(pl.finished, pl.maxFailcount)
+	wasConnCand := p.isConnectCandidate(pl.maxFailcount)
 	p.connectable = connectable
-	isConnCand := p.isConnectCandidate(pl.finished, pl.maxFailcount)
+	isConnCand := p.isConnectCandidate(pl.maxFailcount)
 
 	if wasConnCand && !isConnCand {
 		pl.numConnectCandidates--

--- a/internal/download/request_leak_test.go
+++ b/internal/download/request_leak_test.go
@@ -109,7 +109,7 @@ func TestLeavingDownloadingClearsNamedClaims(t *testing.T) {
 			peer.info = d.info
 			peer.setNumPieces(d.info.NumPieces)
 			peer.bitmap.Fill()
-			d.peers.Store(peer.ID(), peer)
+			d.peerList.activeByID.Store(peer.ID(), peer)
 
 			claim := claimBlockForTest(t, d, 0, 0, peer.ID())
 			peer.queued = append(peer.queued, claim)

--- a/internal/download/stale_request_test.go
+++ b/internal/download/stale_request_test.go
@@ -37,7 +37,7 @@ func FuzzStaleRequest(f *testing.F) {
 		combined := bm.New(numPieces)
 		for i := range numPeers {
 			p := asyncPeer(d, numPieces, seed+uint64(i))
-			d.peers.Store(p.ID(), p)
+			d.peerList.activeByID.Store(p.ID(), p)
 			p.bitmap.Range(func(pi uint32) {
 				d.picker.Load().IncRefcount(pi)
 				combined.Set(pi)
@@ -53,7 +53,7 @@ func FuzzStaleRequest(f *testing.F) {
 		go func() {
 			defer close(closerDone)
 			time.Sleep(500 * time.Microsecond)
-			d.peers.Range(func(_ uint64, p Peer) bool {
+			d.peerList.Range(func(_ uint64, p Peer) bool {
 				p.Close()
 				return true
 			})
@@ -70,7 +70,7 @@ func FuzzStaleRequest(f *testing.F) {
 			default:
 			}
 
-			d.peers.Range(func(_ uint64, p Peer) bool {
+			d.peerList.Range(func(_ uint64, p Peer) bool {
 				if !p.Closed() {
 					p.(*mockPeer).requestABlock()
 				}
@@ -82,7 +82,7 @@ func FuzzStaleRequest(f *testing.F) {
 		// were skipped by a racing map traversal. Calling requestABlock afterward
 		// waits on reqMu for any scheduler call that passed its initial Closed
 		// check before Close; once it returns, no such call can retain a claim.
-		d.peers.Range(func(_ uint64, p Peer) bool {
+		d.peerList.Range(func(_ uint64, p Peer) bool {
 			p.Close()
 			p.(*mockPeer).requestABlock()
 			return true

--- a/internal/download/turnover_test.go
+++ b/internal/download/turnover_test.go
@@ -32,7 +32,7 @@ func testTurnoverDownload(t *testing.T, connLimit int) *Download {
 func addConnectedPeer(d *Download, id uint64, p *mockPeer) *mockPeer {
 	p.connectedAt = time.Now().Add(-time.Hour)
 	p.SetOurInterested(true)
-	d.peers.Store(id, p)
+	d.peerList.activeByID.Store(id, p)
 	return p
 }
 

--- a/internal/download/upload.go
+++ b/internal/download/upload.go
@@ -86,7 +86,7 @@ func (d *Download) recalculateUnchokeSlots() {
 
 	var candidates []candidate
 
-	d.peers.Range(func(_ uint64, p Peer) bool {
+	d.peerList.Range(func(_ uint64, p Peer) bool {
 		if p.Closed() {
 			return true
 		}
@@ -228,7 +228,7 @@ func (d *Download) onPeerInterested(p Peer) {
 
 	// Count currently unchoked peers.
 	unchoked := 0
-	d.peers.Range(func(_ uint64, p2 Peer) bool {
+	d.peerList.Range(func(_ uint64, p2 Peer) bool {
 		if !p2.Closed() && !p2.IsOurChoking() {
 			unchoked++
 		}
@@ -274,7 +274,7 @@ func (d *Download) backgroundReqHandler() {
 
 			dispatched := 0
 			queueFull := false
-			d.peers.Range(func(_ uint64, p Peer) bool {
+			d.peerList.Range(func(_ uint64, p Peer) bool {
 				if dispatched >= maxResponsesPerWake || queueFull {
 					return false
 				}

--- a/internal/download/upload_test.go
+++ b/internal/download/upload_test.go
@@ -22,7 +22,7 @@ func TestBackgroundReqHandlerDoesNotQueueClaimedRequestAgain(t *testing.T) {
 
 	p := newMockPeer()
 	p.dl = d
-	d.peers.Store(p.ID(), p)
+	d.peerList.activeByID.Store(p.ID(), p)
 
 	req := proto.ChunkRequest{PieceIndex: 0, Begin: 0, Length: defaultBlockSize}
 	require.True(t, p.AddPeerRequest(req))


### PR DESCRIPTION
## What

`peerList` now owns the active connection registry (by unique peer ID and by address) in addition to the persistent peer metadata and connect-candidate cache, so a connection is registered and cleaned up in exactly one place.

## Motivation

A peer connection's state used to live in three places maintained across multiple paths:

- `Download.peers` (by ID) and `Download.connectedAddrs` (by address) — registered in `peerImpl.start()`, removed in `recordDisconnect`
- `peerList.persistentPeer.connection` — attached in `tryDial`, released in `connectionClosed`

This made lifecycle consistency a manual concern and left duplicated state to keep in sync.

## Changes

- `Download` drops `peers`, `connectedAddrs`, `peerIDCounter`, `bannedAddrs`, `bannedAddrsMu` — all peer state now lives in `peerList`
- New `peerList` API: `Register` (admission + address dedup), `Unregister` (identity-based cleanup), `AllocID`, `Range`/`Size`/`Load`
- Ban state deduplicated to a single `bannedAddrs` owned by `peerList`
- `newPeerList(d)` takes `*Download` at construction — removes the `newPeerList(nil)` + `d.peerList.d = d` backpatch
- Removed dead code: `setFinished`/`finished` (never called) and the never-assigned `persistentPeer.seed`
- `peerImpl.d` back-reference intentionally kept: peers decide for themselves whether to disconnect

## Verification

- `go build ./...` and `go build -tags release ./...`
- `go test -tags assert ./internal/download/...` (dev + release peer modes)
- `go test -tags assert ./...` full repo
- `golangci-lint run ./internal/download/...` — 0 issues