### PR TITLE
fix(meta): reject zero/negative piece length to prevent divide-by-zero panic

### DIFF
--- a/internal/meta/info.go
+++ b/internal/meta/info.go
@@ -123,6 +123,12 @@ func FromTorrent(m metainfo.MetaInfo) (Info, error) {
 		return Info{}, errors.New("invalid pieces length, len(info.pieces)%sha1.Size != 0")
 	}
 
+	// A zero or negative piece length would divide by zero (or underflow)
+	// in the piece-count check below. Reject it before doing any arithmetic.
+	if info.PieceLength <= 0 {
+		return Info{}, ErrInvalidLength
+	}
+
 	var pieces = make([]metainfo.Hash, info.NumPieces())
 	for i := range info.NumPieces() {
 		pieces[i] = metainfo.Hash(info.Pieces[i*sha1.Size : (i+1)*sha1.Size])

--- a/internal/meta/info_test.go
+++ b/internal/meta/info_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 trim21 <trim21.me@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package meta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trim21/go-bencode"
+
+	"neptune/internal/metainfo"
+)
+
+// buildMetaInfo marshals an Info into a MetaInfo with the given piece length.
+func buildMetaInfo(pieceLength int64) metainfo.MetaInfo {
+	infoBytes, err := bencode.Marshal(metainfo.Info{
+		Name:        "test",
+		PieceLength: pieceLength,
+		Length:      100,
+		Pieces:      make([]byte, 20), // 1 piece
+	})
+	if err != nil {
+		panic(err)
+	}
+	return metainfo.MetaInfo{InfoBytes: infoBytes}
+}
+
+// FromTorrent must reject zero or negative piece lengths instead of dividing
+// by zero while validating the piece count. A malicious torrent with
+// `piece length=0` used to panic the whole process (integer divide by zero).
+func TestFromTorrentRejectsInvalidPieceLength(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		length int64
+	}{
+		{"zero", 0},
+		{"negative", -1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := FromTorrent(buildMetaInfo(tc.length))
+			require.ErrorIs(t, err, ErrInvalidLength)
+		})
+	}
+}
+
+// Sanity check: the same torrent with a valid piece length parses fine.
+func TestFromTorrentAcceptsValidPieceLength(t *testing.T) {
+	t.Parallel()
+
+	info, err := FromTorrent(buildMetaInfo(100))
+	require.NoError(t, err)
+	require.Equal(t, int64(100), info.PieceLength)
+	require.Equal(t, uint32(1), info.NumPieces)
+	require.Equal(t, int64(100), info.LastPieceSize)
+}


### PR DESCRIPTION
## Problem

`meta.FromTorrent` panics with `runtime error: integer divide by zero` when parsing a malicious torrent with `piece length=0`:

```go
if int64(i.NumPieces) != (i.TotalLength+i.PieceLength-1)/i.PieceLength {
```

The existing `> 256 MiB` piece-length check in `torrent.add` runs **after** `FromTorrent`, so it cannot prevent the panic. Both entry points are affected:

- `torrent.add` API (`internal/web/torrent.go`)
- resume loading at startup (`internal/download/from_resume.go`)

An attacker with API access (or who can place a torrent file in the session dir) can crash the whole process.

## Fix

Validate `PieceLength <= 0` inside `meta.FromTorrent` before any arithmetic, returning `ErrInvalidLength`. Since `FromTorrent` is the shared parse layer for both add and resume paths, this covers both entry points.

## Tests

- New regression test `TestFromTorrentRejectsInvalidPieceLength`: zero and negative piece lengths return `ErrInvalidLength` (fails with panic before the fix, passes after).
- `TestFromTorrentAcceptsValidPieceLength`: sanity check that valid torrents still parse.
- Verified: `go test -tags assert -race ./internal/meta/ ./internal/download/ ./internal/web/... ./internal/client/...` all pass; full `./internal/...` suite passes.